### PR TITLE
Fix: Ensure cloud providers use their default endpoints

### DIFF
--- a/src/core/llm/factory.py
+++ b/src/core/llm/factory.py
@@ -9,11 +9,11 @@ import os
 from typing import Optional
 
 from src.config import (
-    API_ENDPOINT, DEFAULT_MODEL, OLLAMA_NUM_CTX,
+    API_ENDPOINT, OPENAI_API_ENDPOINT, DEFAULT_MODEL, OLLAMA_NUM_CTX,
     OPENROUTER_API_KEY, OPENROUTER_MODEL,
-    MISTRAL_API_KEY, MISTRAL_MODEL,
-    DEEPSEEK_API_KEY, DEEPSEEK_MODEL,
-    POE_API_KEY, POE_MODEL
+    MISTRAL_API_KEY, MISTRAL_MODEL, MISTRAL_API_ENDPOINT,
+    DEEPSEEK_API_KEY, DEEPSEEK_MODEL, DEEPSEEK_API_ENDPOINT,
+    POE_API_KEY, POE_MODEL, POE_API_ENDPOINT
 )
 from .base import LLMProvider
 from .providers.ollama import OllamaProvider
@@ -66,16 +66,27 @@ def create_llm_provider(provider_type: str = "ollama", **kwargs) -> LLMProvider:
         # Auto-switch to Gemini provider when Gemini model is detected
         provider_type = "gemini"
 
+    # Common endpoint resolution
+    provided_endpoint = kwargs.get("api_endpoint") or kwargs.get("endpoint")
+
+    # If the provided endpoint is exactly the global default for Ollama or OpenAI,
+    # and the provider is a cloud-based one (DeepSeek, Mistral, Poe), we ignore it
+    # to avoid "infection" from CLI/Web UI default parameters.
+    # This allows these providers to use their own cloud endpoints.
+    is_cloud_provider = provider_type.lower() in ["deepseek", "mistral", "poe"]
+    if is_cloud_provider and provided_endpoint in [API_ENDPOINT, OPENAI_API_ENDPOINT]:
+        provided_endpoint = None
+
     if provider_type.lower() == "ollama":
         return OllamaProvider(
-            api_endpoint=kwargs.get("api_endpoint") or kwargs.get("endpoint") or API_ENDPOINT,
+            api_endpoint=provided_endpoint or API_ENDPOINT,
             model=kwargs.get("model", DEFAULT_MODEL),
             context_window=kwargs.get("context_window") or OLLAMA_NUM_CTX,
             log_callback=kwargs.get("log_callback")
         )
     elif provider_type.lower() == "openai":
         return OpenAICompatibleProvider(
-            api_endpoint=kwargs.get("api_endpoint") or kwargs.get("endpoint"),
+            api_endpoint=provided_endpoint or OPENAI_API_ENDPOINT,
             model=kwargs.get("model", DEFAULT_MODEL),
             api_key=kwargs.get("api_key") or kwargs.get("openai_api_key"),
             context_window=kwargs.get("context_window") or OLLAMA_NUM_CTX,
@@ -113,7 +124,7 @@ def create_llm_provider(provider_type: str = "ollama", **kwargs) -> LLMProvider:
         return MistralProvider(
             api_key=api_key,
             model=kwargs.get("model", MISTRAL_MODEL),
-            api_endpoint=kwargs.get("api_endpoint") or kwargs.get("endpoint")
+            api_endpoint=provided_endpoint or MISTRAL_API_ENDPOINT
         )
     elif provider_type.lower() == "deepseek":
         api_key = kwargs.get("api_key") or kwargs.get("deepseek_api_key")
@@ -125,7 +136,7 @@ def create_llm_provider(provider_type: str = "ollama", **kwargs) -> LLMProvider:
         return DeepSeekProvider(
             api_key=api_key,
             model=kwargs.get("model", DEEPSEEK_MODEL),
-            api_endpoint=kwargs.get("api_endpoint") or kwargs.get("endpoint")
+            api_endpoint=provided_endpoint or DEEPSEEK_API_ENDPOINT
         )
     elif provider_type.lower() == "poe":
         api_key = kwargs.get("api_key") or kwargs.get("poe_api_key")
@@ -137,7 +148,7 @@ def create_llm_provider(provider_type: str = "ollama", **kwargs) -> LLMProvider:
         return PoeProvider(
             api_key=api_key,
             model=kwargs.get("model", POE_MODEL),
-            api_endpoint=kwargs.get("api_endpoint") or kwargs.get("endpoint")
+            api_endpoint=provided_endpoint or POE_API_ENDPOINT
         )
     else:
         raise ValueError(f"Unknown provider type: {provider_type}")

--- a/src/core/llm_client.py
+++ b/src/core/llm_client.py
@@ -191,6 +191,11 @@ def create_llm_client(llm_provider: str, gemini_api_key: Optional[str],
     Returns:
         LLMClient instance or None if using default client
     """
+    # If the endpoint matches the global default Ollama endpoint,
+    # we consider it "unspecified" for other providers.
+    is_default_endpoint = (api_endpoint == API_ENDPOINT)
+    effective_endpoint = None if is_default_endpoint else api_endpoint
+
     if llm_provider == "gemini" and gemini_api_key:
         return LLMClient(provider_type="gemini", api_key=gemini_api_key, model=model_name)
     if llm_provider == "openai":
@@ -199,11 +204,11 @@ def create_llm_client(llm_provider: str, gemini_api_key: Optional[str],
     if llm_provider == "openrouter":
         return LLMClient(provider_type="openrouter", model=model_name, api_key=openrouter_api_key)
     if llm_provider == "mistral":
-        return LLMClient(provider_type="mistral", model=model_name, api_key=mistral_api_key)
+        return LLMClient(provider_type="mistral", model=model_name, api_key=mistral_api_key, api_endpoint=effective_endpoint)
     if llm_provider == "deepseek":
-        return LLMClient(provider_type="deepseek", model=model_name, api_key=deepseek_api_key)
+        return LLMClient(provider_type="deepseek", model=model_name, api_key=deepseek_api_key, api_endpoint=effective_endpoint)
     if llm_provider == "poe":
-        return LLMClient(provider_type="poe", model=model_name, api_key=poe_api_key)
+        return LLMClient(provider_type="poe", model=model_name, api_key=poe_api_key, api_endpoint=effective_endpoint)
     if llm_provider == "ollama":
         # Always create a new client for Ollama to ensure proper configuration
         return LLMClient(provider_type="ollama", api_endpoint=api_endpoint, model=model_name,

--- a/translate.py
+++ b/translate.py
@@ -24,9 +24,10 @@ if __name__ == "__main__":
     parser.add_argument("-o", "--output", default=None, help="Path to the output file. If not specified, uses input filename with suffix.")
     parser.add_argument("-sl", "--source_lang", default=DEFAULT_SOURCE_LANGUAGE, help=f"Source language (default: {DEFAULT_SOURCE_LANGUAGE}).")
     parser.add_argument("-tl", "--target_lang", default=DEFAULT_TARGET_LANGUAGE, help=f"Target language (default: {DEFAULT_TARGET_LANGUAGE}).")
-    parser.add_argument("-m", "--model", default=DEFAULT_MODEL, help=f"LLM model (default: {DEFAULT_MODEL}).")
-    parser.add_argument("--api_endpoint", default=API_ENDPOINT, help=f"API endpoint for Ollama or OpenAI-compatible servers (llama.cpp, LM Studio, vLLM, etc.) (default: {API_ENDPOINT}).")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help=f"LLM model (default: {DEFAULT_MODEL}).")
+    parser.add_argument("--api_endpoint", default=None, help="API endpoint for Ollama or OpenAI-compatible servers (llama.cpp, LM Studio, vLLM, etc.). If not specified, uses provider-specific default.")
     parser.add_argument("--provider", default=LLM_PROVIDER, choices=["ollama", "gemini", "openai", "openrouter", "mistral", "deepseek", "poe"], help=f"LLM provider (default: {LLM_PROVIDER}). Use 'openai' for any OpenAI-compatible server.")
+
     parser.add_argument("--gemini_api_key", default=GEMINI_API_KEY, help="Google Gemini API key (required if using gemini provider).")
     parser.add_argument("--openai_api_key", default=OPENAI_API_KEY, help="OpenAI API key (required for OpenAI cloud, not needed for local servers).")
     parser.add_argument("--openrouter_api_key", default=OPENROUTER_API_KEY, help="OpenRouter API key (required if using openrouter provider).")


### PR DESCRIPTION
Fixed an issue where cloud providers (DeepSeek, Mistral, Poe) were incorrectly defaulting to the local Ollama endpoint from the global configuration. This was causing connection failures when using these cloud APIs (issue #112).