### PR TITLE
fix: replace bare except clauses with except Exception

### DIFF
--- a/prompt_optimizer/llm_adapter.py
+++ b/prompt_optimizer/llm_adapter.py
@@ -161,7 +161,7 @@ class TranslationAdapter:
             try:
                 error_data = e.response.json()
                 error_msg = error_data.get("error", error_msg)
-            except:
+            except Exception:
                 pass
             return TranslationResult(
                 text="", success=False,

--- a/prompt_optimizer/logger.py
+++ b/prompt_optimizer/logger.py
@@ -61,7 +61,7 @@ def supports_color() -> bool:
             # Enable ANSI escape sequences on Windows
             os.system("")
             return True
-        except:
+        except Exception:
             return False
     return hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()
 

--- a/src/core/adapters/generic_translator.py
+++ b/src/core/adapters/generic_translator.py
@@ -355,7 +355,7 @@ class GenericTranslator:
             # Ensure cleanup even on error
             try:
                 await self.adapter.cleanup()
-            except:
+            except Exception:
                 pass
 
     def __repr__(self) -> str:

--- a/src/core/epub/xml_helpers.py
+++ b/src/core/epub/xml_helpers.py
@@ -35,12 +35,12 @@ def safe_iter_children(element: etree._Element) -> Iterator[etree._Element]:
                 children = list(element)
                 for child in children:
                     yield child
-        except:
+        except Exception:
             # If all else fails, use xpath
             try:
                 for child in element.xpath('*'):
                     yield child
-            except:
+            except Exception:
                 # Give up - no children accessible
                 pass
 
@@ -83,18 +83,18 @@ def safe_get_tag(element: etree._Element) -> str:
                     if hasattr(element, 'nsmap') and None in element.nsmap:
                         return f"{{{element.nsmap[None]}}}{tag_with_ns}"
                     return tag_with_ns
-        except:
+        except Exception:
             pass
 
         # Fourth try: Use QName if element has it
         try:
             if hasattr(element, 'qname'):
                 return str(element.qname)
-        except:
+        except Exception:
             pass
 
         return ""
-    except:
+    except Exception:
         return ""
 
 
@@ -113,7 +113,7 @@ def safe_get_attrib(element: etree._Element) -> Dict[str, Any]:
         if callable(attrib):
             return attrib()
         return attrib
-    except:
+    except Exception:
         return {}
 
 
@@ -148,7 +148,7 @@ def get_node_text_content_with_br_as_newline(node: etree._Element, namespaces: D
                     parts.append(child.text)
                 if hasattr(child, 'tail') and child.tail:
                     parts.append(child.tail)
-            except:
+            except Exception:
                 pass
             continue
 
@@ -214,7 +214,7 @@ def serialize_inline_tags(node: etree._Element, preserve_tags: bool = True) -> s
                 child_content = etree.tostring(child, encoding='unicode', method='xml')
                 if child_content and ' at 0x' not in child_content:
                     parts.append(child_content)
-        except:
+        except Exception:
             pass
 
         return "".join(parts)

--- a/src/core/llm/providers/ollama.py
+++ b/src/core/llm/providers/ollama.py
@@ -537,7 +537,7 @@ class OllamaProvider(LLMProvider):
                     try:
                         error_data = e.response.json()
                         error_message = error_data.get("error", str(e))
-                    except:
+                    except Exception:
                         pass
 
                 # Handle context overflow errors

--- a/src/core/llm/providers/openai.py
+++ b/src/core/llm/providers/openai.py
@@ -195,7 +195,7 @@ class OpenAICompatibleProvider(LLMProvider):
                                 error_message = error_json["error"].get("message", str(e))
                             else:
                                 error_message = str(error_json.get("error", e))
-                    except:
+                    except Exception:
                         error_message = f"{e} - {error_body}"
 
                 # Handle rate limiting (429)

--- a/src/utils/telemetry.py
+++ b/src/utils/telemetry.py
@@ -55,7 +55,7 @@ class TelemetryCollector:
         try:
             mac = uuid.getnode()
             base = f"{mac}-{self.GENERATOR_NAME}"
-        except:
+        except Exception:
             base = f"{uuid.uuid4()}-{self.GENERATOR_NAME}"
 
         # Create deterministic hash

--- a/src/utils/text_encoding.py
+++ b/src/utils/text_encoding.py
@@ -225,7 +225,7 @@ class TextMetadataEncoder:
                 match = re.search(r'SID:[0-9a-f]{16}', decoded)
                 if match:
                     return match.group(0)
-        except:
+        except Exception:
             pass
 
         return None
@@ -333,7 +333,7 @@ class WhitespaceMetadata:
 
             detected_id = ''.join(hex_chars)
             return f"SID-{detected_id}" if len(detected_id) == 8 else None
-        except:
+        except Exception:
             return None
 
 


### PR DESCRIPTION
## Summary

Replace 16 bare `except:` clauses across 8 files with `except Exception:` to prevent accidentally catching `SystemExit`, `KeyboardInterrupt`, and other `BaseException` subclasses.

### Problem

Bare `except:` catches **all** exceptions including:
- `SystemExit` (from `sys.exit()`)
- `KeyboardInterrupt` (from Ctrl+C)
- `GeneratorExit` (from generator cleanup)

This means pressing Ctrl+C during a long translation job could be silently swallowed, preventing clean shutdown and potentially leaving files in an inconsistent state.

### Changes

| File | Instances | Context |
|------|-----------|---------|
| `src/core/epub/xml_helpers.py` | 8 | XML element attribute access fallbacks |
| `src/core/llm/providers/openai.py` | 1 | Error response JSON parsing |
| `src/core/llm/providers/ollama.py` | 1 | Error response JSON parsing |
| `src/core/adapters/generic_translator.py` | 1 | Adapter cleanup |
| `src/utils/text_encoding.py` | 2 | Encoding detection |
| `src/utils/telemetry.py` | 1 | UUID generation fallback |
| `prompt_optimizer/logger.py` | 1 | TTY detection |
| `prompt_optimizer/llm_adapter.py` | 1 | Error response parsing |

### Impact

- **Behavioral change**: None for normal operation. All `Exception` subclasses are still caught.
- **Signal propagation**: `KeyboardInterrupt` and `SystemExit` now propagate correctly, allowing clean shutdown.
