### PR TITLE
Add OpenAI-compatible translation provider support and documentation

### DIFF
--- a/benchmark/cli.py
+++ b/benchmark/cli.py
@@ -16,7 +16,11 @@ from benchmark.config import BenchmarkConfig, DEFAULT_EVALUATOR_MODEL, DEFAULT_E
 from benchmark.runner import BenchmarkRunner, quick_benchmark, full_benchmark
 from benchmark.results.storage import ResultsStorage
 from benchmark.wiki.generator import WikiGenerator
-from benchmark.translator import get_available_ollama_models, get_available_openrouter_models
+from benchmark.translator import (
+    get_available_ollama_models,
+    get_available_openrouter_models,
+    get_available_openai_models,
+)
 
 
 # ANSI color codes for terminal output
@@ -75,6 +79,8 @@ def cmd_run(args: argparse.Namespace) -> int:
     evaluator_provider = getattr(args, 'evaluator_provider', DEFAULT_EVALUATOR_PROVIDER)
     config = BenchmarkConfig.from_cli_args(
         openrouter_key=args.openrouter_key,
+        openai_key=args.openai_key,
+        openai_endpoint=args.openai_endpoint,
         poe_key=args.poe_key,
         evaluator_model=args.evaluator,
         ollama_endpoint=args.ollama_endpoint,
@@ -99,6 +105,14 @@ def cmd_run(args: argparse.Namespace) -> int:
                 log_callback("error", "No OpenRouter models available.")
                 return 1
             # Extract model IDs
+            models = [m["id"] if isinstance(m, dict) else m for m in models_data[:10]]
+            print(colored(f"Found {len(models_data)} models. Using top 10: {', '.join(models[:3])}...", Colors.GREEN))
+        elif provider == "openai":
+            print(colored("Fetching available OpenAI-compatible models...", Colors.CYAN))
+            models_data = asyncio.run(get_available_openai_models(config))
+            if not models_data:
+                log_callback("error", "No OpenAI-compatible models available.")
+                return 1
             models = [m["id"] if isinstance(m, dict) else m for m in models_data[:10]]
             print(colored(f"Found {len(models_data)} models. Using top 10: {', '.join(models[:3])}...", Colors.GREEN))
         else:
@@ -288,7 +302,12 @@ def cmd_models(args: argparse.Namespace) -> int:
     """List available models for benchmarking."""
     print_banner()
 
-    config = BenchmarkConfig.from_cli_args(openrouter_key=args.openrouter_key)
+    config = BenchmarkConfig.from_cli_args(
+        openrouter_key=args.openrouter_key,
+        openai_key=args.openai_key,
+        openai_endpoint=args.openai_endpoint,
+        translation_provider=args.provider,
+    )
     provider = args.provider
 
     if provider == "openrouter":
@@ -321,6 +340,32 @@ def cmd_models(args: argparse.Namespace) -> int:
         print()
         print(colored("Tip: Use -m to specify models, e.g.:", Colors.YELLOW))
         print("  python -m benchmark.cli run -p openrouter -m anthropic/claude-sonnet-4 openai/gpt-4o")
+
+    elif provider == "openai":
+        print(colored("Fetching OpenAI-compatible models...\n", Colors.CYAN))
+        models = asyncio.run(get_available_openai_models(config))
+
+        if not models:
+            log_callback("error", "Failed to fetch OpenAI-compatible models")
+            return 1
+
+        print(colored(f"Available OpenAI-Compatible Models ({len(models)}):\n", Colors.BOLD))
+        print(f"{'Model ID':<50} {'Owner':<20}")
+        print("-" * 72)
+
+        for model in models[:50]:
+            if isinstance(model, dict):
+                model_id = model.get("id", "unknown")
+                owned_by = model.get("owned_by", "unknown")
+            else:
+                model_id = model
+                owned_by = "unknown"
+
+            print(f"{model_id:<50} {owned_by:<20}")
+
+        print()
+        print(colored("Tip: Use -m and --openai-endpoint to specify a backend, e.g.:", Colors.YELLOW))
+        print("  python -m benchmark.cli run -p openai --openai-endpoint http://localhost:8080/v1 -m your-model")
 
     else:
         print(colored("Detecting Ollama models...\n", Colors.CYAN))
@@ -566,6 +611,9 @@ Examples:
   # Quick benchmark with Ollama (local models)
   python -m benchmark.cli run --openrouter-key YOUR_KEY
 
+    # Quick benchmark with an OpenAI-compatible backend
+    python -m benchmark.cli run --provider openai --openai-endpoint http://localhost:8080/v1 -m your-model
+
   # Quick benchmark with OpenRouter (cloud models)
   python -m benchmark.cli run --provider openrouter --openrouter-key YOUR_KEY
 
@@ -577,6 +625,9 @@ Examples:
 
   # Specific OpenRouter models
   python -m benchmark.cli run -p openrouter -m anthropic/claude-sonnet-4 openai/gpt-4o -l fr de ja
+
+    # Specific OpenAI-compatible backend and models
+    python -m benchmark.cli run -p openai --openai-endpoint http://localhost:8080/v1 -m qwen2.5-14b-instruct
 
   # Generate wiki pages
   python -m benchmark.cli wiki
@@ -594,6 +645,7 @@ Examples:
         "-m", "--models",
         nargs="+",
         help="Models to benchmark. For Ollama: model names (e.g., llama3:8b). "
+             "For OpenAI-compatible backends: model IDs (e.g., gpt-4o or local server model names). "
              "For OpenRouter: model IDs (e.g., anthropic/claude-sonnet-4). "
              "If not specified, auto-detects available models."
     )
@@ -609,9 +661,17 @@ Examples:
     )
     run_parser.add_argument(
         "-p", "--provider",
-        choices=["ollama", "openrouter"],
+        choices=["ollama", "openai", "openrouter"],
         default="ollama",
-        help="Translation provider: 'ollama' (local, default) or 'openrouter' (cloud, 200+ models)"
+        help="Translation provider: 'ollama' (local, default), 'openai' (OpenAI-compatible), or 'openrouter' (cloud, 200+ models)"
+    )
+    run_parser.add_argument(
+        "--openai-key",
+        help="API key for OpenAI-compatible translation backends. Can also be set via OPENAI_API_KEY env var."
+    )
+    run_parser.add_argument(
+        "--openai-endpoint",
+        help="OpenAI-compatible chat completions endpoint or /v1 base URL. Can also be set via OPENAI_API_ENDPOINT env var."
     )
     run_parser.add_argument(
         "--openrouter-key",
@@ -696,9 +756,17 @@ Examples:
     models_parser = subparsers.add_parser("models", help="List available models for benchmarking")
     models_parser.add_argument(
         "-p", "--provider",
-        choices=["ollama", "openrouter"],
+        choices=["ollama", "openai", "openrouter"],
         default="ollama",
         help="Provider to list models for (default: ollama)"
+    )
+    models_parser.add_argument(
+        "--openai-key",
+        help="API key for listing models from an OpenAI-compatible endpoint"
+    )
+    models_parser.add_argument(
+        "--openai-endpoint",
+        help="OpenAI-compatible endpoint to query for available models"
     )
     models_parser.add_argument(
         "--openrouter-key",

--- a/benchmark/config.py
+++ b/benchmark/config.py
@@ -2,7 +2,7 @@
 Benchmark configuration module.
 
 Defines configuration settings for the benchmark system including:
-- Ollama settings for translation
+- Ollama/OpenAI-compatible settings for translation
 - OpenRouter settings for evaluation
 - File paths and defaults
 """
@@ -100,6 +100,30 @@ class OpenRouterConfig:
 
 
 @dataclass
+class OpenAICompatibleConfig:
+    """Configuration for OpenAI-compatible translation provider."""
+
+    api_key: Optional[str] = field(
+        default_factory=lambda: os.getenv("OPENAI_API_KEY")
+    )
+    endpoint: str = field(
+        default_factory=lambda: os.getenv(
+            "OPENAI_API_ENDPOINT",
+            "https://api.openai.com/v1/chat/completions"
+        )
+    )
+    default_model: str = field(
+        default_factory=lambda: os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+    )
+    context_window: int = field(
+        default_factory=lambda: int(os.getenv("OPENAI_NUM_CTX", os.getenv("OLLAMA_NUM_CTX", "2048")))
+    )
+    timeout: int = field(
+        default_factory=lambda: int(os.getenv("OPENAI_REQUEST_TIMEOUT", os.getenv("REQUEST_TIMEOUT", "900")))
+    )
+
+
+@dataclass
 class PoeConfig:
     """Configuration for Poe evaluation provider."""
 
@@ -155,6 +179,7 @@ class BenchmarkConfig:
     """Main benchmark configuration aggregating all sub-configs."""
 
     ollama: OllamaConfig = field(default_factory=OllamaConfig)
+    openai: OpenAICompatibleConfig = field(default_factory=OpenAICompatibleConfig)
     openrouter: OpenRouterConfig = field(default_factory=OpenRouterConfig)
     poe: PoeConfig = field(default_factory=PoeConfig)
     paths: PathConfig = field(default_factory=PathConfig)
@@ -163,7 +188,7 @@ class BenchmarkConfig:
     source_language: str = "English"
     quick_languages: list = field(default_factory=lambda: DEFAULT_QUICK_LANGUAGES.copy())
 
-    # Translation provider ("ollama" or "openrouter")
+    # Translation provider ("ollama", "openai", or "openrouter")
     translation_provider: str = "ollama"
 
     # Evaluator provider ("openrouter" or "poe")
@@ -182,6 +207,8 @@ class BenchmarkConfig:
     def from_cli_args(
         cls,
         openrouter_key: Optional[str] = None,
+        openai_key: Optional[str] = None,
+        openai_endpoint: Optional[str] = None,
         evaluator_model: Optional[str] = None,
         ollama_endpoint: Optional[str] = None,
         translation_provider: Optional[str] = None,
@@ -195,6 +222,9 @@ class BenchmarkConfig:
         if openrouter_key:
             config.openrouter.api_key = openrouter_key
 
+        if openai_key:
+            config.openai.api_key = openai_key
+
         if poe_key:
             config.poe.api_key = poe_key
 
@@ -204,6 +234,9 @@ class BenchmarkConfig:
 
         if ollama_endpoint:
             config.ollama.endpoint = ollama_endpoint
+
+        if openai_endpoint:
+            config.openai.endpoint = openai_endpoint
 
         if translation_provider:
             config.translation_provider = translation_provider.lower()
@@ -245,6 +278,12 @@ class BenchmarkConfig:
                 "Set OPENROUTER_API_KEY in .env or use --openrouter-key"
             )
 
+        if self.translation_provider == "openai" and not self.openai.endpoint:
+            errors.append(
+                "OpenAI-compatible endpoint not configured. Required for translation. "
+                "Set OPENAI_API_ENDPOINT in .env or use --openai-endpoint"
+            )
+
         if not self.paths.languages_file.exists():
             errors.append(f"Languages file not found: {self.paths.languages_file}")
 
@@ -252,10 +291,10 @@ class BenchmarkConfig:
             errors.append(f"Reference texts file not found: {self.paths.reference_texts_file}")
 
         # Validate translation provider
-        if self.translation_provider not in ("ollama", "openrouter"):
+        if self.translation_provider not in ("ollama", "openai", "openrouter"):
             errors.append(
                 f"Invalid translation provider: {self.translation_provider}. "
-                "Must be 'ollama' or 'openrouter'"
+                "Must be 'ollama', 'openai', or 'openrouter'"
             )
 
         return errors

--- a/benchmark/runner.py
+++ b/benchmark/runner.py
@@ -3,7 +3,7 @@ Benchmark orchestrator.
 
 Coordinates the complete benchmark workflow:
 1. Load languages and reference texts
-2. Run translations with specified Ollama models
+2. Run translations with specified provider models
 3. Evaluate translations with OpenRouter
 4. Track progress and handle resumption
 5. Generate results
@@ -25,6 +25,7 @@ from benchmark.models import (
 from benchmark.translator import (
     BenchmarkTranslator, TranslationRequest,
     test_ollama_connection, get_available_ollama_models,
+    test_openai_translation_connection, get_available_openai_models,
     test_openrouter_translation_connection, get_available_openrouter_models
 )
 from benchmark.evaluator import (
@@ -206,6 +207,12 @@ class BenchmarkRunner:
                 errors.append(f"OpenRouter (translation): {or_trans_msg}")
             else:
                 self._log("info", f"OpenRouter (translation): {or_trans_msg}")
+        elif self.config.translation_provider == "openai":
+            openai_ok, openai_msg = await test_openai_translation_connection(self.config)
+            if not openai_ok:
+                errors.append(f"OpenAI-compatible (translation): {openai_msg}")
+            else:
+                self._log("info", f"OpenAI-compatible (translation): {openai_msg}")
         else:
             # Test Ollama connection
             ollama_ok, ollama_msg = await test_ollama_connection(self.config)
@@ -241,7 +248,7 @@ class BenchmarkRunner:
         Generate translation jobs, skipping already completed ones.
 
         Args:
-            models: List of Ollama model names
+            models: List of provider model names
             languages: List of target languages
             texts: List of reference texts
             existing_results: Results from a previous run (for resumption)
@@ -280,7 +287,7 @@ class BenchmarkRunner:
         Execute a complete benchmark run.
 
         Args:
-            models: List of Ollama model names to benchmark
+            models: List of provider model names to benchmark
             language_codes: Language codes to test (None = quick test set)
             resume_run: Optional previous run to resume
 
@@ -432,7 +439,7 @@ async def quick_benchmark(
 
     Args:
         config: Benchmark configuration
-        models: Optional list of models (defaults to available Ollama models)
+        models: Optional list of models (defaults to auto-detected provider models)
         log_callback: Optional logging callback
 
     Returns:
@@ -447,9 +454,16 @@ async def quick_benchmark(
 
     # Get models if not specified
     if models is None:
-        models = await get_available_ollama_models(config)
+        if config.translation_provider == "openrouter":
+            provider_models = await get_available_openrouter_models(config)
+            models = [m["id"] if isinstance(m, dict) else m for m in provider_models]
+        elif config.translation_provider == "openai":
+            provider_models = await get_available_openai_models(config)
+            models = [m["id"] if isinstance(m, dict) else m for m in provider_models]
+        else:
+            models = await get_available_ollama_models(config)
         if not models:
-            raise RuntimeError("No Ollama models available")
+            raise RuntimeError(f"No {config.translation_provider} models available")
         # Limit to first 3 models for quick benchmark
         models = models[:3]
 
@@ -466,7 +480,7 @@ async def full_benchmark(
 
     Args:
         config: Benchmark configuration
-        models: List of Ollama models to benchmark
+        models: List of provider models to benchmark
         log_callback: Optional logging callback
 
     Returns:

--- a/benchmark/translator.py
+++ b/benchmark/translator.py
@@ -2,7 +2,7 @@
 Benchmark translation wrapper.
 
 Provides a simplified interface for translating reference texts
-using Ollama or OpenRouter models for benchmark testing.
+using Ollama, OpenAI-compatible, or OpenRouter models for benchmark testing.
 """
 
 import asyncio
@@ -12,7 +12,7 @@ from typing import Optional, Callable, Union
 
 from benchmark.config import BenchmarkConfig
 from benchmark.models import ReferenceText, TranslationResult
-from src.core.llm import OllamaProvider, OpenRouterProvider, LLMProvider
+from src.core.llm import OllamaProvider, OpenAICompatibleProvider, OpenRouterProvider, LLMProvider
 from src.config import TRANSLATE_TAG_IN, TRANSLATE_TAG_OUT
 
 
@@ -28,13 +28,13 @@ class TranslationRequest:
 
 class BenchmarkTranslator:
     """
-    Wrapper for Ollama or OpenRouter translation in benchmark context.
+    Wrapper for translation in benchmark context.
 
     Simplified interface focusing on:
     - Single text translation
     - Timing measurement
     - Error handling for benchmark purposes
-    - Support for multiple providers (Ollama, OpenRouter)
+    - Support for multiple providers (Ollama, OpenAI-compatible, OpenRouter)
     """
 
     def __init__(
@@ -49,12 +49,21 @@ class BenchmarkTranslator:
         Args:
             config: Benchmark configuration
             log_callback: Optional callback for logging (level, message)
-            provider_type: Provider to use ("ollama" or "openrouter")
+            provider_type: Provider to use ("ollama", "openai", or "openrouter")
         """
         self.config = config
         self.log_callback = log_callback
         self.provider_type = provider_type.lower()
         self._providers: dict[str, LLMProvider] = {}
+
+    def _provider_label(self) -> str:
+        """Get a human-readable label for the active provider."""
+        labels = {
+            "ollama": "Ollama",
+            "openai": "OpenAI-compatible provider",
+            "openrouter": "OpenRouter",
+        }
+        return labels.get(self.provider_type, self.provider_type)
 
     def _log(self, level: str, message: str) -> None:
         """Log a message using the callback if available."""
@@ -73,6 +82,14 @@ class BenchmarkTranslator:
                 self._providers[model] = OpenRouterProvider(
                     api_key=self.config.openrouter.api_key,
                     model=model
+                )
+            elif self.provider_type == "openai":
+                self._providers[model] = OpenAICompatibleProvider(
+                    api_endpoint=self.config.openai.endpoint,
+                    api_key=self.config.openai.api_key,
+                    model=model,
+                    context_window=self.config.openai.context_window,
+                    log_callback=lambda level, msg: self._log(level, msg)
                 )
             else:
                 # Default to Ollama
@@ -187,9 +204,10 @@ Provide your translation now:"""
             )
 
             # Make the translation request
+            request_timeout = self.config.openai.timeout if self.provider_type == "openai" else self.config.ollama.timeout
             llm_response = await provider.generate(
                 prompt=user_prompt,
-                timeout=self.config.ollama.timeout,
+                timeout=request_timeout,
                 system_prompt=system_prompt
             )
 
@@ -202,7 +220,7 @@ Provide your translation now:"""
                     model=request.model,
                     translated_text="",
                     translation_time_ms=elapsed_ms,
-                    error="No response from Ollama"
+                    error=f"No response from {self._provider_label()}"
                 )
 
             # Extract response content from LLMResponse object
@@ -264,7 +282,7 @@ Provide your translation now:"""
             if progress_callback:
                 progress_callback(i + 1, total)
 
-            # Small delay to avoid overwhelming the Ollama server
+            # Small delay to avoid overwhelming the selected backend
             if i < total - 1:
                 await asyncio.sleep(0.5)
 
@@ -364,6 +382,104 @@ async def get_available_openrouter_models(config: BenchmarkConfig, text_only: bo
     except Exception as e:
         print(f"⚠️ Failed to fetch OpenRouter models: {e}")
         return [{"id": m, "name": m} for m in OpenRouterProvider.FALLBACK_MODELS]
+
+
+async def get_available_openai_models(config: BenchmarkConfig) -> list[dict]:
+    """
+    Get list of available models from an OpenAI-compatible endpoint.
+
+    Args:
+        config: Benchmark configuration
+
+    Returns:
+        List of model dicts with id and name
+    """
+    import httpx
+
+    base_url = config.openai.endpoint.replace("/chat/completions", "").rstrip("/")
+    headers = {}
+    if config.openai.api_key:
+        headers["Authorization"] = f"Bearer {config.openai.api_key}"
+
+    fallback_models = [
+        {"id": "gpt-4o", "name": "gpt-4o"},
+        {"id": "gpt-4o-mini", "name": "gpt-4o-mini"},
+        {"id": "gpt-4-turbo", "name": "gpt-4-turbo"},
+        {"id": "gpt-4", "name": "gpt-4"},
+        {"id": "gpt-3.5-turbo", "name": "gpt-3.5-turbo"},
+    ]
+
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            response = await client.get(f"{base_url}/models", headers=headers)
+            response.raise_for_status()
+
+            data = response.json()
+            models = []
+            for model in data.get("data", []):
+                model_id = model.get("id", "")
+                if not model_id:
+                    continue
+                if "embedding" in model_id.lower() or "whisper" in model_id.lower():
+                    continue
+                models.append({
+                    "id": model_id,
+                    "name": model_id,
+                    "owned_by": model.get("owned_by", "unknown"),
+                })
+
+            models.sort(key=lambda item: item["name"].lower())
+            return models or fallback_models
+    except Exception:
+        return fallback_models
+
+
+async def test_openai_translation_connection(config: BenchmarkConfig) -> tuple[bool, str]:
+    """
+    Test if an OpenAI-compatible endpoint is accessible for translation.
+
+    Args:
+        config: Benchmark configuration
+
+    Returns:
+        Tuple of (success, message)
+    """
+    import httpx
+
+    base_url = config.openai.endpoint.replace("/chat/completions", "").rstrip("/")
+    headers = {}
+    if config.openai.api_key:
+        headers["Authorization"] = f"Bearer {config.openai.api_key}"
+
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            response = await client.get(f"{base_url}/models", headers=headers)
+            response.raise_for_status()
+            data = response.json()
+
+        models = []
+        for model in data.get("data", []):
+            model_id = model.get("id", "")
+            if not model_id:
+                continue
+            if "embedding" in model_id.lower() or "whisper" in model_id.lower():
+                continue
+            models.append(model_id)
+
+        if not models:
+            return False, "No OpenAI-compatible models available"
+
+        model_names = models[:5]
+        return True, (
+            f"OpenAI-compatible endpoint connected ({config.openai.endpoint}). "
+            f"Available models: {', '.join(model_names)}..."
+        )
+    except httpx.ConnectError:
+        return False, f"Cannot connect to OpenAI-compatible endpoint at {config.openai.endpoint}"
+    except httpx.HTTPStatusError as e:
+        return False, f"OpenAI-compatible HTTP error: {e.response.status_code}"
+    except Exception as e:
+        return False, f"OpenAI-compatible connection test failed: {e}"
 
 
 async def test_openrouter_translation_connection(config: BenchmarkConfig) -> tuple[bool, str]:

--- a/docs/BENCHMARK.md
+++ b/docs/BENCHMARK.md
@@ -6,7 +6,7 @@ This document describes the benchmark system for testing LLM translation quality
 
 The benchmark system allows you to:
 
-- **Test translation quality** of Ollama models across 40+ languages
+- **Test translation quality** of Ollama, OpenAI-compatible, or OpenRouter models across 40+ languages
 - **Evaluate translations** using OpenRouter LLMs (Claude, GPT-4, etc.)
 - **Generate detailed reports** with scores and rankings
 - **Publish results** to the GitHub wiki automatically
@@ -17,6 +17,9 @@ The benchmark system allows you to:
 # Run quick benchmark (19 representative languages)
 python -m benchmark.cli run --openrouter-key YOUR_OPENROUTER_KEY
 
+# Run quick benchmark against an OpenAI-compatible backend
+python -m benchmark.cli run --provider openai --openai-endpoint http://localhost:8080/v1 -m your-model
+
 # Run full benchmark (all 40+ languages)
 python -m benchmark.cli run --full --openrouter-key YOUR_OPENROUTER_KEY
 
@@ -26,7 +29,7 @@ python -m benchmark.cli wiki-publish
 
 ## Prerequisites
 
-1. **Ollama** running with at least one model installed
+1. **Translation backend**: Ollama, OpenAI-compatible endpoint, or OpenRouter
 2. **OpenRouter API key** for translation evaluation (get one at [openrouter.ai](https://openrouter.ai))
 
 ## CLI Commands
@@ -43,9 +46,12 @@ python -m benchmark.cli run [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `-m, --models MODEL [MODEL ...]` | Specific Ollama models to test. If omitted, auto-detects all available models |
+| `-m, --models MODEL [MODEL ...]` | Specific provider models to test. If omitted, auto-detects available models from the selected provider |
 | `-l, --languages CODE [CODE ...]` | Language codes to test (e.g., `fr de ja zh`). Default: quick test set (19 languages) |
 | `--full` | Run full benchmark with all 40+ languages |
+| `-p, --provider {ollama,openai,openrouter}` | Translation backend to benchmark |
+| `--openai-key KEY` | API key for OpenAI-compatible translation backends |
+| `--openai-endpoint URL` | OpenAI-compatible endpoint or `/v1` base URL |
 | `--openrouter-key KEY` | OpenRouter API key (can also use `OPENROUTER_API_KEY` env var) |
 | `--evaluator MODEL` | OpenRouter model for evaluation (default: `anthropic/claude-haiku-4.5`) |
 | `--ollama-endpoint URL` | Custom Ollama endpoint (default: from `.env` or `http://localhost:11434/api/generate`) |
@@ -56,6 +62,9 @@ python -m benchmark.cli run [OPTIONS]
 ```bash
 # Test specific models on specific languages
 python -m benchmark.cli run -m llama3:8b qwen2.5:14b mistral:7b -l fr de ja zh
+
+# Test an OpenAI-compatible server
+python -m benchmark.cli run -p openai --openai-endpoint http://localhost:8080/v1 -m qwen2.5-14b-instruct -l fr de ja zh
 
 # Use a different evaluator model
 python -m benchmark.cli run --evaluator anthropic/claude-3.5-sonnet --openrouter-key KEY


### PR DESCRIPTION
Added the option to use an open-ai compatible provider for running benchmarks, mainly so I can run some benchmarks of my own using that provider.