### PR TITLE
feat: Separate system and user prompts for all LLM providers

### DIFF
--- a/prompts/__init__.py
+++ b/prompts/__init__.py
@@ -1,3 +1,14 @@
 """
 Prompts module for TranslateBookWithLLM
 """
+from prompts.prompts import (
+    PromptPair,
+    generate_translation_prompt,
+    generate_subtitle_block_prompt,
+)
+
+__all__ = [
+    "PromptPair",
+    "generate_translation_prompt",
+    "generate_subtitle_block_prompt",
+]

--- a/src/core/llm_client.py
+++ b/src/core/llm_client.py
@@ -29,29 +29,30 @@ class LLMClient:
             self._provider = create_llm_provider(self.provider_type, **self.provider_kwargs)
         return self._provider
     
-    async def make_request(self, prompt: str, model: Optional[str] = None, 
-                    timeout: int = None) -> Optional[str]:
+    async def make_request(self, prompt: str, model: Optional[str] = None,
+                    timeout: int = None, system_prompt: Optional[str] = None) -> Optional[str]:
         """
         Make a request to the LLM API with error handling and retries
-        
+
         Args:
-            prompt: The prompt to send
+            prompt: The user prompt to send (content to process)
             model: Model to use (defaults to instance model)
             timeout: Request timeout in seconds
-            
+            system_prompt: Optional system prompt (role/instructions)
+
         Returns:
             Raw response text or None if failed
         """
         provider = self._get_provider()
-        
+
         # Update model if specified
         if model:
             provider.model = model
-            
+
         if timeout:
-            return await provider.generate(prompt, timeout)
+            return await provider.generate(prompt, timeout, system_prompt=system_prompt)
         else:
-            return await provider.generate(prompt)
+            return await provider.generate(prompt, system_prompt=system_prompt)
     
     def extract_translation(self, response: str) -> Optional[str]:
         """


### PR DESCRIPTION
- Add PromptPair NamedTuple to return system/user prompts separately
- Update OllamaProvider to use 'system' field in payload
- Update OpenAICompatibleProvider to include system message in messages array
- Update GeminiProvider to use 'systemInstruction' field
- Refactor translator.py and subtitle_translator.py to use new prompt structure