### PR TITLE
Benchmark v2 — schema-first, multi-source, rubric-based judging

### DIFF
--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -1,0 +1,75 @@
+name: Publish Benchmark Wiki
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'benchmark/data/**'
+      - 'benchmark/wiki/templates/**'
+  workflow_dispatch:
+
+concurrency:
+  group: publish-wiki
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Aggregate all submissions
+        run: |
+          python -m benchmark.cli aggregate-submissions \
+            --run-id aggregated \
+            --output benchmark_results/aggregated.json \
+            --allow-empty
+
+      - name: Generate wiki pages
+        if: hashFiles('benchmark_results/aggregated.json') != ''
+        run: |
+          python -m benchmark.cli wiki aggregated
+
+      - name: Push to wiki repo
+        if: hashFiles('wiki/Home.md') != ''
+        env:
+          GH_TOKEN: ${{ secrets.WIKI_PUSH_TOKEN }}
+          WIKI_REPO_URL: https://x-access-token:${{ secrets.WIKI_PUSH_TOKEN }}@github.com/${{ github.repository }}.wiki.git
+        run: |
+          set -e
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          rm -rf .wiki_repo
+          git clone "$WIKI_REPO_URL" .wiki_repo
+
+          # Mirror the generated wiki/ flat layout into the wiki repo.
+          # Remove old language/model pages first so renames clean up.
+          find .wiki_repo -maxdepth 1 -name 'Language-*.md' -delete
+          find .wiki_repo -maxdepth 1 -name 'Model-*.md' -delete
+          rm -f .wiki_repo/Home.md .wiki_repo/All-Languages.md .wiki_repo/All-Models.md
+
+          cp wiki/*.md .wiki_repo/
+
+          cd .wiki_repo
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No wiki changes to push."
+            exit 0
+          fi
+          git commit -m "Update benchmark wiki (aggregated)"
+          git push

--- a/.github/workflows/validate-submission.yml
+++ b/.github/workflows/validate-submission.yml
@@ -1,0 +1,75 @@
+name: Validate Benchmark Submission
+
+on:
+  pull_request:
+    paths:
+      - 'benchmark/data/submissions/**'
+      - 'benchmark/schemas/**'
+      - 'scripts/validate_submission.py'
+      - 'scripts/replay_submission.py'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt jsonschema langdetect
+
+      - name: Identify changed submissions
+        id: files
+        run: |
+          set -e
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          git diff --name-only "origin/${{ github.base_ref }}"...HEAD \
+            | grep -E '^benchmark/data/submissions/.*\.json$' > submissions.txt || true
+          count=$(wc -l < submissions.txt | tr -d ' ')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "Changed submission files: $count"
+          cat submissions.txt || true
+
+      - name: Schema validation
+        if: steps.files.outputs.count != '0'
+        run: |
+          xargs -a submissions.txt python scripts/validate_submission.py
+
+      - name: Replay sampling
+        if: steps.files.outputs.count != '0'
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENAI_API_KEY:     ${{ secrets.OPENAI_API_KEY }}
+          POE_API_KEY:        ${{ secrets.POE_API_KEY }}
+          GEMINI_API_KEY:     ${{ secrets.GEMINI_API_KEY }}
+          MISTRAL_API_KEY:    ${{ secrets.MISTRAL_API_KEY }}
+          DEEPSEEK_API_KEY:   ${{ secrets.DEEPSEEK_API_KEY }}
+          NIM_API_KEY:        ${{ secrets.NIM_API_KEY }}
+        run: |
+          mapfile -t FILES < submissions.txt
+          python scripts/replay_submission.py \
+            --files "${FILES[@]}" \
+            --sample-pct 10 \
+            --max-divergence 1.0 \
+            --chrf-threshold 0.85 \
+            --report replay_report.md
+
+      - name: Post replay report as PR comment
+        if: always() && steps.files.outputs.count != '0'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: benchmark-replay
+          path: replay_report.md

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ secrets.*
 credentials.*
 *_secret.*
 *_credentials.*
+.wiki_repo_archive/

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ tests/.placeholder_tests/
 /plan/
 /experiments
 /tests
+/benchmark_results/
 
 # Ad-hoc scratch scripts at repo root — keep them out of commits.
 # Real tests live under tests/, real entrypoints are translate.py / translation_api.py / launcher.py.

--- a/benchmark/aggregator.py
+++ b/benchmark/aggregator.py
@@ -1,0 +1,169 @@
+"""
+Aggregate community-submitted benchmark results.
+
+Reads all `*.json` files from `benchmark/data/submissions/` (after they've been
+validated against `submission.schema.json`) and produces a synthetic
+`BenchmarkRun` whose results carry:
+
+- The **median** of `accuracy/fluency/style/overall` when several contributors
+  have tested the same `(model, text_id, target_lang)` triple.
+- `n_obs`: how many observations went into that median.
+- `verified`: True when all observations come from cloud providers (replayable),
+  False when at least one observation is `self_reported` (local model).
+- `contributors`: list of distinct GitHub identities that submitted that triple.
+
+The wiki generator can then consume this `BenchmarkRun` exactly like a real one.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import median
+from typing import Iterable, Optional
+
+from .models import (
+    BenchmarkRun,
+    EvaluationScores,
+    Submission,
+    TranslationResult,
+)
+
+
+# Cloud providers whose results are replayable in CI. Anything outside this set
+# is treated as "self-reported".
+CLOUD_PROVIDERS = {"openai", "openrouter", "gemini", "mistral", "deepseek", "poe", "nim"}
+
+
+@dataclass
+class AggregationStats:
+    n_submissions: int = 0
+    n_results_in: int = 0
+    n_results_out: int = 0
+    n_conflicts: int = 0  # how many keys had >1 observation
+
+
+class SubmissionAggregator:
+    """Merge per-contributor submissions into a single BenchmarkRun."""
+
+    def __init__(self, submissions_dir: Path):
+        self.submissions_dir = submissions_dir
+        self.stats = AggregationStats()
+
+    def discover(self) -> list[Path]:
+        if not self.submissions_dir.is_dir():
+            return []
+        return sorted(p for p in self.submissions_dir.glob("*.json") if p.is_file())
+
+    def load(self) -> list[Submission]:
+        submissions: list[Submission] = []
+        for path in self.discover():
+            try:
+                with path.open("r", encoding="utf-8") as f:
+                    data = json.load(f)
+                submissions.append(Submission.from_dict(data))
+            except (OSError, json.JSONDecodeError, KeyError) as exc:
+                raise RuntimeError(f"Failed to load submission {path}: {exc}") from exc
+        self.stats.n_submissions = len(submissions)
+        return submissions
+
+    def aggregate(
+        self,
+        submissions: Optional[Iterable[Submission]] = None,
+        run_id: Optional[str] = None,
+    ) -> BenchmarkRun:
+        if submissions is None:
+            submissions = self.load()
+        submissions = list(submissions)
+
+        # Bucket observations by (model_id, text_id, target_lang).
+        buckets: dict[tuple[str, str, str], list[dict]] = {}
+        models: set[str] = set()
+        languages: set[str] = set()
+        judges: set[str] = set()
+
+        for sub in submissions:
+            models.add(sub.model_id)
+            judges.add(sub.judge_id)
+            verified = sub.model_provider in CLOUD_PROVIDERS
+
+            for r in sub.results:
+                key = (sub.model_id, r.text_id, r.target_lang)
+                self.stats.n_results_in += 1
+                languages.add(r.target_lang)
+                buckets.setdefault(key, []).append({
+                    "submission": sub,
+                    "result": r,
+                    "verified": verified,
+                })
+
+        # Reduce each bucket to a single TranslationResult with median scores.
+        merged: list[TranslationResult] = []
+
+        for key, observations in buckets.items():
+            model_id, text_id, target_lang = key
+
+            if len(observations) > 1:
+                self.stats.n_conflicts += 1
+
+            accs = [o["result"].scores.accuracy for o in observations]
+            flus = [o["result"].scores.fluency for o in observations]
+            stys = [o["result"].scores.style for o in observations]
+            ovrs = [o["result"].scores.overall for o in observations]
+
+            # Pick the output text from the observation closest to the median
+            # overall score, so the example shown is representative.
+            target_overall = median(ovrs)
+            representative = min(
+                observations,
+                key=lambda o: abs(o["result"].scores.overall - target_overall),
+            )
+            rep_result = representative["result"]
+            rep_sub = representative["submission"]
+
+            scores = EvaluationScores(
+                accuracy=median(accs),
+                fluency=median(flus),
+                style=median(stys),
+                overall=target_overall,
+                feedback=rep_result.scores.feedback,
+            )
+
+            merged.append(TranslationResult(
+                source_text_id=text_id,
+                target_language=target_lang,
+                model=model_id,
+                translated_text=rep_result.output,
+                scores=scores,
+                translation_time_ms=int(rep_result.translation_latency_ms or 0),
+                evaluation_time_ms=0,
+                timestamp=rep_sub.submitted_at or datetime.now(timezone.utc).isoformat(),
+                error=None,
+                n_obs=len(observations),
+                verified=all(o["verified"] for o in observations),
+                contributors=sorted({o["submission"].submitted_by for o in observations}),
+            ))
+
+        self.stats.n_results_out = len(merged)
+
+        # Pick the most-used judge as the run's evaluator label.
+        judge_label = ", ".join(sorted(judges)) if judges else ""
+
+        run = BenchmarkRun(
+            run_id=run_id or "aggregated",
+            started_at=datetime.now(timezone.utc).isoformat(),
+            completed_at=datetime.now(timezone.utc).isoformat(),
+            models=sorted(models),
+            languages=sorted(languages),
+            evaluator_model=judge_label,
+            results=merged,
+            status="completed",
+        )
+        return run
+
+    def write_run(self, run: BenchmarkRun, output_path: Path) -> None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as f:
+            f.write(run.to_json())

--- a/benchmark/cli.py
+++ b/benchmark/cli.py
@@ -9,10 +9,33 @@ Provides commands for:
 
 import argparse
 import asyncio
+import hashlib
+import json
+import re
 import sys
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Optional
 
+# Force UTF-8 stdio so emoji prints (e.g. 💬, ❌, ⚠️) don't crash on Windows
+# consoles using cp1252 (charmap codec). errors='replace' keeps the process
+# alive even on terminals that can't render some glyphs.
+for _stream_name in ("stdout", "stderr"):
+    _stream = getattr(sys, _stream_name, None)
+    if _stream is not None and hasattr(_stream, "reconfigure"):
+        try:
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            pass
+
+from benchmark.aggregator import CLOUD_PROVIDERS, SubmissionAggregator
 from benchmark.config import BenchmarkConfig, DEFAULT_EVALUATOR_MODEL, DEFAULT_EVALUATOR_PROVIDER, DEFAULT_POE_EVALUATOR_MODEL
+from benchmark.models import (
+    BenchmarkRun,
+    EvaluationScores,
+    Submission,
+    SubmissionResult,
+)
 from benchmark.runner import BenchmarkRunner, quick_benchmark, full_benchmark
 from benchmark.results.storage import ResultsStorage
 from benchmark.wiki.generator import WikiGenerator
@@ -98,6 +121,9 @@ def cmd_run(args: argparse.Namespace) -> int:
     # Get models based on provider
     models = args.models
     if not models:
+        if provider == "poe":
+            log_callback("error", "Poe provider requires explicit --models (e.g. 'gemini-3-flash-preview', 'mistral-medium-3.1', 'gpt-5-mini').")
+            return 1
         if provider == "openrouter":
             print(colored("Fetching available OpenRouter models...", Colors.CYAN))
             models_data = asyncio.run(get_available_openrouter_models(config))
@@ -126,16 +152,31 @@ def cmd_run(args: argparse.Namespace) -> int:
     # Show provider info
     print(colored(f"Translation provider: {provider.upper()}", Colors.YELLOW))
 
-    # Determine languages
-    if args.full:
-        language_codes = None  # Full benchmark uses all languages
-        print(colored("Running FULL benchmark with all 40+ languages", Colors.YELLOW))
+    # Determine pairs / language codes
+    pairs: Optional[list[tuple[str, str]]] = None
+    language_codes: Optional[list[str]] = None
+    if getattr(args, "pairs", None):
+        pairs = []
+        for spec in args.pairs:
+            if ":" not in spec:
+                log_callback("error", f"--pairs entries must be 'src:tgt' (got: {spec})")
+                return 1
+            src, tgt = spec.split(":", 1)
+            pairs.append((src.strip(), tgt.strip()))
+        print(colored(f"Running benchmark on {len(pairs)} pair(s): {', '.join(args.pairs)}", Colors.CYAN))
+    elif args.full:
+        language_codes = None
+        print(colored("Running FULL benchmark with all 40+ languages (English source)", Colors.YELLOW))
     elif args.languages:
         language_codes = args.languages
-        print(colored(f"Running benchmark with languages: {', '.join(language_codes)}", Colors.CYAN))
+        print(colored(f"Running benchmark with languages: {', '.join(language_codes)} (English source)", Colors.CYAN))
     else:
         language_codes = config.quick_languages
-        print(colored(f"Running QUICK benchmark with {len(language_codes)} languages", Colors.CYAN))
+        print(colored(f"Running QUICK benchmark with {len(language_codes)} languages (English source)", Colors.CYAN))
+
+    evaluate = not getattr(args, "no_evaluate", False)
+    if not evaluate:
+        print(colored("Auto-evaluation DISABLED — translations only.", Colors.YELLOW))
 
     # Check for resumable run
     storage = ResultsStorage(config)
@@ -161,7 +202,9 @@ def cmd_run(args: argparse.Namespace) -> int:
         run = asyncio.run(runner.run(
             models=models,
             language_codes=language_codes,
+            pairs=pairs,
             resume_run=resume_run,
+            evaluate=evaluate,
         ))
 
         # Save results
@@ -298,17 +341,85 @@ def cmd_export(args: argparse.Namespace) -> int:
         return 1
 
 
-def cmd_models(args: argparse.Namespace) -> int:
-    """List available models for benchmarking."""
-    print_banner()
+def _fetch_model_ids(provider: str, config: BenchmarkConfig) -> list[str]:
+    """Return a flat list of model IDs available on the given provider."""
+    if provider == "ollama":
+        return asyncio.run(get_available_ollama_models(config)) or []
+    if provider == "openrouter":
+        models = asyncio.run(get_available_openrouter_models(config)) or []
+        return [m.get("id") if isinstance(m, dict) else m for m in models]
+    if provider == "openai":
+        models = asyncio.run(get_available_openai_models(config)) or []
+        return [m.get("id") if isinstance(m, dict) else m for m in models]
+    if provider == "poe":
+        from src.core.llm.providers.poe import PoeProvider
+        if not config.poe.api_key:
+            return []
+        poe = PoeProvider(api_key=config.poe.api_key, model="placeholder")
+        models = asyncio.run(poe.get_available_models()) or []
+        return [m.get("id") for m in models if m.get("id")]
+    return []
 
+
+def _close_matches(target: str, candidates: list[str], limit: int = 10) -> list[str]:
+    """Return up to `limit` close matches to `target` from `candidates`.
+
+    Combines difflib similarity with substring/token overlap so single-token
+    misspellings like 'gemini-3-flash-preview' surface 'gemini-3-flash'.
+    """
+    import difflib
+    target_l = target.lower()
+    target_tokens = set(re.split(r"[^a-z0-9]+", target_l))
+    target_tokens.discard("")
+
+    scored: list[tuple[float, str]] = []
+    for c in candidates:
+        if not c:
+            continue
+        cl = c.lower()
+        ratio = difflib.SequenceMatcher(None, target_l, cl).ratio()
+        if target_l in cl or cl in target_l:
+            ratio += 0.2
+        c_tokens = set(re.split(r"[^a-z0-9]+", cl))
+        if target_tokens & c_tokens:
+            ratio += 0.1 * len(target_tokens & c_tokens)
+        scored.append((ratio, c))
+
+    scored.sort(key=lambda x: (-x[0], x[1]))
+    return [c for _, c in scored[:limit]]
+
+
+def cmd_models(args: argparse.Namespace) -> int:
+    """List available models for benchmarking, or validate a specific id."""
     config = BenchmarkConfig.from_cli_args(
         openrouter_key=args.openrouter_key,
         openai_key=args.openai_key,
         openai_endpoint=args.openai_endpoint,
+        poe_key=getattr(args, "poe_key", None),
         translation_provider=args.provider,
     )
     provider = args.provider
+
+    # --check: validate a single model id and exit 0/1.
+    if getattr(args, "check", None):
+        target = args.check
+        ids = _fetch_model_ids(provider, config)
+        if not ids:
+            print(f"NOT FOUND: could not fetch model list from {provider} "
+                  f"(missing API key, network error, or service down)")
+            return 1
+        if target in ids:
+            print(f"OK: '{target}' is available on {provider}")
+            return 0
+        matches = _close_matches(target, ids)
+        print(f"NOT FOUND: '{target}' is not a valid {provider} model id.")
+        if matches:
+            print("Closest matches:")
+            for m in matches:
+                print(f"  - {m}")
+        return 1
+
+    print_banner()
 
     if provider == "openrouter":
         print(colored("Fetching OpenRouter models...\n", Colors.CYAN))
@@ -366,6 +477,23 @@ def cmd_models(args: argparse.Namespace) -> int:
         print()
         print(colored("Tip: Use -m and --openai-endpoint to specify a backend, e.g.:", Colors.YELLOW))
         print("  python -m benchmark.cli run -p openai --openai-endpoint http://localhost:8080/v1 -m your-model")
+
+    elif provider == "poe":
+        print(colored("Fetching Poe models...\n", Colors.CYAN))
+        ids = _fetch_model_ids("poe", config)
+        if not ids:
+            log_callback("error", "Failed to fetch Poe models. Check POE_API_KEY or --poe-key.")
+            return 1
+
+        print(colored(f"Available Poe Models ({len(ids)}):\n", Colors.BOLD))
+        for model_id in ids[:80]:
+            print(f"  - {model_id}")
+        if len(ids) > 80:
+            print(f"  ... ({len(ids) - 80} more)")
+
+        print()
+        print(colored("Tip: Use -m to specify a model, e.g.:", Colors.YELLOW))
+        print("  python -m benchmark.cli run -p poe -m gemini-3-flash")
 
     else:
         print(colored("Detecting Ollama models...\n", Colors.CYAN))
@@ -567,6 +695,288 @@ def cmd_wiki_publish(args: argparse.Namespace) -> int:
         return 1
 
 
+_SUBMISSION_SCHEMA_VERSION = "1.0"
+_GITHUB_LOGIN_RE = re.compile(r"^github:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,38})$")
+
+
+def _slugify_for_filename(text: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", text).strip("-").lower()
+    return slug or "model"
+
+
+def _sha256_text(text: str) -> str:
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _detect_tbl_version() -> str:
+    """Best-effort TBL version: env var > git short SHA > 'dev'."""
+    import os
+    env = os.getenv("TBL_VERSION")
+    if env:
+        return env
+    try:
+        import subprocess
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return f"git-{result.stdout.strip()}"
+    except Exception:
+        pass
+    return "dev"
+
+
+def _validate_submission_schema(submission_dict: dict) -> list[str]:
+    """Validate against the JSON schema. Returns [] on success, [errors] on failure.
+
+    Returns a single warning entry instead of failing if `jsonschema` is missing.
+    """
+    schema_path = Path(__file__).parent / "schemas" / "submission.schema.json"
+    if not schema_path.exists():
+        return [f"Schema file not found: {schema_path}"]
+
+    try:
+        import jsonschema
+    except ImportError:
+        return ["WARN: jsonschema not installed; skipping schema validation. Install with `pip install jsonschema`."]
+
+    with schema_path.open("r", encoding="utf-8") as f:
+        schema = json.load(f)
+
+    validator = jsonschema.Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(submission_dict), key=lambda e: e.path)
+    return [f"{'/'.join(str(p) for p in err.path) or '<root>'}: {err.message}" for err in errors]
+
+
+def _build_submission_from_run(
+    run: BenchmarkRun,
+    submitted_by: str,
+    *,
+    provider: str,
+    judge_id: str,
+    tbl_version: str,
+    prompt_version: str,
+    notes: Optional[str] = None,
+    judge_temperature: Optional[float] = None,
+    judge_seed: Optional[int] = None,
+    source_lang_default: str = "en",
+) -> tuple[Submission, str]:
+    """
+    Convert an existing BenchmarkRun into a Submission, computing output hashes.
+
+    Returns (submission, single_model_id). `single_model_id` is the dominant
+    model — submissions in this layout cover one model at a time.
+    """
+    if not run.results:
+        raise ValueError(f"Run {run.run_id} has no results to submit.")
+
+    # The submission schema covers a single model. Pick the most-used model
+    # in the run and warn if there are others.
+    model_counts: dict[str, int] = {}
+    for r in run.results:
+        model_counts[r.model] = model_counts.get(r.model, 0) + 1
+    primary_model = max(model_counts.items(), key=lambda kv: kv[1])[0]
+
+    sub_results: list[SubmissionResult] = []
+    skipped_other_models = 0
+    skipped_no_scores = 0
+    skipped_failed = 0
+
+    for r in run.results:
+        if r.model != primary_model:
+            skipped_other_models += 1
+            continue
+        if not r.success:
+            skipped_failed += 1
+            continue
+        if r.scores is None:
+            skipped_no_scores += 1
+            continue
+
+        sub_results.append(SubmissionResult(
+            text_id=r.source_text_id,
+            source_lang=source_lang_default,
+            target_lang=r.target_language,
+            output=r.translated_text,
+            output_hash=_sha256_text(r.translated_text),
+            translation_latency_ms=int(r.translation_time_ms or 0),
+            scores=EvaluationScores(
+                accuracy=float(r.scores.accuracy),
+                fluency=float(r.scores.fluency),
+                style=float(r.scores.style),
+                overall=float(r.scores.overall),
+                feedback=r.scores.feedback,
+            ),
+        ))
+
+    if not sub_results:
+        raise ValueError(
+            f"No usable results in run {run.run_id} for model {primary_model}."
+        )
+
+    if skipped_other_models:
+        log_callback(
+            "warning",
+            f"Skipped {skipped_other_models} results for non-primary models. "
+            "Run `submit` once per model.",
+        )
+    if skipped_failed or skipped_no_scores:
+        log_callback(
+            "warning",
+            f"Skipped {skipped_failed} failed and {skipped_no_scores} unscored results.",
+        )
+
+    submission = Submission(
+        schema_version=_SUBMISSION_SCHEMA_VERSION,
+        submitted_by=submitted_by,
+        submitted_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        notes=notes,
+        tbl_version=tbl_version,
+        prompt_version=prompt_version,
+        judge_id=judge_id,
+        judge_seed=judge_seed,
+        judge_temperature=judge_temperature,
+        model_provider=provider,
+        model_id=primary_model,
+        results=sub_results,
+    )
+    return submission, primary_model
+
+
+def cmd_submit(args: argparse.Namespace) -> int:
+    """Convert a benchmark run JSON into a community submission file."""
+    print_banner()
+
+    submitted_by = args.by
+    if not _GITHUB_LOGIN_RE.match(submitted_by):
+        log_callback(
+            "error",
+            f"--by must be 'github:<username>' (got: {submitted_by})",
+        )
+        return 1
+
+    source_path = Path(args.input).expanduser()
+    if not source_path.is_file():
+        log_callback("error", f"Input file not found: {source_path}")
+        return 1
+
+    try:
+        with source_path.open("r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except json.JSONDecodeError as exc:
+        log_callback("error", f"Failed to parse {source_path}: {exc}")
+        return 1
+
+    # Accept either a raw BenchmarkRun JSON or a Submission already.
+    if "results" in payload and "submission" in payload:
+        log_callback("error", "Input already looks like a submission. Aborting.")
+        return 1
+
+    run = BenchmarkRun.from_dict(payload)
+
+    config = BenchmarkConfig()
+    output_dir = Path(args.output).expanduser() if args.output else config.paths.base_dir / "data" / "submissions"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    judge_id = args.judge_id or run.evaluator_model or "unknown"
+    tbl_version = args.tbl_version or _detect_tbl_version()
+    prompt_version = args.prompt_version or "v1"
+    provider = args.provider
+
+    if provider not in CLOUD_PROVIDERS and provider != "ollama":
+        log_callback("warning", f"Unknown provider '{provider}' — submission will be marked self-reported by aggregator.")
+
+    try:
+        submission, primary_model = _build_submission_from_run(
+            run,
+            submitted_by=submitted_by,
+            provider=provider,
+            judge_id=judge_id,
+            tbl_version=tbl_version,
+            prompt_version=prompt_version,
+            notes=args.notes,
+            judge_temperature=args.judge_temperature,
+            judge_seed=args.judge_seed,
+            source_lang_default=args.source_lang,
+        )
+    except ValueError as exc:
+        log_callback("error", str(exc))
+        return 1
+
+    # Validate against the JSON schema before writing.
+    submission_dict = submission.to_dict()
+    validation_errors = _validate_submission_schema(submission_dict)
+    if validation_errors and not validation_errors[0].startswith("WARN:"):
+        log_callback("error", "Submission failed schema validation:")
+        for err in validation_errors[:10]:
+            print(f"  - {err}")
+        return 1
+    elif validation_errors:
+        log_callback("warning", validation_errors[0])
+
+    # Compose filename: <date>_<username>_<model-slug>.json
+    date_part = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    user_part = submitted_by.split(":", 1)[1]
+    model_slug = _slugify_for_filename(primary_model)
+    filename = f"{date_part}_{user_part}_{model_slug}.json"
+    output_path = output_dir / filename
+
+    with output_path.open("w", encoding="utf-8") as f:
+        f.write(submission.to_json())
+
+    print(colored(f"\nSubmission written: {output_path}", Colors.GREEN))
+    print(colored(f"  Model:    {primary_model} ({provider})", Colors.CYAN))
+    print(colored(f"  Results:  {len(submission.results)}", Colors.CYAN))
+    print(colored(f"  Judge:    {judge_id}", Colors.CYAN))
+    print()
+    print(colored("Next steps to open a Pull Request:", Colors.BOLD))
+    branch = f"submit/{model_slug}"
+    rel_path = output_path.relative_to(Path.cwd()) if output_path.is_absolute() else output_path
+    print(f"  git checkout -b {branch}")
+    print(f"  git add {rel_path}")
+    print(f"  git commit -s -m \"submit: {primary_model} benchmark results\"")
+    print(f"  gh pr create --title \"Submit {primary_model} benchmark results\" --body \"by {submitted_by}\"")
+    return 0
+
+
+def cmd_aggregate_submissions(args: argparse.Namespace) -> int:
+    """Aggregate all submissions into a synthetic BenchmarkRun JSON."""
+    print_banner()
+
+    config = BenchmarkConfig()
+    submissions_dir = (
+        Path(args.submissions_dir).expanduser()
+        if args.submissions_dir
+        else config.paths.base_dir / "data" / "submissions"
+    )
+
+    aggregator = SubmissionAggregator(submissions_dir)
+    submissions = aggregator.load()
+    if not submissions:
+        log_callback("warning", f"No submissions found in {submissions_dir}.")
+        return 0 if args.allow_empty else 1
+
+    run = aggregator.aggregate(submissions, run_id=args.run_id or "aggregated")
+
+    output_path = (
+        Path(args.output).expanduser()
+        if args.output
+        else config.paths.results_dir / f"{run.run_id}.json"
+    )
+    aggregator.write_run(run, output_path)
+
+    print(colored(f"\nAggregated run written: {output_path}", Colors.GREEN))
+    print(f"  Submissions:       {aggregator.stats.n_submissions}")
+    print(f"  Raw results:       {aggregator.stats.n_results_in}")
+    print(f"  Aggregated results:{aggregator.stats.n_results_out}")
+    print(f"  Conflicts (>=2 obs): {aggregator.stats.n_conflicts}")
+    print(f"  Models:            {len(run.models)}")
+    print(f"  Languages:         {len(run.languages)}")
+    return 0
+
+
 def print_run_summary(run) -> None:
     """Print a summary of a benchmark run."""
     print(colored("\n" + "=" * 60, Colors.BOLD))
@@ -661,9 +1071,23 @@ Examples:
     )
     run_parser.add_argument(
         "-p", "--provider",
-        choices=["ollama", "openai", "openrouter"],
+        choices=["ollama", "openai", "openrouter", "poe"],
         default="ollama",
-        help="Translation provider: 'ollama' (local, default), 'openai' (OpenAI-compatible), or 'openrouter' (cloud, 200+ models)"
+        help="Translation provider: 'ollama' (local), 'openai' (OpenAI-compatible), "
+             "'openrouter' (cloud), or 'poe' (Poe.com unified API)."
+    )
+    run_parser.add_argument(
+        "--pairs",
+        nargs="+",
+        metavar="SRC:TGT",
+        help="Explicit (source:target) language pairs, e.g. 'en:zh-Hans en:fr ja:en'. "
+             "Overrides --languages and --full. Texts are filtered by `source_language`.",
+    )
+    run_parser.add_argument(
+        "--no-evaluate",
+        action="store_true",
+        help="Skip automatic LLM judge. Translations are saved with scores=None, "
+             "ready for manual evaluation via scripts/dump_for_evaluation.py.",
     )
     run_parser.add_argument(
         "--openai-key",
@@ -756,7 +1180,7 @@ Examples:
     models_parser = subparsers.add_parser("models", help="List available models for benchmarking")
     models_parser.add_argument(
         "-p", "--provider",
-        choices=["ollama", "openai", "openrouter"],
+        choices=["ollama", "openai", "openrouter", "poe"],
         default="ollama",
         help="Provider to list models for (default: ollama)"
     )
@@ -771,6 +1195,16 @@ Examples:
     models_parser.add_argument(
         "--openrouter-key",
         help="OpenRouter API key (required for listing OpenRouter models)"
+    )
+    models_parser.add_argument(
+        "--poe-key",
+        help="Poe API key (overrides POE_API_KEY env)"
+    )
+    models_parser.add_argument(
+        "--check",
+        metavar="MODEL_ID",
+        help="Validate that MODEL_ID exists on the provider. Exits 0 if found, "
+             "1 if not. On miss, prints up to 10 close matches to stdout."
     )
     models_parser.set_defaults(func=cmd_models)
 
@@ -793,6 +1227,88 @@ Examples:
         help="Output file path (default: benchmark_results/<run_id>.csv)"
     )
     export_parser.set_defaults(func=cmd_export)
+
+    # Submit command
+    submit_parser = subparsers.add_parser(
+        "submit",
+        help="Convert a benchmark run JSON into a community submission file",
+    )
+    submit_parser.add_argument(
+        "input",
+        help="Path to the benchmark run JSON to convert (e.g. benchmark_results/<run_id>.json)",
+    )
+    submit_parser.add_argument(
+        "--by",
+        required=True,
+        help="GitHub identity, e.g. github:hydropix",
+    )
+    submit_parser.add_argument(
+        "--provider",
+        required=True,
+        choices=sorted(CLOUD_PROVIDERS | {"ollama"}),
+        help="Provider used to produce the translations.",
+    )
+    submit_parser.add_argument(
+        "--judge-id",
+        help="Judge model ID (defaults to the run's evaluator_model field).",
+    )
+    submit_parser.add_argument(
+        "--judge-seed",
+        type=int,
+        help="Seed used by the judge, if any.",
+    )
+    submit_parser.add_argument(
+        "--judge-temperature",
+        type=float,
+        help="Temperature used by the judge, if any.",
+    )
+    submit_parser.add_argument(
+        "--tbl-version",
+        help="TBL version label (defaults to git short SHA or 'dev').",
+    )
+    submit_parser.add_argument(
+        "--prompt-version",
+        default="v1",
+        help="Prompt version label.",
+    )
+    submit_parser.add_argument(
+        "--source-lang",
+        default="en",
+        help="Source language code for the texts (default: en).",
+    )
+    submit_parser.add_argument(
+        "--notes",
+        help="Optional free-text notes attached to the submission (<=2000 chars).",
+    )
+    submit_parser.add_argument(
+        "-o", "--output",
+        help="Destination directory (default: benchmark/data/submissions/).",
+    )
+    submit_parser.set_defaults(func=cmd_submit)
+
+    # Aggregate-submissions command
+    aggregate_parser = subparsers.add_parser(
+        "aggregate-submissions",
+        help="Merge all benchmark/data/submissions/*.json into a single run JSON",
+    )
+    aggregate_parser.add_argument(
+        "--submissions-dir",
+        help="Where to read submissions from (default: benchmark/data/submissions).",
+    )
+    aggregate_parser.add_argument(
+        "--output",
+        help="Where to write the aggregated run JSON (default: benchmark_results/<run_id>.json).",
+    )
+    aggregate_parser.add_argument(
+        "--run-id",
+        help="Run ID for the aggregated run (default: 'aggregated').",
+    )
+    aggregate_parser.add_argument(
+        "--allow-empty",
+        action="store_true",
+        help="Exit 0 instead of 1 when no submissions are found.",
+    )
+    aggregate_parser.set_defaults(func=cmd_aggregate_submissions)
 
     # Delete command
     delete_parser = subparsers.add_parser("delete", help="Delete a benchmark run")

--- a/benchmark/config.py
+++ b/benchmark/config.py
@@ -284,17 +284,30 @@ class BenchmarkConfig:
                 "Set OPENAI_API_ENDPOINT in .env or use --openai-endpoint"
             )
 
-        if not self.paths.languages_file.exists():
-            errors.append(f"Languages file not found: {self.paths.languages_file}")
+        if self.translation_provider == "poe" and not self.poe.api_key:
+            errors.append(
+                "Poe API key not configured. Required for translation. "
+                "Set POE_API_KEY in .env or use --poe-key"
+            )
 
-        if not self.paths.reference_texts_file.exists():
-            errors.append(f"Reference texts file not found: {self.paths.reference_texts_file}")
+        # Accept either the split layout or the legacy monolithic YAMLs.
+        split_lang_dir = self.paths.base_dir / "data" / "languages"
+        if not split_lang_dir.is_dir() and not self.paths.languages_file.exists():
+            errors.append(
+                f"Languages data not found at {split_lang_dir} or {self.paths.languages_file}"
+            )
+
+        split_texts_dir = self.paths.base_dir / "data" / "reference_texts"
+        if not split_texts_dir.is_dir() and not self.paths.reference_texts_file.exists():
+            errors.append(
+                f"Reference texts not found at {split_texts_dir} or {self.paths.reference_texts_file}"
+            )
 
         # Validate translation provider
-        if self.translation_provider not in ("ollama", "openai", "openrouter"):
+        if self.translation_provider not in ("ollama", "openai", "openrouter", "poe"):
             errors.append(
                 f"Invalid translation provider: {self.translation_provider}. "
-                "Must be 'ollama', 'openai', or 'openrouter'"
+                "Must be 'ollama', 'openai', 'openrouter', or 'poe'"
             )
 
         return errors

--- a/benchmark/data/languages/ar.yaml
+++ b/benchmark/data/languages/ar.yaml
@@ -1,0 +1,7 @@
+code: ar
+name: Arabic
+native_name: العربية
+script: Arabic
+category: semitic
+rtl: true
+difficulty: hard

--- a/benchmark/data/languages/bg.yaml
+++ b/benchmark/data/languages/bg.yaml
@@ -1,0 +1,7 @@
+code: bg
+name: Bulgarian
+native_name: Български
+script: Cyrillic
+category: cyrillic
+rtl: false
+difficulty: medium

--- a/benchmark/data/languages/bn.yaml
+++ b/benchmark/data/languages/bn.yaml
@@ -1,0 +1,7 @@
+code: bn
+name: Bengali
+native_name: বাংলা
+script: Bengali
+category: asian
+rtl: false
+difficulty: hard

--- a/benchmark/data/languages/ca.yaml
+++ b/benchmark/data/languages/ca.yaml
@@ -1,0 +1,7 @@
+code: ca
+name: Catalan
+native_name: Català
+script: Latin
+category: minority
+rtl: false
+difficulty: medium

--- a/benchmark/data/languages/cs.yaml
+++ b/benchmark/data/languages/cs.yaml
@@ -1,0 +1,7 @@
+code: cs
+name: Czech
+native_name: Čeština
+script: Latin
+category: european_major
+rtl: false
+difficulty: medium

--- a/benchmark/data/languages/cy.yaml
+++ b/benchmark/data/languages/cy.yaml
@@ -1,0 +1,7 @@
+code: cy
+name: Welsh
+native_name: Cymraeg
+script: Latin
+category: minority
+rtl: false
+difficulty: hard

--- a/benchmark/data/languages/da.yaml
+++ b/benchmark/data/languages/da.yaml
@@ -1,0 +1,7 @@
+code: da
+name: Danish
+native_name: Dansk
+script: Latin
+category: european_major
+rtl: false
+difficulty: easy

--- a/benchmark/data/languages/de.yaml
+++ b/benchmark/data/languages/de.yaml
@@ -1,0 +1,7 @@
+code: de
+name: German
+native_name: Deutsch
+script: Latin
+category: european_major
+rtl: false
+difficulty: easy

--- a/benchmark/data/languages/el.yaml
+++ b/benchmark/data/languages/el.yaml
@@ -1,0 +1,7 @@
+code: el
+name: Greek
+native_name: Ελληνικά
+script: Greek
+category: european_major
+rtl: false
+difficulty: medium

--- a/benchmark/data/languages/en.yaml
+++ b/benchmark/data/languages/en.yaml
@@ -1,0 +1,7 @@
+code: en
+name: English
+native_name: English
+script: Latin
+category: european_major
+rtl: false
+difficulty: easy

--- a/benchmark/data/languages/es.yaml
+++ b/benchmark/data/languages/es.yaml
@@ -1,0 +1,7 @@
+code: es
+name: Spanish
+native_name: Español
+script: Latin
+category: european_major
+rtl: false
+difficulty: easy

--- a/benchmark/data/languages/eu.yaml
+++ b/benchmark/data/languages/eu.yaml
@@ -1,0 +1,7 @@
+code: eu
+name: Basque
+native_name: Euskara
+script: Latin
+category: minority
+rtl: false
+difficulty: very_hard

--- a/benchmark/data/languages/fi.yaml
+++ b/benchmark/data/languages/fi.yaml
@@ -1,0 +1,7 @@
+code: fi
+name: Finnish
+native_name: Suomi
+script: Latin
+category: european_major
+rtl: false
+difficulty: hard

--- a/benchmark/data/languages/fr.yaml
+++ b/benchmark/data/languages/fr.yaml
@@ -1,0 +1,7 @@
+code: fr
+name: French
+native_name: Français
+script: Latin
+category: european_major
+rtl: false
+difficulty: easy

--- a/benchmark/data/languages/ga.yaml
+++ b/benchmark/data/languages/ga.yaml
@@ -1,0 +1,7 @@
+code: ga
+name: Irish
+native_name: Gaeilge
+script: Latin
+category: minority
+rtl: false
+difficulty: hard

--- a/benchmark/data/languages/gd.yaml
+++ b/benchmark/data/languages/gd.yaml
@@ -1,0 +1,7 @@
+code: gd
+name: Scottish Gaelic
+native_name: Gàidhlig
+script: Latin
+category: minority
+rtl: false
+difficulty: very_hard

--- a/benchmark/data/languages/gl.yaml
+++ b/benchmark/data/languages/gl.yaml
@@ -1,0 +1,7 @@
+code: gl
+name: Galician
+native_name: Galego
+script: Latin
+category: minority
+rtl: false
+difficulty: medium

--- a/benchmark/data/languages/grc.yaml
+++ b/benchmark/data/languages/grc.yaml
@@ -1,0 +1,7 @@
+code: grc
+name: Ancient Greek
+native_name: Ἀρχαία Ἑλληνική
+script: Greek
+category: classical
+rtl: false
+difficulty: very_hard

--- a/benchmark/data/languages/he.yaml
+++ b/benchmark/data/languages/he.yaml
@@ -1,0 +1,7 @@
+code: he
+name: Hebrew
+native_name: עברית
+script: Hebrew
+category: semitic
+rtl: true
+difficulty: hard

--- a/benchmark/data/languages/hi.yaml
+++ b/benchmark/data/languages/hi.yaml
@@ -1,0 +1,7 @@
+code: hi
+name: Hindi
+native_name: हिन्दी
+script: Devanagari
+category: asian
+rtl: false
+difficulty: hard

--- a/benchmark/data/languages/hu.yaml
+++ b/benchmark/data/languages/hu.yaml
@@ -1,0 +1,7 @@
+code: hu
+name: Hungarian
+native_name: Magyar
+script: Latin
+category: european_major
+rtl: false
+difficulty: hard

--- a/benchmark/data/languages/id.yaml
+++ b/benchmark/data/languages/id.yaml
@@ -1,0 +1,7 @@
+code: id
+name: Indonesian
+native_name: Bahasa Indonesia
+script: Latin
+category: asian
+rtl: false
+difficulty: easy

--- a/benchmark/data/languages/is.yaml
+++ b/benchmark/data/languages/is.yaml
@@ -1,0 +1,7 @@
+code: is
+name: Icelandic
+native_name: Íslenska
+script: Latin
+category: minority
+rtl: false
+difficulty: hard

--- a/benchmark/data/languages/it.yaml
+++ b/benchmark/data/languages/it.yaml
@@ -1,0 +1,7 @@
+code: it
+name: Italian
+native_name: Italiano
+script: Latin
+category: european_major
+rtl: false
+difficulty: easy

--- a/benchmark/data/languages/ja.yaml
+++ b/benchmark/data/languages/ja.yaml
@@ -1,0 +1,7 @@
+code: ja
+name: Japanese
+native_name: 日本語
+script: Japanese
+category: asian
+rtl: false
+difficulty: hard

--- a/benchmark/data/languages/ko.yaml
+++ b/benchmark/data/languages/ko.yaml
@@ -1,0 +1,7 @@
+code: ko
+name: Korean
+native_name: 한국어
+script: Hangul
+category: asian
+rtl: false
+difficulty: hard

--- a/benchmark/data/languages/la.yaml
+++ b/benchmark/data/languages/la.yaml
@@ -1,0 +1,7 @@
+code: la
+name: Latin
+native_name: Latina
+script: Latin
+category: classical
+rtl: false
+difficulty: very_hard

--- a/benchmark/data/languages/ms.yaml
+++ b/benchmark/data/languages/ms.yaml
@@ -1,0 +1,7 @@
+code: ms
+name: Malay
+native_name: Bahasa Melayu
+script: Latin
+category: asian
+rtl: false
+difficulty: easy

--- a/benchmark/data/languages/mt.yaml
+++ b/benchmark/data/languages/mt.yaml
@@ -1,0 +1,7 @@
+code: mt
+name: Maltese
+native_name: Malti
+script: Latin
+category: minority
+rtl: false
+difficulty: hard

--- a/benchmark/data/languages/nl.yaml
+++ b/benchmark/data/languages/nl.yaml
@@ -1,0 +1,7 @@
+code: nl
+name: Dutch
+native_name: Nederlands
+script: Latin
+category: european_major
+rtl: false
+difficulty: easy

--- a/benchmark/data/languages/no.yaml
+++ b/benchmark/data/languages/no.yaml
@@ -1,0 +1,7 @@
+code: 'no'
+name: Norwegian
+native_name: Norsk
+script: Latin
+category: european_major
+rtl: false
+difficulty: easy

--- a/benchmark/data/languages/pl.yaml
+++ b/benchmark/data/languages/pl.yaml
@@ -1,0 +1,7 @@
+code: pl
+name: Polish
+native_name: Polski
+script: Latin
+category: european_major
+rtl: false
+difficulty: medium

--- a/benchmark/data/languages/pt.yaml
+++ b/benchmark/data/languages/pt.yaml
@@ -1,0 +1,7 @@
+code: pt
+name: Portuguese
+native_name: Português
+script: Latin
+category: european_major
+rtl: false
+difficulty: easy

--- a/benchmark/data/languages/ro.yaml
+++ b/benchmark/data/languages/ro.yaml
@@ -1,0 +1,7 @@
+code: ro
+name: Romanian
+native_name: Română
+script: Latin
+category: european_major
+rtl: false
+difficulty: medium

--- a/benchmark/data/languages/ru.yaml
+++ b/benchmark/data/languages/ru.yaml
@@ -1,0 +1,7 @@
+code: ru
+name: Russian
+native_name: Русский
+script: Cyrillic
+category: cyrillic
+rtl: false
+difficulty: medium

--- a/benchmark/data/languages/sa.yaml
+++ b/benchmark/data/languages/sa.yaml
@@ -1,0 +1,7 @@
+code: sa
+name: Sanskrit
+native_name: संस्कृतम्
+script: Devanagari
+category: classical
+rtl: false
+difficulty: very_hard

--- a/benchmark/data/languages/sr.yaml
+++ b/benchmark/data/languages/sr.yaml
@@ -1,0 +1,7 @@
+code: sr
+name: Serbian
+native_name: Српски
+script: Cyrillic
+category: cyrillic
+rtl: false
+difficulty: medium

--- a/benchmark/data/languages/sv.yaml
+++ b/benchmark/data/languages/sv.yaml
@@ -1,0 +1,7 @@
+code: sv
+name: Swedish
+native_name: Svenska
+script: Latin
+category: european_major
+rtl: false
+difficulty: easy

--- a/benchmark/data/languages/ta.yaml
+++ b/benchmark/data/languages/ta.yaml
@@ -1,0 +1,7 @@
+code: ta
+name: Tamil
+native_name: தமிழ்
+script: Tamil
+category: asian
+rtl: false
+difficulty: hard

--- a/benchmark/data/languages/th.yaml
+++ b/benchmark/data/languages/th.yaml
@@ -1,0 +1,7 @@
+code: th
+name: Thai
+native_name: ไทย
+script: Thai
+category: asian
+rtl: false
+difficulty: hard

--- a/benchmark/data/languages/tl.yaml
+++ b/benchmark/data/languages/tl.yaml
@@ -1,0 +1,7 @@
+code: tl
+name: Filipino
+native_name: Filipino
+script: Latin
+category: asian
+rtl: false
+difficulty: medium

--- a/benchmark/data/languages/uk.yaml
+++ b/benchmark/data/languages/uk.yaml
@@ -1,0 +1,7 @@
+code: uk
+name: Ukrainian
+native_name: Українська
+script: Cyrillic
+category: cyrillic
+rtl: false
+difficulty: medium

--- a/benchmark/data/languages/vi.yaml
+++ b/benchmark/data/languages/vi.yaml
@@ -1,0 +1,7 @@
+code: vi
+name: Vietnamese
+native_name: Tiếng Việt
+script: Latin
+category: asian
+rtl: false
+difficulty: medium

--- a/benchmark/data/languages/zh-Hans.yaml
+++ b/benchmark/data/languages/zh-Hans.yaml
@@ -1,0 +1,7 @@
+code: zh-Hans
+name: Chinese (Simplified)
+native_name: 简体中文
+script: Han
+category: asian
+rtl: false
+difficulty: hard

--- a/benchmark/data/languages/zh-Hant.yaml
+++ b/benchmark/data/languages/zh-Hant.yaml
@@ -1,0 +1,7 @@
+code: zh-Hant
+name: Chinese (Traditional)
+native_name: 繁體中文
+script: Han
+category: asian
+rtl: false
+difficulty: hard

--- a/benchmark/data/reference_texts/de/verwandlung.yaml
+++ b/benchmark/data/reference_texts/de/verwandlung.yaml
@@ -1,0 +1,15 @@
+id: verwandlung
+title: Die Verwandlung
+author: Franz Kafka
+year: 1915
+source_language: de
+style: Long-breathed narrative syntax with nested subordinate clauses
+challenges:
+- Extended hypotactic sentences with multiple embedded relative clauses
+- Precise body/spatial description of an unfamiliar (insect) anatomy
+- Free indirect access to Gregor's perception inside narrative third person
+- Idiomatic adverbial chains (fast wild geworden, mit gesammelter Kraft, ohne Rücksicht)
+text: |
+  Zuerst wollte er mit dem unteren Teil seines Körpers aus dem Bett hinauskommen, aber dieser untere Teil, den er übrigens noch nicht gesehen hatte und von dem er sich auch keine rechte Vorstellung machen konnte, erwies sich als zu schwer beweglich; es ging so langsam; und als er schließlich, fast wild geworden, mit gesammelter Kraft, ohne Rücksicht sich vorwärtsstieß, hatte er die Richtung falsch gewählt, schlug an den unteren Bettpfosten heftig an, und der brennende Schmerz, den er empfand, belehrte ihn, daß gerade der untere Teil seines Körpers augenblicklich vielleicht der empfindlichste war.
+license: public-domain
+character_count: 601

--- a/benchmark/data/reference_texts/en/aurelius_meditations.yaml
+++ b/benchmark/data/reference_texts/en/aurelius_meditations.yaml
@@ -1,0 +1,14 @@
+id: aurelius_meditations
+title: Meditations
+author: Marcus Aurelius (trans. George Long)
+year: 1862
+source_language: en
+style: Stoic maxims and philosophical imperatives
+challenges:
+- Archaic second-person pronouns (thou, thee, thy)
+- Gnomic, aphoristic register
+- Abstract ethical concepts to render concisely
+text: |
+  Do, soul, do; abuse and contemn thyself; yet a while and the time for thee to respect thyself, will be at an end. Every man's happiness depends from himself, but behold thy life is almost at an end, whiles affording thyself no respect, thou dost make thy happiness to consist in the souls, and conceits of other men. Why should any of these things that happen externally, so much distract thee? Give thyself leisure to learn some good thing, and cease roving and wandering to and fro.
+license: public-domain
+character_count: 484

--- a/benchmark/data/reference_texts/en/dorian_gray.yaml
+++ b/benchmark/data/reference_texts/en/dorian_gray.yaml
@@ -1,0 +1,13 @@
+id: dorian_gray
+title: The Picture of Dorian Gray
+author: Oscar Wilde
+year: 1890
+source_language: en
+style: Sensory description and aestheticism
+challenges:
+- Rich sensory vocabulary
+- Aesthetic philosophy
+- Ornate descriptive prose
+text: The studio was filled with the rich odour of roses, and when the light summer wind stirred amidst the trees of the garden, there came through the open door the heavy scent of the lilac, or the more delicate perfume of the pink-flowering thorn. From the corner of the divan of Persian saddle-bags on which he was lying, smoking, as was his custom, innumerable cigarettes, Lord Henry Wotton could just catch the gleam of the honey-sweet and honey-coloured blossoms of a laburnum.
+license: public-domain
+character_count: 506

--- a/benchmark/data/reference_texts/en/einstein_relativity.yaml
+++ b/benchmark/data/reference_texts/en/einstein_relativity.yaml
@@ -1,0 +1,15 @@
+id: einstein_relativity
+title: "Relativity: The Special and General Theory"
+author: Albert Einstein
+year: 1920
+source_language: en
+style: Popular-science exposition with logical reasoning
+challenges:
+- Abstract physics concepts (simultaneity, reference frames, motion) in plain prose
+- Logical connectors and conditional reasoning ("if... then", "we have just seen", "tacitly assumed")
+- Latin scientific phrases (i.e., in vacuo) that have established translation conventions
+- Maintaining clarity of an argument that overturns intuitive assumptions
+text: |
+  Now before the advent of the theory of relativity it had always tacitly been assumed in physics that the statement of time had an absolute significance, i.e. that it is independent of the state of motion of the body of reference. But we have just seen that this assumption is incompatible with the most natural definition of simultaneity; if we discard this assumption, then the conflict between the law of the propagation of light in vacuo and the principle of relativity (developed in Section VII) disappears.
+license: public-domain
+character_count: 511

--- a/benchmark/data/reference_texts/en/emerson_self_reliance.yaml
+++ b/benchmark/data/reference_texts/en/emerson_self_reliance.yaml
@@ -1,0 +1,14 @@
+id: emerson_self_reliance
+title: Self-Reliance
+author: Ralph Waldo Emerson
+year: 1841
+source_language: en
+style: Aphoristic motivational essay
+challenges:
+- Maxim-driven rhetoric with archaic imperatives (Trust thyself)
+- Long periodic sentences with abstract nouns
+- Register shifts between proclamation and reflection
+text: |
+  Trust thyself: every heart vibrates to that iron string. Accept the place the divine providence has found for you, the society of your contemporaries, the connection of events. Great men have always done so, and confided themselves childlike to the genius of their age, betraying their perception that the absolutely trustworthy was seated at their heart, working through their hands, predominating in all their being.
+license: public-domain
+character_count: 418

--- a/benchmark/data/reference_texts/en/moby_dick.yaml
+++ b/benchmark/data/reference_texts/en/moby_dick.yaml
@@ -1,0 +1,13 @@
+id: moby_dick
+title: Moby-Dick
+author: Herman Melville
+year: 1851
+source_language: en
+style: Archaic literary prose
+challenges:
+- Archaic vocabulary and syntax
+- Maritime terminology
+- Epic narrative style
+text: Call me Ishmael. Some years ago—never mind how long precisely—having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little and see the watery part of the world. It is a way I have of driving off the spleen and regulating the circulation. Whenever I find myself growing grim about the mouth; whenever it is a damp, drizzly November in my soul, I account it high time to get to sea as soon as I can.
+license: public-domain
+character_count: 467

--- a/benchmark/data/reference_texts/en/origin_species.yaml
+++ b/benchmark/data/reference_texts/en/origin_species.yaml
@@ -1,0 +1,15 @@
+id: origin_species
+title: On the Origin of Species
+author: Charles Darwin
+year: 1859
+source_language: en
+style: Victorian scientific argumentation
+challenges:
+- Preserving scientific hedging and qualified claims across languages
+- Long subordinate clauses with conditional reasoning
+- Author's first-person epistemic stance ("I hope", "No doubt", "I must trust")
+- 19th-century formal scientific register
+text: |
+  This Abstract, which I now publish, must necessarily be imperfect. I cannot here give references and authorities for my several statements; and I must trust to the reader reposing some confidence in my accuracy. No doubt errors will have crept in, though I hope I have always been cautious in trusting to good authorities alone. I can here give only the general conclusions at which I have arrived, with a few facts in illustration, but which, I hope, in most cases will suffice.
+license: public-domain
+character_count: 479

--- a/benchmark/data/reference_texts/en/pride_prejudice.yaml
+++ b/benchmark/data/reference_texts/en/pride_prejudice.yaml
@@ -1,0 +1,13 @@
+id: pride_prejudice
+title: Pride and Prejudice
+author: Jane Austen
+year: 1813
+source_language: en
+style: Prose narrative with irony
+challenges:
+- Subtle irony and social commentary
+- Period-appropriate language
+- Complex sentence structures
+text: It is a truth universally acknowledged, that a single man in possession of a good fortune, must be in want of a wife. However little known the feelings or views of such a man may be on his first entering a neighbourhood, this truth is so well fixed in the minds of the surrounding families, that he is considered as the rightful property of some one or other of their daughters.
+license: public-domain
+character_count: 399

--- a/benchmark/data/reference_texts/en/study_scarlet.yaml
+++ b/benchmark/data/reference_texts/en/study_scarlet.yaml
@@ -1,0 +1,13 @@
+id: study_scarlet
+title: A Study in Scarlet
+author: Arthur Conan Doyle
+year: 1887
+source_language: en
+style: Dialogue and character introduction
+challenges:
+- Natural dialogue flow
+- Character voice preservation
+- Period British English
+text: '"You have been in Afghanistan, I perceive." "How on earth did you know that?" I asked in astonishment. "Never mind," said he, chuckling to himself. "The question now is about haemoglobin. No doubt you see the significance of this discovery of mine?" "It is interesting, chemically, no doubt," I answered, "but practically—" "Why, man, it is the most practical medico-legal discovery for years. Don''t you see that it gives us an infallible test for blood stains?"'
+license: public-domain
+character_count: 472

--- a/benchmark/data/reference_texts/en/twain_innocents.yaml
+++ b/benchmark/data/reference_texts/en/twain_innocents.yaml
@@ -1,0 +1,14 @@
+id: twain_innocents
+title: The Innocents Abroad
+author: Mark Twain
+year: 1869
+source_language: en
+style: Deadpan humorous travel narration
+challenges:
+- Ironic understatement and mock-naive voice
+- Mixed registers shifting from elevated to colloquial American idiom
+- Idioms like "what in the mischief" that resist literal translation
+text: |
+  It seems to me that whenever I glory to think that for once I have discovered an ancient painting that is beautiful and worthy of all praise, the pleasure it gives me is an infallible proof that it is not a beautiful picture and not in any wise worthy of commendation. This very thing has occurred more times than I can mention, in Venice. In every single instance the guide has crushed out my swelling enthusiasm with the remark: “It is nothing--it is of the Renaissance.”
+license: public-domain
+character_count: 473

--- a/benchmark/data/reference_texts/en/walden.yaml
+++ b/benchmark/data/reference_texts/en/walden.yaml
@@ -1,0 +1,13 @@
+id: walden
+title: Walden
+author: Henry David Thoreau
+year: 1854
+source_language: en
+style: Philosophical prose and nature writing
+challenges:
+- Abstract philosophical concepts
+- Metaphorical language
+- Contemplative tone
+text: I went to the woods because I wished to live deliberately, to front only the essential facts of life, and see if I could not learn what it had to teach, and not, when I came to die, discover that I had not lived. I did not wish to live what was not life, living is so dear; nor did I wish to practise resignation, unless it was quite necessary. I wanted to live deep and suck out all the marrow of life.
+license: public-domain
+character_count: 419

--- a/benchmark/data/reference_texts/es/quijote.yaml
+++ b/benchmark/data/reference_texts/es/quijote.yaml
@@ -1,0 +1,15 @@
+id: quijote
+title: Don Quijote de la Mancha
+author: Miguel de Cervantes
+year: 1605
+source_language: es
+style: Early Modern Spanish narrative with classical syntax and ironic distance
+challenges:
+- Archaic forms (dellos, hanegas) and Golden Age vocabulary
+- Long periodic sentences with chained subordinate clauses
+- Cervantine irony — mock-serious tone the translator must not flatten
+- Idiomatic phrasing (de todo punto, llegó a tanto su curiosidad y desatino)
+text: |
+  Es, pues, de saber que este sobredicho hidalgo, los ratos que estaba ocioso, que eran los más del año, se daba a leer libros de caballerías, con tanta afición y gusto, que olvidó casi de todo punto el ejercicio de la caza, y aun la administración de su hacienda. Y llegó a tanto su curiosidad y desatino en esto, que vendió muchas hanegas de tierra de sembradura para comprar libros de caballerías en que leer, y así, llevó a su casa todos cuantos pudo haber dellos.
+license: public-domain
+character_count: 466

--- a/benchmark/data/reference_texts/fr/madame_bovary.yaml
+++ b/benchmark/data/reference_texts/fr/madame_bovary.yaml
@@ -1,0 +1,15 @@
+id: madame_bovary
+title: Madame Bovary
+author: Gustave Flaubert
+year: 1857
+source_language: fr
+style: Free indirect discourse and lyrical description
+challenges:
+- Style indirect libre (narrator merging into character's reverie)
+- Sustained imparfait/conditionnel mood and unreal hypothesis
+- Sensory clichés of romantic exoticism without irony breaking
+- Long periodic sentences with embedded clauses
+text: |
+  Elle songeait quelquefois que c’étaient là pourtant les plus beaux jours de sa vie, la lune de miel, comme on disait. Pour en goûter la douceur, il eût fallu, sans doute, s’en aller vers ces pays à noms sonores où les lendemains de mariage ont de plus suaves paresses! Dans des chaises de poste, sous des stores de soie bleue, on monte au pas des routes escarpées, écoutant la chanson du postillon, qui se répète dans la montagne avec les clochettes des chèvres et le bruit sourd de la cascade.
+license: public-domain
+character_count: 494

--- a/benchmark/data/reference_texts/fr/poincare_science.yaml
+++ b/benchmark/data/reference_texts/fr/poincare_science.yaml
@@ -1,0 +1,15 @@
+id: poincare_science
+title: La Science et l’Hypothèse
+author: Henri Poincaré
+year: 1902
+source_language: fr
+style: French academic essay, early 20th-century philosophy of science
+challenges:
+- Long periodic sentences with multiple subordinate clauses
+- Abstract epistemological vocabulary (hypothèse, mathématicien, expérimentateur, sceptique)
+- French typographic conventions (espace insécable before ; and ?, curly apostrophes)
+- Philosophical balance and antithesis ("Douter de tout ou tout croire")
+text: |
+  Quand on a un peu plus réfléchi, on a aperçu la place tenue par l’hypothèse ; on a vu que le mathématicien ne saurait s’en passer et que l’expérimentateur ne s’en passe pas davantage. Et alors, on s’est demandé si toutes ces constructions étaient bien solides et on a cru qu’un souffle allait les abattre. Être sceptique de cette façon, c’est encore être superficiel. Douter de tout ou tout croire, ce sont deux solutions également commodes, qui l’une et l’autre nous dispensent de réfléchir.
+license: public-domain
+character_count: 492

--- a/benchmark/data/reference_texts/ja/kokoro.yaml
+++ b/benchmark/data/reference_texts/ja/kokoro.yaml
@@ -1,0 +1,15 @@
+id: kokoro
+title: こころ
+author: 夏目漱石
+year: 1914
+source_language: ja
+style: First-person introspective narration in early-modern colloquial Japanese
+challenges:
+- Pronoun and referent ambiguity (その人, 先生 used as common noun and address)
+- Subtle shifts between past habit and present reflection
+- Honorific/affective register attached to a title rather than a name
+- Idiomatic phrasing (世間を憚る, 心持は同じ事である) without direct equivalents
+text: |
+  私はその人を常に先生と呼んでいた。だからここでもただ先生と書くだけで本名は打ち明けない。これは世間を憚る遠慮というよりも、その方が私にとって自然だからである。私はその人の記憶を呼び起すごとに、すぐ「先生」といいたくなる。筆を執っても心持は同じ事である。よそよそしい頭文字などはとても使う気にならない。
+license: public-domain
+character_count: 150

--- a/benchmark/data/reference_texts/ko/unsu_jouen_nal.yaml
+++ b/benchmark/data/reference_texts/ko/unsu_jouen_nal.yaml
@@ -1,0 +1,20 @@
+id: unsu_jouen_nal
+title: 운수 좋은 날
+author: 현진건
+year: 1924
+source_language: ko
+style: Realist third-person narration in 1920s colonial-era Korean, mixing literary register with vernacular peasant detail
+challenges:
+- Implicit subjects and topic-comment syntax that resist direct mapping to English SVO
+- Mimetic onomatopoeia (추적추적, 어정어정, 찰깍) carrying tactile and aural texture
+- Period-specific vocabulary (인력거꾼, 김 첨지, 백통화, 동소문) tied to colonial Joseon rickshaw culture
+- Long, comma-stacked sentences blending narrator interiority with social observation
+- Mixed Hangul-Hanja notation (東光學校) signalling formal/institutional registers
+text: |
+  새침하게 흐린 품이 눈이 올 듯하더니 눈은 아니 오고 얼다가 만 비가 추적추적 내리었다.
+
+  이날이야말로 동소문 안에서 인력거꾼 노릇을 하는 김 첨지에게는 오래간만에도 닥친 운수 좋은 날이었다. 문안에(거기도 문밖은 아니지만) 들어간답시는 앞집 마나님을 전찻길까지 모셔다 드린 것을 비롯으로 행여나 손님이 있을까 하고 정류장에서 어정어정하며 내리는 사람 하나하나에게 거의 비는 듯한 눈결을 보내고 있다가 마침내 교원인 듯한 양복장이를 동광학교(東光學校)까지 태워다 주기로 되었다.
+
+  첫번에 삼십 전, 둘째 번에 오십 전 - 아침 댓바람에 그리 흔치 않은 일이었다. 그야말로 재수가 옴붙어서 근 열흘 동안 돈 구경도 못한 김 첨지는 십 전짜리 백통화 서 푼, 또는 다섯 푼이 찰깍하고 손바닥에 떨어질 제 거의 눈물을 흘릴 만큼 기뻤었다.
+license: public-domain
+character_count: 410

--- a/benchmark/data/reference_texts/zh-Hans/hu_shi_reform.yaml
+++ b/benchmark/data/reference_texts/zh-Hans/hu_shi_reform.yaml
@@ -1,0 +1,15 @@
+id: hu_shi_reform
+title: "文学改良刍议 (Wénxué gǎiliáng chúyì / A Modest Proposal for Literary Reform)"
+author: "胡适 (Hu Shi)"
+year: 1917
+source_language: zh-Hans
+style: Early-20th-century argumentative essay bridging classical and vernacular registers
+challenges:
+- Classical-vernacular tension (吾, 之, 者何) inside a modernizing manifesto
+- Enumerative parallelism (一曰…二曰…) demanding consistent target-language rhythm
+- Programmatic terms of art (言之有物, 不摹仿古人, 不用典, 不讲对仗) needing scholarly precision
+- Authorial self-reference in the third person (记者末学不文) shifting register mid-sentence
+text: |
+  今之谈文学改良者众矣，记者末学不文，何足以言此。然年来颇于此事再四研思，辅以友朋辩论，其结果所得，颇不无讨论之价值。因综括所怀见解，列为八事，分别言之，以与当世之留意文学改良者一研究之。吾以为今日而言文学改良，须从八事入手。八事者何？一曰，须言之有物。二曰，不摹仿古人。三曰，须讲求文法。四曰，不作无病之呻吟。五曰，务去滥调套语。六曰，不用典。七曰，不讲对仗。八曰，不避俗字俗语。
+license: public-domain
+character_count: 190

--- a/benchmark/data/reference_texts/zh-Hans/lu_xun_guxiang.yaml
+++ b/benchmark/data/reference_texts/zh-Hans/lu_xun_guxiang.yaml
@@ -1,0 +1,15 @@
+id: lu_xun_guxiang
+title: "故乡 (Gùxiāng / Hometown)"
+author: "鲁迅 (Lu Xun)"
+year: 1921
+source_language: zh-Hans
+style: Modern vernacular narrative with introspective melancholy
+challenges:
+- Multi-register prose mixing literary narration with colloquial reflection
+- Sentence-final particles and exclamations (阿！, 罢了) carrying tonal weight
+- Rendering early Báihuà (白话文) without flattening its rhythm into modern prose
+- Concrete sensory imagery (苍黄的天, 萧索的荒村) anchoring an interior mood
+text: |
+  我冒了严寒，回到相隔二千馀里，别了二十馀年的故乡去。时候既然是深冬；渐近故乡时，天气又阴晦了，冷风吹进船舱中，呜呜的响，从篷隙向外一望，苍黄的天底下，远近横着几个萧索的荒村，没有一些活气。我的心禁不住悲凉起来了。阿！这不是我二十年来时时记得的故乡？我所记得的故乡全不如此。我的故乡好得多了。但要我记起他的美丽，说出他的佳处来，却又没有影像，没有言辞了。仿佛也就如此。于是我自己解释说：故乡本也如此，——虽然没有进步，也未必有如我所感的悲凉，这只是我自己心情的改变罢了，因为我这次回乡，本没有什么好心绪。
+license: public-domain
+character_count: 251

--- a/benchmark/data/submissions/2026-05-09_hydropix_gemma3-27b.json
+++ b/benchmark/data/submissions/2026-05-09_hydropix_gemma3-27b.json
@@ -1,0 +1,693 @@
+{
+  "schema_version": "1.0",
+  "submission": {
+    "submitted_by": "github:hydropix",
+    "submitted_at": "2026-05-09T21:51:31Z"
+  },
+  "environment": {
+    "tbl_version": "v0.2.0",
+    "prompt_version": "v1",
+    "judge_id": "claude-opus-4-7-rubric-v1"
+  },
+  "model": {
+    "provider": "ollama",
+    "id": "gemma3:27b"
+  },
+  "results": [
+    {
+      "text_id": "aurelius_meditations",
+      "source_lang": "en",
+      "target_lang": "zh-Hans",
+      "output": "灵魂啊，去吧，为所欲为；鄙视和轻蔑自己吧；再过一会儿，你尊重自己的时机就要结束了。每个人的幸福都取决于自身，但看看，你的生命已经接近尾声，却依然不尊重自己，将幸福寄托于他人的灵魂和想法。为什么这些外在发生的事情，会如此扰乱你的心绪？给自己一些时间去学习美好的事物，停止漫游和漂泊吧。",
+      "output_hash": "sha256:6256bd8641d9a7f9ceb63a02fb30c37828fc886fa73d34506b4e17f767a570aa",
+      "translation_latency_ms": 14522,
+      "scores": {
+        "accuracy": 7.0,
+        "fluency": 8.5,
+        "style": 7.0,
+        "overall": 6.5,
+        "feedback": "Contresens majeur sur l'incipit 'Do, soul, do' rendu par '为所欲为' (do as one pleases). Registre stoïque gnomique aplati. (-2.0 acc, -1.0 style)"
+      }
+    },
+    {
+      "text_id": "dorian_gray",
+      "source_lang": "en",
+      "target_lang": "zh-Hans",
+      "output": "工作室里弥漫着浓郁的玫瑰香气，当轻盈的夏风吹拂着花园里的树木时，阵阵浓重的丁香花香或是更为清新的粉色蔷薇香气，便随着敞开的门飘入室内。躺在波斯马鞍包制成的长沙发一角，他像往常一样，不停地抽着一支又一支香烟，亨利·沃顿勋爵正能瞥见一簇金黄色的金链花，花朵甜美而色彩如蜜。",
+      "output_hash": "sha256:3cb56d1371407d3c3aa0bb4a7c44ed3eb81c56b6ee039c346efe5a90a8a8c2c0",
+      "translation_latency_ms": 3094,
+      "scores": {
+        "accuracy": 8.5,
+        "fluency": 8.0,
+        "style": 7.5,
+        "overall": 7.5,
+        "feedback": "Faithful rendering, but '波斯马鞍包' is literal and the dual subject '他...亨利·沃顿勋爵' creates redundancy. Ornate sensory register only partially captured. (-0.5 fluency, -1.0 style)"
+      }
+    },
+    {
+      "text_id": "einstein_relativity",
+      "source_lang": "en",
+      "target_lang": "zh-Hans",
+      "output": "在相对论出现之前，物理学界一直默契地认为时间陈述具有绝对意义，即它与参考物体的运动状态无关。但我们刚才已经看到，这个假设与同时性的最自然定义是不相容的；如果我们抛弃这个假设，那么真空中的光传播定律与相对性原理（在第七节中阐述）之间的矛盾就会消失。",
+      "output_hash": "sha256:611554ffdaa9fd51026bf186774feaded125e7a7345e75e968741d84d5125a00",
+      "translation_latency_ms": 2305,
+      "scores": {
+        "accuracy": 8.5,
+        "fluency": 9.0,
+        "style": 8.5,
+        "overall": 8.0,
+        "feedback": "Technically precise with established physics terms; '默契地' (mutual tacit) is a calque for 'tacitly' (silently). (-0.3 accuracy)"
+      }
+    },
+    {
+      "text_id": "emerson_self_reliance",
+      "source_lang": "en",
+      "target_lang": "zh-Hans",
+      "output": "相信自己：每一颗心都在那根钢铁琴弦上震动。接受神 Providence 为你安排的位置，你所处时代的社会，以及事件的关联。伟人总是这样做的，他们像孩子一样信任他们那个时代的精神，流露出他们认识到绝对可靠的东西就坐落在他们的内心，通过他们的双手发挥作用，并支配着他们的整个存在。",
+      "output_hash": "sha256:17815a76129d364634859f2217d5e13bbf856c7b35a079002da0cd2c2fd65e0b",
+      "translation_latency_ms": 2267,
+      "scores": {
+        "accuracy": 8.0,
+        "fluency": 7.5,
+        "style": 7.5,
+        "overall": 7.0,
+        "feedback": "Severe break: 'Providence' left in English inside Chinese text; 'iron string' calque '钢铁琴弦'. (-1.5 accuracy, -1.0 fluency mixed-script, -0.5 style)"
+      }
+    },
+    {
+      "text_id": "moby_dick",
+      "source_lang": "en",
+      "target_lang": "zh-Hans",
+      "output": "叫我以实玛利吧。那是几年前的事了——确切多久已经无所谓了——我兜里几乎没有钱，岸上也没有什么特别让我感兴趣的事，便想出海四处看看，探寻这水天一色的世界。这是我排遣忧郁、调理气血的方式。每当我发现自己变得愁眉苦脸，每当我的内心如同阴湿多雨的十一月时，我就认为该尽快出海了。",
+      "output_hash": "sha256:8bd216bbc0ae2c3d1689f8c27e0b6ddef6c60330da76076e4ef0b8d64d83f316",
+      "translation_latency_ms": 2740,
+      "scores": {
+        "accuracy": 9.0,
+        "fluency": 9.0,
+        "style": 8.5,
+        "overall": 8.5,
+        "feedback": "Excellent literary translation: '水天一色' for 'watery part of the world' and '调理气血' for 'regulating circulation' are idiomatic Chinese choices that preserve Melville's tone."
+      }
+    },
+    {
+      "text_id": "origin_species",
+      "source_lang": "en",
+      "target_lang": "zh-Hans",
+      "output": "这篇摘要，我现予以发表，必然存在不尽完善之处。我无法在此列出所有论述的参考资料和权威出处，只能恳请读者对我所陈述内容的准确性给予一定的信任。毫无疑问，其中可能会出现错误，但我希望自己一直谨慎，仅依赖于可靠的权威来源。我在这里只能阐述我所得出的总体结论，并辅以少量事实作为说明，但我希望这些在大多数情况下是足够的。",
+      "output_hash": "sha256:8d13f0f86a68c0a3c8e0eaef8de272a65d37a112fa9224e74d7ee59d24cab3cc",
+      "translation_latency_ms": 2700,
+      "scores": {
+        "accuracy": 8.5,
+        "fluency": 9.0,
+        "style": 8.0,
+        "overall": 8.0,
+        "feedback": "Faithful to Darwin's qualified scientific tone; '恳请' is slightly stronger than 'I must trust' but preserves the spirit. (-0.3 style)"
+      }
+    },
+    {
+      "text_id": "pride_prejudice",
+      "source_lang": "en",
+      "target_lang": "zh-Hans",
+      "output": "凡是有钱的单身汉，总想找位太太。尽管我们对一个单身汉初入新邻居时的内心感受或想法所知甚少，但这个道理却深深地烙印在周围人家的心中，他们认为这位单身汉就该属于他们女儿中的一位。",
+      "output_hash": "sha256:3146e566eb569d342e59852c0541d64a8857130964f6cf84e82bd744545902dd",
+      "translation_latency_ms": 1966,
+      "scores": {
+        "accuracy": 7.5,
+        "fluency": 9.0,
+        "style": 6.0,
+        "overall": 6.0,
+        "feedback": "Loses Austen's signature ironic 'truth universally acknowledged' framing — reads as plain narrative. 'Must be in want of' flattened to '总想找'. (-1.0 acc, -1.5 style)"
+      }
+    },
+    {
+      "text_id": "study_scarlet",
+      "source_lang": "en",
+      "target_lang": "zh-Hans",
+      "output": "“您去过阿富汗，我看得出来。” “你怎么知道的？”我惊讶地问道。“不必说了，”他一边自顾自地 chuckle 着说，“现在的问题是关于血红蛋白的。你一定能看出我这项发现的意义吧？” “从化学角度来看，这无疑是很有趣的，”我回答道，“但实际上——” “我的天，这可是近年来最实用的法医发现。难道你没意识到，它为我们提供了一种万无一失的血迹检验方法吗？”",
+      "output_hash": "sha256:f4a5eac95dbec71d75f91f92626555766147a847ab9e8942f0cde84e8f5d6707",
+      "translation_latency_ms": 3026,
+      "scores": {
+        "accuracy": 8.5,
+        "fluency": 7.0,
+        "style": 7.5,
+        "overall": 7.5,
+        "feedback": "Untranslated 'chuckle' embedded with Chinese suffix breaks fluency mid-sentence. Otherwise the dialogue rendering is natural. (-1.0 fluency mixed-script, -0.5 calque)"
+      }
+    },
+    {
+      "text_id": "twain_innocents",
+      "source_lang": "en",
+      "target_lang": "zh-Hans",
+      "output": "在我看来，每当我得意地认为自己偶然发现了一幅既古老又美丽、值得赞扬的画作时，由此获得的快乐，反而成了证明它并非一幅杰作，也绝不值得称赞的确凿证据。这种事情在威尼斯已经发生过无数次。每一次，导游都会用一句“没什麼——这是文艺复兴时期的作品”来当头浇灭我高涨的热情。",
+      "output_hash": "sha256:9ba12cff2dc33f16762c05a967ad42f7a0b5ccf84b3f9be7f02d0396fa4c0f00",
+      "translation_latency_ms": 2577,
+      "scores": {
+        "accuracy": 9.0,
+        "fluency": 8.0,
+        "style": 8.5,
+        "overall": 7.5,
+        "feedback": "Captures Twain's deflationary irony with idiomatic '当头浇灭', but uses Traditional 麼 in zh-Hans output. (-1.0 fluency script mismatch)"
+      }
+    },
+    {
+      "text_id": "walden",
+      "source_lang": "en",
+      "target_lang": "zh-Hans",
+      "output": "我走进森林，是因为我渴望过一种有目的的生活，直面生活的基本真相，并看看我能否从中有所学得，而不是等到临终时才发现我从未真正活过。我不愿度过虚伪的生活，生命如此珍贵；我也不愿轻易放弃，除非万不得已。我想要深入地生活，吮吸生命的精髓。",
+      "output_hash": "sha256:94b9440256d8999e904ecb554d99d3a8f29d399508e6697d769678c351dc46a5",
+      "translation_latency_ms": 2288,
+      "scores": {
+        "accuracy": 8.0,
+        "fluency": 9.0,
+        "style": 8.0,
+        "overall": 7.5,
+        "feedback": "Slight semantic drift on 'deliberately' (→ '有目的'), 'what was not life' (→ '虚伪的生活'), 'practise resignation' (→ '轻易放弃'). Reflective tone preserved. (-1.5 accuracy aggregate)"
+      }
+    },
+    {
+      "text_id": "aurelius_meditations",
+      "source_lang": "en",
+      "target_lang": "es",
+      "output": "Hazlo, alma, hazlo; ultraja y desprecia tu propio ser; pero aún te queda tiempo antes de que llegue el momento de respetarte, cuando este habrá terminado. La felicidad de cada hombre depende de sí mismo, pero observa que tu vida está llegando a su fin, y sin mostrarte el menor respeto, haces que tu felicidad dependa de las almas y las opiniones de otros. ¿Por qué estas cosas que suceden externamente deberían distraerte tanto? Date tiempo para aprender algo bueno y deja de vagar y deambulando sin rumbo.",
+      "output_hash": "sha256:65fcbbd8e0e8e65ed63bba4ffe2778733fcc24e18750a1aa82eb6c4ac415a26a",
+      "translation_latency_ms": 3233,
+      "scores": {
+        "accuracy": 8.5,
+        "fluency": 7.5,
+        "style": 7.5,
+        "overall": 7.0,
+        "feedback": "Grammar error: 'deja de vagar y deambulando' mixes infinitive and gerund (should be 'vagar y deambular'). Archaic Stoic register reasonably attempted. (-1.5 fluency)"
+      }
+    },
+    {
+      "text_id": "dorian_gray",
+      "source_lang": "en",
+      "target_lang": "es",
+      "output": "El estudio estaba impregnado del intenso aroma de las rosas, y cuando la ligera brisa veraniega agitaba los árboles del jardín, el pesado perfume de los lilas, o el más delicado aroma de las espinas florecientes de color rosa, entraba por la puerta abierta. Desde el rincón del diván cubierto de alfombras persas de montar a caballo, donde estaba tumbado fumando, como solía hacer, innumerables cigarrillos, Lord Henry Wotton podía apenas vislumbrar el brillo de las flores de color miel y de un tono miel de un labiérnago.",
+      "output_hash": "sha256:d247e0b2428aa8712b1459cb3347be8dfdbae731997e0a47a0f41a540c170055",
+      "translation_latency_ms": 3389,
+      "scores": {
+        "accuracy": 7.0,
+        "fluency": 8.0,
+        "style": 7.0,
+        "overall": 6.5,
+        "feedback": "Multiple specialized errors: saddle-bags → 'alfombras de montar' (riding rugs), laburnum → 'labiérnago' (mock privet, wrong species), thorn → bare 'espinas'. Wilde's imagery suffers. (-2.5 accuracy, -0.5 fluency)"
+      }
+    },
+    {
+      "text_id": "einstein_relativity",
+      "source_lang": "en",
+      "target_lang": "es",
+      "output": "Ahora bien, antes del advenimiento de la teoría de la relatividad, siempre se había dado por sentado tácitamente en la física que la declaración del tiempo tenía un significado absoluto, es decir, que era independiente del estado de movimiento del sistema de referencia. Pero acabamos de ver que esta suposición es incompatible con la definición más natural de simultaneidad; si descartamos esta suposición, entonces el conflicto entre la ley de la propagación de la luz en el vacío y el principio de relatividad (desarrollado en la Sección VII) desaparece.",
+      "output_hash": "sha256:5e8920ebceed0601360aa65637013b300262e15a8615326559ecc4937a7b036c",
+      "translation_latency_ms": 3111,
+      "scores": {
+        "accuracy": 9.0,
+        "fluency": 9.0,
+        "style": 8.5,
+        "overall": 8.5,
+        "feedback": "Excellent technical Spanish; established physics terminology ('en el vacío', 'simultaneidad', 'principio de relatividad'); conditional argument preserved cleanly."
+      }
+    },
+    {
+      "text_id": "emerson_self_reliance",
+      "source_lang": "en",
+      "target_lang": "es",
+      "output": "Confía en ti mismo: todo corazón vibra con esa cuerda de hierro. Acepta el lugar que la divina providencia te ha asignado, la sociedad de tus contemporáneos, la conexión de los acontecimientos. Los grandes hombres siempre lo han hecho, y se han confiado infantilmente al genio de su época, traicionando su percepción de que lo absolutamente confiable residía en su corazón, obrando a través de sus manos, predominando en todo su ser.",
+      "output_hash": "sha256:7ccb7c09ad1705b23e066e64512f43cf16596c733bfe3e793541856bf0b302af",
+      "translation_latency_ms": 2752,
+      "scores": {
+        "accuracy": 9.0,
+        "fluency": 8.5,
+        "style": 7.5,
+        "overall": 7.5,
+        "feedback": "Modern Spanish that captures Emerson's argument; archaic 'thyself' register is flattened to 'Confía en ti'. 'Cuerda de hierro' is a literal calque. (-1.0 style, -0.3 fluency)"
+      }
+    },
+    {
+      "text_id": "moby_dick",
+      "source_lang": "en",
+      "target_lang": "es",
+      "output": "Llámame Ismael. Hace algunos años—no importa con exactitud cuánto tiempo—sin apenas dinero en el bolsillo y sin nada en particular que me interesara en tierra firme, pensé en navegar un poco y ver la parte acuática del mundo. Es una forma que tengo de combatir la melancolía y regular la circulación. Cada vez que me encuentro con el rostro sombrío; cada vez que es un noviembre húmedo y lloviznoso en mi alma, considero que es hora de zarpar lo antes posible.",
+      "output_hash": "sha256:ef822f079c1b869f019819400764b9be26aab8c8d69d8ce389b49936d040d4f9",
+      "translation_latency_ms": 2963,
+      "scores": {
+        "accuracy": 9.0,
+        "fluency": 9.0,
+        "style": 8.0,
+        "overall": 8.0,
+        "feedback": "Canonical Spanish 'Llámame Ismael' opener; 'rostro sombrío' weakens the specific 'growing grim about the mouth' image. (-0.5 style)"
+      }
+    },
+    {
+      "text_id": "origin_species",
+      "source_lang": "en",
+      "target_lang": "es",
+      "output": "Este Resumen, que ahora publico, debe ser necesariamente imperfecto. No puedo incluir aquí referencias y fuentes para mis diversas afirmaciones, y debo confiar en que el lector deposite cierta confianza en mi precisión. Sin duda, se habrán colado errores, aunque espero haber sido siempre cauteloso al basarme únicamente en fuentes fiables. Aquí solo puedo ofrecer las conclusiones generales a las que he llegado, con algunos hechos ilustrativos que, espero, serán suficientes en la mayoría de los casos.",
+      "output_hash": "sha256:8dcf3de606ae5055faadcabe83d5a32e23a4d9e07abbf524717f52bef5bdab54",
+      "translation_latency_ms": 2874,
+      "scores": {
+        "accuracy": 9.0,
+        "fluency": 9.0,
+        "style": 8.0,
+        "overall": 8.0,
+        "feedback": "Faithful Spanish rendering of Darwin's hedged stance; reads as natural academic Spanish, no notable losses."
+      }
+    },
+    {
+      "text_id": "pride_prejudice",
+      "source_lang": "en",
+      "target_lang": "es",
+      "output": "Es una verdad universalmente reconocida que un hombre soltero con una buena fortuna debe necesitar una esposa. Por poco que se conozcan los sentimientos o las intenciones de un hombre al entrar por primera vez en un vecindario, esta verdad está tan arraigada en las mentes de las familias circundantes, que lo consideran la propiedad legítima de una de sus hijas.",
+      "output_hash": "sha256:bb2dacbbc59fee4f535e01e146d8f7270cd95dad926f64d0ae3ccded6fcb56b0",
+      "translation_latency_ms": 2240,
+      "scores": {
+        "accuracy": 9.0,
+        "fluency": 9.0,
+        "style": 8.5,
+        "overall": 8.5,
+        "feedback": "Preserves Austen's 'Es una verdad universalmente reconocida' framing (canonical Spanish opener); ironic register intact. The strongest Pride and Prejudice rendering of the four."
+      }
+    },
+    {
+      "text_id": "study_scarlet",
+      "source_lang": "en",
+      "target_lang": "es",
+      "output": "—Parece que ha estado en Afganistán.\n—¿Cómo demonios lo supo? —pregunté, asombrado.\n—No importa —dijo, riendo entre dientes—. La cuestión ahora es sobre la hemoglobina. ¿No duda de la importancia de este descubrimiento mío?\n—Es interesante, químicamente, sin duda —respondí—, pero en la práctica…\n—Hombre, es el descubrimiento médico-legal más práctico de los últimos años. ¿No ve que nos proporciona una prueba infalible para las manchas de sangre?",
+      "output_hash": "sha256:35e76f3e6e7564cd3caf18e2068fbd63c7a57279358aa8f9d90ae1b996a33cd3",
+      "translation_latency_ms": 3167,
+      "scores": {
+        "accuracy": 8.0,
+        "fluency": 9.0,
+        "style": 8.5,
+        "overall": 7.5,
+        "feedback": "Smooth Spanish dialogue with proper dash convention, but mistranslates 'No doubt you see' as '¿No duda de la importancia?', reversing the rhetorical question. (-1.0 accuracy)"
+      }
+    },
+    {
+      "text_id": "twain_innocents",
+      "source_lang": "en",
+      "target_lang": "es",
+      "output": "Me parece que cada vez que me deleito pensando haber descubierto un cuadro antiguo que es bello y digno de todo elogio, el placer que me proporciona es una prueba infalible de que no es una buena pintura y en absoluto merece ser alabada. Esto mismo me ha ocurrido más veces de las que puedo contar, en Venecia. En cada ocasión, el guía ha destrozado mi creciente entusiasmo con el comentario: “No es nada, es del Renacimiento”.",
+      "output_hash": "sha256:df7ef03737119bceb6a73a4a8c7bc57f0149d5c1de53c0127799ab32f2a19c2a",
+      "translation_latency_ms": 2676,
+      "scores": {
+        "accuracy": 9.0,
+        "fluency": 9.0,
+        "style": 8.0,
+        "overall": 8.0,
+        "feedback": "Captures Twain's deflationary irony cleanly in idiomatic Spanish; faithful rendering throughout."
+      }
+    },
+    {
+      "text_id": "walden",
+      "source_lang": "en",
+      "target_lang": "es",
+      "output": "Fui al bosque porque deseaba vivir deliberadamente, encarar solo los hechos esenciales de la vida y ver si podía aprender lo que tenía que enseñarme, y no, cuando llegara mi hora, descubrir que no había vivido. No quería vivir una vida que no fuera vida; vivir es tan precioso. Tampoco quería practicar la resignación, a menos que fuera estrictamente necesario. Quería vivir profundamente y extraer hasta la médula de la vida.",
+      "output_hash": "sha256:da122d004a89da0704e6c9ed4af6b0d12043afa83e0e9a3fd2fd2a74327874bb",
+      "translation_latency_ms": 2648,
+      "scores": {
+        "accuracy": 9.0,
+        "fluency": 9.0,
+        "style": 8.5,
+        "overall": 8.5,
+        "feedback": "Excellent: bone-marrow metaphor preserved as 'extraer hasta la médula'; contemplative tone intact; 'No quería vivir una vida que no fuera vida' captures Thoreau's tautology."
+      }
+    },
+    {
+      "text_id": "aurelius_meditations",
+      "source_lang": "en",
+      "target_lang": "fr",
+      "output": "Âme, agis ainsi, rabaisse-toi et méprise-toi ; mais sache qu'il adviendra un temps où tu ne pourras plus te respecter. Le bonheur de chacun dépend de lui-même, et pourtant vois comme ta vie touche à sa fin, alors que tu ne te donnes aucun respect, faisant reposer ton bonheur sur l’avis et les pensées d’autrui. Pourquoi ces événements extérieurs devraient-ils te troubler à ce point ? Accorde-toi du temps pour apprendre quelque chose de bien et cesse de courir et de vagabonder sans but.",
+      "output_hash": "sha256:280364d58a56329ddd33dc2f175dc550b8900d96bdc99756dc7ea3cf3886de59",
+      "translation_latency_ms": 3440,
+      "scores": {
+        "accuracy": 8.5,
+        "fluency": 9.0,
+        "style": 7.5,
+        "overall": 7.5,
+        "feedback": "'Le temps...sera fini' shifts the deadline to an inability ('tu ne pourras plus te respecter'); Stoic French register reasonable. (-0.5 accuracy, -0.5 style)"
+      }
+    },
+    {
+      "text_id": "dorian_gray",
+      "source_lang": "en",
+      "target_lang": "fr",
+      "output": "L'atelier était empli du riche parfum des roses, et lorsque la légère brise d'été s'agitait parmi les arbres du jardin, une lourde senteur de lilas, ou le parfum plus délicat de l'églantine rose, parvenait par la porte ouverte. Du coin du divan recouvert de sacs à dos persans sur lequel il était allongé, fumant d'innombrables cigarettes comme à son habitude, Lord Henry Wotton pouvait apercevoir le scintillement des fleurs miel-sucrées et miel-colorées d'un laburnum.",
+      "output_hash": "sha256:0e5be67cbd8ba77a1c044661657448bc16f46a1471789d47e1403040f0d75352",
+      "translation_latency_ms": 3285,
+      "scores": {
+        "accuracy": 7.0,
+        "fluency": 8.0,
+        "style": 7.5,
+        "overall": 7.0,
+        "feedback": "Multiple botanical/material errors: saddle-bags → 'sacs à dos persans' (= backpacks; should be 'sacoches de selle'), laburnum left untranslated (FR = 'cytise'), 'miel-sucrées' awkward compound. (-2.5 accuracy, -0.5 fluency)"
+      }
+    },
+    {
+      "text_id": "einstein_relativity",
+      "source_lang": "en",
+      "target_lang": "fr",
+      "output": "Or, avant l’avènement de la théorie de la relativité, on avait toujours tacitement supposé en physique que l’énoncé du temps avait une signification absolue, c’est-à-dire qu’il était indépendant de l’état de mouvement du référentiel. Mais nous venons de voir que cette supposition est incompatible avec la définition la plus naturelle de la simultanéité ; si nous abandonnons cette supposition, le conflit entre la loi de la propagation de la lumière dans le vide et le principe de relativité (développé au paragraphe VII) disparaît.",
+      "output_hash": "sha256:b6dfc7b0ceb0d6d5fe22a4b75e7736c41fb2fd68ee378249c2a54a8f771b6044",
+      "translation_latency_ms": 3205,
+      "scores": {
+        "accuracy": 9.0,
+        "fluency": 9.0,
+        "style": 8.5,
+        "overall": 8.5,
+        "feedback": "Excellent technical French; 'paragraphe VII' for 'Section VII' is a minor convention choice but acceptable in French academic writing."
+      }
+    },
+    {
+      "text_id": "emerson_self_reliance",
+      "source_lang": "en",
+      "target_lang": "fr",
+      "output": "Aie confiance en toi : chaque cœur vibre à cette corde de fer. Accepte la place que la divine Providence t’a réservée, la société de tes contemporains, le concours des événements. Les grands hommes ont toujours agi ainsi, se confiant, comme des enfants, au génie de leur époque, trahissant la conviction que le véritable guide était en leur cœur, agissant par leurs mains, dominant toute leur existence.",
+      "output_hash": "sha256:f70500cfd5ba1dff774b892171afd9e92a7e896dd84ffae82997468f6c4f55f7",
+      "translation_latency_ms": 2578,
+      "scores": {
+        "accuracy": 8.7,
+        "fluency": 9.0,
+        "style": 8.5,
+        "overall": 8.0,
+        "feedback": "Elegant French; 'le concours des événements' is felicitous. 'Le véritable guide' is a slight gloss for 'the absolutely trustworthy'. (-0.3 accuracy)"
+      }
+    },
+    {
+      "text_id": "moby_dick",
+      "source_lang": "en",
+      "target_lang": "fr",
+      "output": "Appelez-moi Ismaël. Il y a quelques années – peu importe précisément combien – n’ayant guère d’argent en poche et rien de particulièrement intéressant à me retenir sur terre, je me suis dit que j’irais naviguer un peu et découvrir la partie liquide du monde. C’est une façon que j’ai de chasser la mélancolie et de réguler ma circulation sanguine. Dès que je sens ma bouche s’assombrir, dès que novembre humide et pluvieux s’installe dans mon âme, je considère qu’il est grand temps de prendre la mer le plus tôt possible.",
+      "output_hash": "sha256:1bdbcac2a625cb4018ed311c094017a43eb38b3d3a5b81b24bc461222c6f23d4",
+      "translation_latency_ms": 3476,
+      "scores": {
+        "accuracy": 9.0,
+        "fluency": 9.0,
+        "style": 8.5,
+        "overall": 8.5,
+        "feedback": "Canonical French 'Appelez-moi Ismaël' opener; faithful rendering of physiognomic and mood imagery, mid-19th-c maritime register preserved."
+      }
+    },
+    {
+      "text_id": "origin_species",
+      "source_lang": "en",
+      "target_lang": "fr",
+      "output": "Cet Abrégé, que je publie aujourd’hui, sera forcément imparfait. Je ne peux ici fournir de références ni citer les sources de mes affirmations, et je dois compter sur la confiance du lecteur quant à mon exactitude. Il est certain que des erreurs s’y seront glissées, bien que j’espère avoir toujours fait preuve de prudence en ne me fiant qu’à des sources fiables. Je ne peux ici présenter que les conclusions générales auxquelles je suis parvenu, accompagnées de quelques faits à titre d’illustration, mais qui, je l’espère, suffiront dans la plupart des cas.",
+      "output_hash": "sha256:fdbacfa3b079888b3d90016504c63031219d78c6d5f4f3430b72788e3a4148b2",
+      "translation_latency_ms": 3385,
+      "scores": {
+        "accuracy": 9.0,
+        "fluency": 9.0,
+        "style": 8.5,
+        "overall": 8.0,
+        "feedback": "Period-appropriate scientific French ('Cet Abrégé', 'sera forcément imparfait'); Darwin's hedging fully preserved."
+      }
+    },
+    {
+      "text_id": "pride_prejudice",
+      "source_lang": "en",
+      "target_lang": "fr",
+      "output": "Il est généralement admis qu'un homme célibataire fortuné doit avoir besoin d'une épouse. Peu importe à quel point on peut ignorer les sentiments ou les intentions d'un tel homme lorsqu'il arrive dans un nouveau voisinage, cette vérité est si solidement ancrée dans l'esprit des familles alentour qu'il est considéré comme la propriété légitime de l'une de leurs filles.",
+      "output_hash": "sha256:5007c6ba14a8c540301c7da28b944ec8b14d3f5a0ba6470c07d64a267f003dc5",
+      "translation_latency_ms": 2476,
+      "scores": {
+        "accuracy": 9.0,
+        "fluency": 9.0,
+        "style": 7.0,
+        "overall": 7.5,
+        "feedback": "'Généralement admis' is significantly weaker than 'universally acknowledged'; loses Austen's mock-universal framing that drives the chapter. (-1.0 style)"
+      }
+    },
+    {
+      "text_id": "study_scarlet",
+      "source_lang": "en",
+      "target_lang": "fr",
+      "output": "« Vous avez donc été en Afghanistan, je crois comprendre. » « Mais comment diable avez-vous découvert ça ? » demandai-je, stupéfait. « Peu importe, » répondit-il en riant pour lui-même. « La question est maintenant de savoir en est-on à l'hémoglobine. N'êtes-vous pas conscient de l'importance de cette découverte ? » « C'est intéressant, chimiquement, sans aucun doute, » répondis-je, « mais en pratique— » « Allons, mon ami, c'est la découverte médico-légale la plus pratique depuis des années. Ne voyez-vous pas qu'elle nous fournit un test infaillible pour les taches de sang ? »",
+      "output_hash": "sha256:ddfe6d236e5b5b51969271252760d573141b92fae496656bc21bd094e7a626e0",
+      "translation_latency_ms": 4030,
+      "scores": {
+        "accuracy": 8.5,
+        "fluency": 7.5,
+        "style": 8.0,
+        "overall": 7.0,
+        "feedback": "Period-appropriate French dialogue, but contains a broken sentence: 'La question est maintenant de savoir en est-on à l'hémoglobine'. (-1.5 fluency grammar)"
+      }
+    },
+    {
+      "text_id": "twain_innocents",
+      "source_lang": "en",
+      "target_lang": "fr",
+      "output": "Il me semble que chaque fois que je me réjouis de penser avoir découvert une peinture ancienne, belle et digne de tous les éloges, le plaisir qu’elle me procure est la preuve infaillible qu’elle n’est pas une belle toile et n’est en rien digne de commendation. Il m’est arrivé plus de fois que je ne saurais le dire, à Venise, que le guide vienne briser mon enthousiasme grandissant avec cette remarque : « Ce n’est rien, c’est de la Renaissance. »",
+      "output_hash": "sha256:94be6ac00f4395131b4207dfec9705fcb032afec2b9ee1afcbb35455874c0368",
+      "translation_latency_ms": 3186,
+      "scores": {
+        "accuracy": 9.0,
+        "fluency": 8.5,
+        "style": 8.0,
+        "overall": 7.5,
+        "feedback": "Captures Twain's irony but 'commendation' is an English anglicism (FR: 'éloges' / 'louanges'). (-0.5 fluency)"
+      }
+    },
+    {
+      "text_id": "walden",
+      "source_lang": "en",
+      "target_lang": "fr",
+      "output": "Je suis allé dans les bois parce que je voulais vivre délibérément, ne faire face qu’aux faits essentiels de la vie, et voir si je ne pouvais pas apprendre ce qu’elle avait à m’enseigner, afin de ne pas découvrir, au moment de mourir, que je n’avais pas vécu. Je ne voulais pas vivre une vie sans en être, car vivre est si précieux ; ni me résigner, à moins que cela ne soit absolument nécessaire. Je voulais vivre pleinement et extraire toute la moelle de la vie.",
+      "output_hash": "sha256:3288fd5fa6af207eada5c8050a11ed0a89f40fca8beede360f5ca32656e9f1b0",
+      "translation_latency_ms": 3117,
+      "scores": {
+        "accuracy": 9.0,
+        "fluency": 8.5,
+        "style": 8.5,
+        "overall": 7.5,
+        "feedback": "Faithful contemplative French; 'vivre une vie sans en être' is awkward as a rendering of 'live what was not life'. (-0.5 fluency)"
+      }
+    },
+    {
+      "text_id": "aurelius_meditations",
+      "source_lang": "en",
+      "target_lang": "vi",
+      "output": "Linh hồn ơi, hãy cứ hành hạ và khinh miệt bản thân đi; nhưng hãy nhớ rằng, thời gian để ngươi tự trọng sắp kết thúc rồi. Hạnh phúc của mỗi người phụ thuộc vào chính mình, vậy mà ngươi lại gần hết đời mà vẫn không tự trọng, cứ tìm kiếm niềm vui nơi ý kiến và suy nghĩ của người khác. Tại sao những chuyện xảy ra bên ngoài lại khiến ngươi xao xuyến đến thế? Hãy cho bản thân chút thời gian để học hỏi điều tốt đẹp, và ngừng rong ruổi, đi lại vô ích.",
+      "output_hash": "sha256:585903356a44c29a4fe16a753cc8cc770c9593d722c0e5ecc08fda93878d7cfa",
+      "translation_latency_ms": 3346,
+      "scores": {
+        "accuracy": 8.7,
+        "fluency": 9.0,
+        "style": 8.0,
+        "overall": 7.5,
+        "feedback": "Captures Stoic imperative tone with archaic 'ngươi'; minor semantic compression on 'affording thyself no respect'. (-0.3 accuracy)"
+      }
+    },
+    {
+      "text_id": "dorian_gray",
+      "source_lang": "en",
+      "target_lang": "vi",
+      "output": "Căn phòng tràn ngập hương thơm đậm đà của hoa hồng, và mỗi khi gió mùa hè nhẹ thoảng qua những hàng cây trong vườn, mùi hoa tử đằng nồng nàn hoặc hương thơm tinh tế của cây gai dại nở hoa hồng lại lan tỏa qua cánh cửa mở. Từ góc chiếc ghế dài bọc túi da ngựa Ba Tư nơi anh đang nằm, hút vô số điếu thuốc lá như thường lệ, Lord Henry Wotton có thể thoáng thấy ánh vàng óng ả của những bông hoa cây chanh vàng mật ngọt.",
+      "output_hash": "sha256:a07fbf3905f939569a519e111490dc6d8ef1be1a80a223a12f01464fb7b43e8b",
+      "translation_latency_ms": 3111,
+      "scores": {
+        "accuracy": 7.5,
+        "fluency": 9.0,
+        "style": 7.5,
+        "overall": 7.0,
+        "feedback": "Botanical errors: lilac → 'tử đằng' (wisteria, wrong species), laburnum → 'cây chanh vàng' (lemon tree, wrong species). Sensory atmosphere preserved overall. (-2.5 accuracy)"
+      }
+    },
+    {
+      "text_id": "einstein_relativity",
+      "source_lang": "en",
+      "target_lang": "vi",
+      "output": "Trước khi có thuyết tương đối, người ta thường ngầm định trong vật lý rằng việc đo thời gian có ý nghĩa tuyệt đối, tức là không phụ thuộc vào trạng thái chuyển động của hệ quy chiếu. Nhưng chúng ta vừa thấy rằng giả định này không tương thích với định nghĩa tự nhiên nhất về tính đồng thời; nếu chúng ta loại bỏ giả định này, thì mâu thuẫn giữa định luật truyền ánh sáng trong chân không và nguyên lý tương đối (được trình bày ở Mục VII) sẽ biến mất.",
+      "output_hash": "sha256:50c4ca834e60a074782fbd6181b1ba179bb76af61e8715437877106cd745c544",
+      "translation_latency_ms": 2873,
+      "scores": {
+        "accuracy": 8.7,
+        "fluency": 9.0,
+        "style": 8.5,
+        "overall": 8.0,
+        "feedback": "Strong technical Vietnamese with established physics terminology; 'việc đo thời gian' slightly shifts 'statement of time' to 'measurement of time'. (-0.3 accuracy)"
+      }
+    },
+    {
+      "text_id": "emerson_self_reliance",
+      "source_lang": "en",
+      "target_lang": "vi",
+      "output": "Hãy tin vào chính mình: mỗi trái tim đều rung động theo sợi dây sắt ấy. Hãy chấp nhận vị trí mà Thượng đế đã sắp đặt cho bạn, xã hội của những người cùng thời, sự kết nối của các sự kiện. Những người vĩ đại luôn làm như vậy, và phó mặc bản thân một cách hồn nhiên cho thiên tài của thời đại, thể hiện nhận thức sâu sắc rằng điều tuyệt đối đáng tin cậy ngự trị trong trái tim họ, vận hành qua đôi tay, thống trị toàn bộ con người họ.",
+      "output_hash": "sha256:2ea7aa7658fc853090a73bbbe2278215af135ec4a443860ce2e4467c2faa90d4",
+      "translation_latency_ms": 3048,
+      "scores": {
+        "accuracy": 8.7,
+        "fluency": 9.0,
+        "style": 8.5,
+        "overall": 8.0,
+        "feedback": "Clean Vietnamese; 'phó mặc' for 'confided childlike' is idiomatic. 'Thượng đế' substitutes for 'divine providence' (acceptable but flattens). (-0.3 accuracy)"
+      }
+    },
+    {
+      "text_id": "moby_dick",
+      "source_lang": "en",
+      "target_lang": "vi",
+      "output": "Hãy gọi tôi là Ishmael. Cách đây vài năm—không cần phải nhớ chính xác là bao lâu—khi hầu bao tôi trống rỗng, và không có việc gì đặc biệt trên bờ để khiến tôi bận tâm, tôi nghĩ bụng sẽ đi biển một chút, để xem phần thế giới đầy nước này. Đó là một cách tôi thường dùng để xua tan sự u sầu và điều hòa khí huyết. Bất cứ khi nào tôi thấy bản thân trở nên cộc cằn, khi trong tâm hồn tôi là một tháng Mười ẩm ướt và mưa rả rích, tôi coi đó là dấu hiệu cho thấy đã đến lúc phải ra khơi càng sớm càng tốt.",
+      "output_hash": "sha256:befd89f524ba03f41126602e849ad1c0f7d8b2fad326e6790de8600d06d886c5",
+      "translation_latency_ms": 3736,
+      "scores": {
+        "accuracy": 8.5,
+        "fluency": 9.0,
+        "style": 8.5,
+        "overall": 7.5,
+        "feedback": "Strong Vietnamese with idiomatic 'điều hòa khí huyết'; mistranslates 'November' as 'tháng Mười' (October) instead of 'tháng Mười Một' — a factual error. (-1.5 accuracy)"
+      }
+    },
+    {
+      "text_id": "origin_species",
+      "source_lang": "en",
+      "target_lang": "vi",
+      "output": "Tóm tắt này, mà tôi xin công bố, chắc chắn sẽ còn nhiều thiếu sót. Tôi không thể trích dẫn các nguồn tham khảo và tài liệu cho những tuyên bố của mình ở đây; và tôi chỉ có thể tin tưởng vào sự tin cậy của độc giả đối với độ chính xác của tôi. Chắc chắn sẽ có những sai sót, dù tôi hy vọng mình luôn thận trọng trong việc chỉ dựa vào những nguồn đáng tin cậy. Tôi chỉ có thể trình bày những kết luận chung mà tôi đã đạt được, cùng với một vài sự kiện minh họa, nhưng tôi hy vọng trong hầu hết các trường hợp, chúng sẽ đủ.",
+      "output_hash": "sha256:b988cc971ac9b5b186138049f2cb469692c5651607c65f95d704beb31f01c880",
+      "translation_latency_ms": 3554,
+      "scores": {
+        "accuracy": 9.0,
+        "fluency": 9.0,
+        "style": 8.0,
+        "overall": 8.0,
+        "feedback": "Faithful Vietnamese rendering of Darwin's hedged scientific stance; clean academic register."
+      }
+    },
+    {
+      "text_id": "pride_prejudice",
+      "source_lang": "en",
+      "target_lang": "vi",
+      "output": "Người ta thường nói, một người đàn ông độc thân có gia tài kha khá chắc chắn phải cần một người vợ. Dù cảm xúc hay suy nghĩ của người đàn ông đó khi mới chuyển đến một vùng đất có thể chưa được ai biết đến, sự thật này đã ăn sâu vào tâm trí của những gia đình xung quanh, đến nỗi họ coi anh ta như tài sản thuộc về một trong những cô con gái của mình.",
+      "output_hash": "sha256:3a2ad1277f4ba73364c388df9db5913ac070d0218b5d33ab9514ad93b7d21c79",
+      "translation_latency_ms": 2505,
+      "scores": {
+        "accuracy": 8.5,
+        "fluency": 9.0,
+        "style": 7.0,
+        "overall": 7.5,
+        "feedback": "Natural Vietnamese, but 'Người ta thường nói' (people often say) flattens the universal-truth opener that drives Austen's irony. (-1.0 style)"
+      }
+    },
+    {
+      "text_id": "study_scarlet",
+      "source_lang": "en",
+      "target_lang": "vi",
+      "output": "“Anh đã từng ở Afghanistan, tôi đoán vậy.” “Trên đời này anh biết chuyện đó từ đâu?” Tôi hỏi với vẻ kinh ngạc. “Không sao,” ông ta đáp, cười khẽ một mình. “Vấn đề bây giờ là về hemoglobin. Anh chắc hẳn thấy ý nghĩa của khám phá này của tôi chứ?” “Nó thú vị, xét về mặt hóa học, không nghi ngờ gì,” tôi trả lời, “nhưng về mặt thực tiễn—” “Ôi, anh bạn, đây là một khám phá y pháp thực tế nhất trong nhiều năm qua. Anh không thấy rằng nó cho chúng ta một xét nghiệm không thể sai sót để phát hiện vết máu sao?”",
+      "output_hash": "sha256:d52dfff2c8f65e62b5443283db5f9827c64eb08d68651df7f8375f0da40c45b3",
+      "translation_latency_ms": 3764,
+      "scores": {
+        "accuracy": 8.7,
+        "fluency": 8.5,
+        "style": 8.0,
+        "overall": 7.5,
+        "feedback": "'Tôi đoán' weakens 'I perceive'; pronoun shifts between 'ông ta' and 'anh bạn' for the same speaker. (-0.3 acc, -0.5 fluency)"
+      }
+    },
+    {
+      "text_id": "twain_innocents",
+      "source_lang": "en",
+      "target_lang": "vi",
+      "output": "Tôi nhận thấy rằng mỗi khi tôi tự hào nghĩ rằng mình đã khám phá ra một bức tranh cổ đẹp đẽ và xứng đáng được ca ngợi, thì niềm vui mà nó mang lại chính là bằng chứng không thể chối cãi rằng đó không phải là một bức tranh đẹp và hoàn toàn không đáng được khen ngợi. Điều này đã xảy ra nhiều lần đến mức tôi không thể kể hết, đặc biệt là ở Venice. Trong mỗi trường hợp, người hướng dẫn đều dập tắt sự hưng phấn đang lớn dần của tôi bằng câu nói: “Chẳng là gì cả – nó thuộc thời Phục hưng mà thôi.”",
+      "output_hash": "sha256:efe878229d0146ca5f1fb37d16d29e2284797ac8ffaad7e683b617a967732200",
+      "translation_latency_ms": 3479,
+      "scores": {
+        "accuracy": 9.0,
+        "fluency": 9.0,
+        "style": 8.5,
+        "overall": 8.5,
+        "feedback": "Excellent Vietnamese rendering of Twain's deflationary irony; 'mà thôi' adds an idiomatic Vietnamese closing particle that captures the dismissive tone."
+      }
+    },
+    {
+      "text_id": "walden",
+      "source_lang": "en",
+      "target_lang": "vi",
+      "output": "Tôi vào rừng vì tôi muốn sống một cuộc đời có ý thức, đối diện với những sự thật cốt yếu của cuộc sống, và xem liệu tôi có thể học hỏi được điều gì từ nó không, để rồi khi đến lúc nhắm mắt xuôi tay, tôi không phát hiện ra rằng mình đã không thực sự sống. Tôi không muốn sống một cuộc đời vô nghĩa, bởi lẽ sống là một điều quý giá; cũng không muốn cam chịu số phận, trừ khi thực sự cần thiết. Tôi muốn sống trọn vẹn và hút cạn tất cả tinh túy của cuộc đời.",
+      "output_hash": "sha256:e26de22ce335c16eac76c769004a20023f097bab7c7864e90265062067fa803b",
+      "translation_latency_ms": 3192,
+      "scores": {
+        "accuracy": 8.5,
+        "fluency": 9.0,
+        "style": 8.0,
+        "overall": 7.5,
+        "feedback": "Idiomatic Vietnamese with 'nhắm mắt xuôi tay' for the deathbed image; 'tinh túy' (essence) abstracts Thoreau's bone-marrow physical metaphor. (-0.3 acc, -0.5 style)"
+      }
+    },
+    {
+      "text_id": "kokoro",
+      "source_lang": "en",
+      "target_lang": "zh-Hans",
+      "output": "我一直称呼那个人为老师。因此，在这里也只是写“老师”，并不提及他的真名。这并非出于顾忌世俗的谨慎，而是因为对我来说，这样更自然。每当我回忆起他，总忍不住想说“老师”。即使提笔写作，也同样如此。我实在没有使用疏远的姓氏或头衔的意愿。",
+      "output_hash": "sha256:c6d72e34bff15b9fdee7ebbda062703479870e2cb0e4a81f14b07a7351276ec6",
+      "translation_latency_ms": 2507,
+      "scores": {
+        "accuracy": 8.0,
+        "fluency": 9.0,
+        "style": 8.5,
+        "overall": 7.5,
+        "feedback": "Smooth Sōseki rendering with proper '老师' as common-noun-as-address; mistranslates 頭文字 (initials) as '姓氏或头衔' (surname or title). (-1.0 accuracy)"
+      }
+    },
+    {
+      "text_id": "kokoro",
+      "source_lang": "en",
+      "target_lang": "en",
+      "output": "I always referred to that person as \"Sensei,\" and so I will simply write \"Sensei\" here without revealing their given name. This isn't so much out of a desire to avoid public attention as it is simply more natural for me. Every time I recall that person, I immediately want to say \"Sensei.\" The feeling is the same even when I pick up a pen. I have absolutely no inclination to use distant or formal initials.",
+      "output_hash": "sha256:7d4178987f2ff3e7ce1bf2a1dbd13e0e2ccda305803f85e43d32902294b1be7b",
+      "translation_latency_ms": 7380,
+      "scores": {
+        "accuracy": 9.0,
+        "fluency": 9.0,
+        "style": 8.5,
+        "overall": 8.5,
+        "feedback": "Strong literary rendering: correctly preserves 'Sensei' as romanized cultural term; handles 頭文字 properly as 'initials'. Reads as natural English literary prose."
+      }
+    },
+    {
+      "text_id": "unsu_jouen_nal",
+      "source_lang": "en",
+      "target_lang": "en",
+      "output": "The sullen, overcast sky threatened snow, but instead, a drizzling rain began to fall.\n\nFor Kim Cheomji, who worked as a rickshaw puller in the Jongno district, this day was a stroke of good luck he hadn’t seen in ages. It started with taking the lady from the neighboring house—though it wasn’t exactly *into* her grounds, but just outside—to the trolley stop. From there, he lingered at the station, almost begging with his eyes, watching each person disembark, hoping for a fare. Finally, he agreed to give a ride to someone who looked like a teacher, taking him to Donggwang School.\n\nThirty jeon for the first ride, fifty jeon for the second—a rare occurrence so early in the morning. Kim Cheomji, who hadn't seen a coin in nearly ten days, was almost moved to tears when the sound of ten-jeon coins jingling into his palm—three or five at a time—filled his hand.",
+      "output_hash": "sha256:04caa42ffe03bf5430fe32c6a05d5a94919ff946f9fbdf1999e0f3e29352ab10",
+      "translation_latency_ms": 5352,
+      "scores": {
+        "accuracy": 6.5,
+        "fluency": 9.0,
+        "style": 8.0,
+        "overall": 6.5,
+        "feedback": "Hallucinates 'Jongno district' for 동소문 (Dongsomun, East Small Gate); misreads '문안에(거기도 문밖은 아니지만)' as a possessive 'her grounds' instead of city-gate liminality. (-2.0 acc hallucination, -1.0 acc misreading, -0.5 style period detail)"
+      }
+    },
+    {
+      "text_id": "hu_shi_reform",
+      "source_lang": "en",
+      "target_lang": "en",
+      "output": "Today, there are many who discuss literary reform, but as a humble and unlearned student, I hardly feel qualified to speak on the matter. However, in recent years I have repeatedly researched this topic, supplementing my thoughts with discussions with friends and colleagues. The result of these efforts, I believe, holds some value for discussion. Therefore, I have summarized my views into eight points, which I will now present individually, for the consideration of those who are also concerned with literary reform. I believe that, for the sake of literary reform today, we must begin with these eight points. What are these eight points? First, one must have something to say. Second, avoid simply imitating the ancients. Third, one must pay attention to grammar. Fourth, avoid empty, affected lamentations. Fifth, strive to avoid clichés and stock phrases. Sixth, refrain from using allusions. Seventh, do not focus on parallelism. And eighth, do not shy away from colloquial words and expressions.",
+      "output_hash": "sha256:5d23e178693c1fa6cc1403df64acd164245d6978ec1af52d2cf3c6732b040fe3",
+      "translation_latency_ms": 5254,
+      "scores": {
+        "accuracy": 8.7,
+        "fluency": 9.0,
+        "style": 8.5,
+        "overall": 8.5,
+        "feedback": "Excellent rendering of Hu Shi's manifesto: captures '言之有物', '不作无病之呻吟', and the enumerative parallelism cleanly. Minor compression on '当世'. (-0.3 accuracy)"
+      }
+    },
+    {
+      "text_id": "lu_xun_guxiang",
+      "source_lang": "en",
+      "target_lang": "en",
+      "output": "I braved the bitter cold and returned to my hometown, over two thousand li distant, after more than twenty years of separation. It was deep winter, and as I neared my hometown, the weather grew gloomy. Cold winds blew into the cabin, whistling mournfully. Peering through the gaps in the canvas, I saw several desolate villages stretching into the distance under a drab, overcast sky—not a sign of life anywhere. My heart couldn't help but fill with sorrow. Is this the hometown I remembered so vividly for the past twenty years? The hometown I recall was far more beautiful. But when I try to remember its beauty, to speak of its charms, I find no images, no words come to mind. It seems to be as it is. So I explained it to myself: my hometown was always like this—though it may not have progressed, it certainly wasn’t as bleak as I felt. This was merely a change in my own mood, for I had returned with no cheerful expectations.",
+      "output_hash": "sha256:838b45c0bb65c59c3857e5a4c57fcea3e0332fe6c716e503c0822b04bc6e18de",
+      "translation_latency_ms": 5101,
+      "scores": {
+        "accuracy": 9.0,
+        "fluency": 9.0,
+        "style": 8.0,
+        "overall": 8.0,
+        "feedback": "Strong Lu Xun rendering, somber return-home mood preserved; '苍黄的天' loses its 'pale-yellow' specificity to bland 'drab', and the '阿！' exclamation particle is dissolved into the rhetorical question. (-0.8 style)"
+      }
+    }
+  ]
+}

--- a/benchmark/data_loader.py
+++ b/benchmark/data_loader.py
@@ -1,0 +1,161 @@
+"""
+Loaders for the split benchmark data layout.
+
+Reads:
+  - `benchmark/data/languages/<code>.yaml`
+  - `benchmark/data/reference_texts/<source_lang>/<id>.yaml`
+
+Falls back to the legacy monolithic YAMLs (`benchmark/languages.yaml`,
+`benchmark/reference_texts.yaml`) when the split layout is absent, so existing
+runs keep working during the migration.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+from .models import Language, LanguageCategory, ReferenceText
+
+
+_CATEGORY_MAP = {
+    "european_major": LanguageCategory.EUROPEAN_MAJOR,
+    "asian": LanguageCategory.ASIAN,
+    "semitic": LanguageCategory.SEMITIC,
+    "cyrillic": LanguageCategory.CYRILLIC,
+    "classical": LanguageCategory.CLASSICAL,
+    "minority": LanguageCategory.MINORITY,
+}
+
+
+def _split_languages_dir(base_dir: Path) -> Path:
+    return base_dir / "data" / "languages"
+
+
+def _split_reference_texts_dir(base_dir: Path) -> Path:
+    return base_dir / "data" / "reference_texts"
+
+
+def load_languages(
+    base_dir: Path,
+    legacy_file: Path,
+) -> dict[str, Language]:
+    """Load languages from the split layout, or the legacy YAML as fallback."""
+    split_dir = _split_languages_dir(base_dir)
+    if split_dir.is_dir():
+        return _load_languages_split(split_dir)
+    if legacy_file.exists():
+        return _load_languages_legacy(legacy_file)
+    raise FileNotFoundError(
+        f"No language data found. Looked in {split_dir} and {legacy_file}."
+    )
+
+
+def load_reference_texts(
+    base_dir: Path,
+    legacy_file: Path,
+) -> dict[str, ReferenceText]:
+    """Load reference texts from the split layout, or the legacy YAML as fallback."""
+    split_dir = _split_reference_texts_dir(base_dir)
+    if split_dir.is_dir():
+        return _load_reference_texts_split(split_dir)
+    if legacy_file.exists():
+        return _load_reference_texts_legacy(legacy_file)
+    raise FileNotFoundError(
+        f"No reference text data found. Looked in {split_dir} and {legacy_file}."
+    )
+
+
+def _iter_yaml_files(directory: Path) -> Iterable[Path]:
+    for path in sorted(directory.rglob("*.yaml")):
+        if path.is_file():
+            yield path
+
+
+def _load_languages_split(directory: Path) -> dict[str, Language]:
+    languages: dict[str, Language] = {}
+    for path in _iter_yaml_files(directory):
+        with path.open("r", encoding="utf-8") as f:
+            entry = yaml.safe_load(f) or {}
+        code = str(entry["code"])
+        category = _CATEGORY_MAP.get(
+            entry.get("category", "european_major"),
+            LanguageCategory.EUROPEAN_MAJOR,
+        )
+        languages[code] = Language(
+            code=code,
+            name=entry["name"],
+            category=category,
+            native_name=entry.get("native_name", entry["name"]),
+            is_rtl=bool(entry.get("rtl", False)),
+            script=entry.get("script", "Latin"),
+        )
+    return languages
+
+
+def _load_languages_legacy(yaml_path: Path) -> dict[str, Language]:
+    with yaml_path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+
+    languages: dict[str, Language] = {}
+    for cat_key, cat_data in (data.get("categories") or {}).items():
+        category = _CATEGORY_MAP.get(cat_key, LanguageCategory.EUROPEAN_MAJOR)
+        for lang in cat_data.get("languages", []):
+            code = str(lang["code"])
+            languages[code] = Language(
+                code=code,
+                name=lang["name"],
+                category=category,
+                native_name=lang.get("native_name", lang["name"]),
+                is_rtl=bool(lang.get("rtl", False)),
+                script=lang.get("script", "Latin"),
+            )
+    return languages
+
+
+def _load_reference_texts_split(directory: Path) -> dict[str, ReferenceText]:
+    texts: dict[str, ReferenceText] = {}
+    for path in _iter_yaml_files(directory):
+        with path.open("r", encoding="utf-8") as f:
+            entry = yaml.safe_load(f) or {}
+        text_id = entry["id"]
+        texts[text_id] = ReferenceText(
+            id=text_id,
+            title=entry["title"],
+            author=entry.get("author", "Unknown"),
+            year=int(entry.get("year") or 0),
+            content=str(entry["text"]).strip(),
+            style=entry.get("style", ""),
+            source_language=entry.get("source_language", "en"),
+            challenges=list(entry.get("challenges", [])),
+            license=entry.get("license", "public-domain"),
+        )
+    return texts
+
+
+def _load_reference_texts_legacy(yaml_path: Path) -> dict[str, ReferenceText]:
+    with yaml_path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+
+    texts: dict[str, ReferenceText] = {}
+    for entry in data.get("texts", []):
+        text_id = entry["id"]
+        source = entry.get("source_language", "English")
+        # Normalize legacy "English" -> "en"
+        if isinstance(source, str) and len(source) > 3:
+            source = {"english": "en", "french": "fr"}.get(source.lower(), source.lower()[:2])
+
+        texts[text_id] = ReferenceText(
+            id=text_id,
+            title=entry["title"],
+            author=entry.get("author", "Unknown"),
+            year=int(entry.get("year") or 0),
+            content=str(entry["text"]).strip(),
+            style=entry.get("style", ""),
+            source_language=source,
+            challenges=list(entry.get("challenges", [])),
+            license=entry.get("license", "public-domain"),
+        )
+    return texts

--- a/benchmark/models.py
+++ b/benchmark/models.py
@@ -71,6 +71,9 @@ class ReferenceText:
     year: int              # Publication year
     content: str           # The text excerpt (~500 chars)
     style: str             # Style description (e.g., "Prose narrative, irony")
+    source_language: str = "en"   # ISO code of the source language
+    challenges: list[str] = field(default_factory=list)
+    license: str = "public-domain"
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""
@@ -81,6 +84,9 @@ class ReferenceText:
             "year": self.year,
             "content": self.content,
             "style": self.style,
+            "source_language": self.source_language,
+            "challenges": list(self.challenges),
+            "license": self.license,
         }
 
     @classmethod
@@ -93,6 +99,9 @@ class ReferenceText:
             year=data["year"],
             content=data["content"],
             style=data["style"],
+            source_language=data.get("source_language", "en"),
+            challenges=list(data.get("challenges", [])),
+            license=data.get("license", "public-domain"),
         )
 
 
@@ -162,6 +171,12 @@ class TranslationResult:
     timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
     error: Optional[str] = None   # Error message if failed
 
+    # Aggregation metadata (populated by SubmissionAggregator).
+    # n_obs > 1 means the score is a median across multiple contributors.
+    n_obs: int = 1
+    verified: bool = True         # False for self-reported (local-model) results
+    contributors: list[str] = field(default_factory=list)
+
     @property
     def success(self) -> bool:
         """Check if translation succeeded."""
@@ -179,6 +194,9 @@ class TranslationResult:
             "evaluation_time_ms": self.evaluation_time_ms,
             "timestamp": self.timestamp,
             "error": self.error,
+            "n_obs": self.n_obs,
+            "verified": self.verified,
+            "contributors": list(self.contributors),
         }
 
     @classmethod
@@ -194,6 +212,9 @@ class TranslationResult:
             evaluation_time_ms=data.get("evaluation_time_ms", 0),
             timestamp=data.get("timestamp", datetime.now().isoformat()),
             error=data.get("error"),
+            n_obs=int(data.get("n_obs", 1)),
+            verified=bool(data.get("verified", True)),
+            contributors=list(data.get("contributors", [])),
         )
 
 
@@ -415,4 +436,137 @@ class BenchmarkRun:
     @classmethod
     def from_json(cls, json_str: str) -> "BenchmarkRun":
         """Create from JSON string."""
+        return cls.from_dict(json.loads(json_str))
+
+
+@dataclass
+class SubmissionResult:
+    """A single (text, source_lang, target_lang) result inside a submission."""
+
+    text_id: str
+    source_lang: str
+    target_lang: str
+    output: str
+    output_hash: str
+    scores: EvaluationScores
+    translation_latency_ms: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "text_id": self.text_id,
+            "source_lang": self.source_lang,
+            "target_lang": self.target_lang,
+            "output": self.output,
+            "output_hash": self.output_hash,
+            "translation_latency_ms": self.translation_latency_ms,
+            "scores": self.scores.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SubmissionResult":
+        return cls(
+            text_id=data["text_id"],
+            source_lang=data["source_lang"],
+            target_lang=data["target_lang"],
+            output=data["output"],
+            output_hash=data["output_hash"],
+            translation_latency_ms=data.get("translation_latency_ms", 0),
+            scores=EvaluationScores.from_dict(data["scores"]),
+        )
+
+
+@dataclass
+class Submission:
+    """
+    A community submission of benchmark results.
+
+    Mirrors `benchmark/schemas/submission.schema.json` (schema_version 1.0).
+    """
+
+    schema_version: str
+    submitted_by: str
+    submitted_at: str
+    tbl_version: str
+    prompt_version: str
+    judge_id: str
+    model_provider: str
+    model_id: str
+    results: list[SubmissionResult] = field(default_factory=list)
+
+    judge_seed: Optional[int] = None
+    judge_temperature: Optional[float] = None
+    notes: Optional[str] = None
+    model_context_window: Optional[int] = None
+    model_released_at: Optional[str] = None
+    model_license: Optional[str] = None
+    model_size_b_params: Optional[float] = None
+
+    def to_dict(self) -> dict:
+        env = {
+            "tbl_version": self.tbl_version,
+            "prompt_version": self.prompt_version,
+            "judge_id": self.judge_id,
+        }
+        if self.judge_seed is not None:
+            env["judge_seed"] = self.judge_seed
+        if self.judge_temperature is not None:
+            env["judge_temperature"] = self.judge_temperature
+
+        sub = {
+            "submitted_by": self.submitted_by,
+            "submitted_at": self.submitted_at,
+        }
+        if self.notes:
+            sub["notes"] = self.notes
+
+        model = {
+            "provider": self.model_provider,
+            "id": self.model_id,
+        }
+        if self.model_context_window is not None:
+            model["context_window"] = self.model_context_window
+        if self.model_released_at:
+            model["released_at"] = self.model_released_at
+        if self.model_license:
+            model["license"] = self.model_license
+        if self.model_size_b_params is not None:
+            model["size_b_params"] = self.model_size_b_params
+
+        return {
+            "schema_version": self.schema_version,
+            "submission": sub,
+            "environment": env,
+            "model": model,
+            "results": [r.to_dict() for r in self.results],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Submission":
+        sub = data.get("submission", {})
+        env = data.get("environment", {})
+        model = data.get("model", {})
+        return cls(
+            schema_version=data.get("schema_version", "1.0"),
+            submitted_by=sub.get("submitted_by", ""),
+            submitted_at=sub.get("submitted_at", ""),
+            notes=sub.get("notes"),
+            tbl_version=env.get("tbl_version", ""),
+            prompt_version=env.get("prompt_version", ""),
+            judge_id=env.get("judge_id", ""),
+            judge_seed=env.get("judge_seed"),
+            judge_temperature=env.get("judge_temperature"),
+            model_provider=model.get("provider", ""),
+            model_id=model.get("id", ""),
+            model_context_window=model.get("context_window"),
+            model_released_at=model.get("released_at"),
+            model_license=model.get("license"),
+            model_size_b_params=model.get("size_b_params"),
+            results=[SubmissionResult.from_dict(r) for r in data.get("results", [])],
+        )
+
+    def to_json(self, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, ensure_ascii=False)
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "Submission":
         return cls.from_dict(json.loads(json_str))

--- a/benchmark/runner.py
+++ b/benchmark/runner.py
@@ -18,12 +18,14 @@ from typing import Optional, Callable, Generator
 import yaml
 
 from benchmark.config import BenchmarkConfig
+from benchmark.data_loader import load_languages, load_reference_texts
 from benchmark.models import (
     Language, LanguageCategory, ReferenceText, TranslationResult,
     BenchmarkRun, EvaluationScores
 )
 from benchmark.translator import (
     BenchmarkTranslator, TranslationRequest,
+    code_to_language_name,
     test_ollama_connection, get_available_ollama_models,
     test_openai_translation_connection, get_available_openai_models,
     test_openrouter_translation_connection, get_available_openrouter_models
@@ -83,78 +85,21 @@ class BenchmarkRunner:
             self._log("info", f"{stage}: {current}/{total} ({percent:.1f}%)")
 
     def load_languages(self) -> dict[str, Language]:
-        """
-        Load languages from YAML configuration.
-
-        Returns:
-            Dictionary of language code -> Language
-        """
-        yaml_path = self.config.paths.languages_file
-
-        if not yaml_path.exists():
-            raise FileNotFoundError(f"Languages file not found: {yaml_path}")
-
-        with open(yaml_path, "r", encoding="utf-8") as f:
-            data = yaml.safe_load(f)
-
-        languages = {}
-
-        # Map YAML category names to enum values
-        category_map = {
-            "european_major": LanguageCategory.EUROPEAN_MAJOR,
-            "asian": LanguageCategory.ASIAN,
-            "semitic": LanguageCategory.SEMITIC,
-            "cyrillic": LanguageCategory.CYRILLIC,
-            "classical": LanguageCategory.CLASSICAL,
-            "minority": LanguageCategory.MINORITY,
-        }
-
-        for cat_key, cat_data in data.get("categories", {}).items():
-            category = category_map.get(cat_key, LanguageCategory.EUROPEAN_MAJOR)
-
-            for lang_data in cat_data.get("languages", []):
-                code = str(lang_data["code"])  # Ensure string (YAML may parse "no" as boolean)
-                languages[code] = Language(
-                    code=code,
-                    name=lang_data["name"],
-                    category=category,
-                    native_name=lang_data["native_name"],
-                    is_rtl=lang_data.get("rtl", False),
-                    script=lang_data.get("script", "Latin"),
-                )
-
+        """Load languages from the split layout (or legacy YAML)."""
+        languages = load_languages(
+            base_dir=self.config.paths.base_dir,
+            legacy_file=self.config.paths.languages_file,
+        )
         self._languages = languages
         self._log("info", f"Loaded {len(languages)} languages")
         return languages
 
     def load_reference_texts(self) -> dict[str, ReferenceText]:
-        """
-        Load reference texts from YAML configuration.
-
-        Returns:
-            Dictionary of text id -> ReferenceText
-        """
-        yaml_path = self.config.paths.reference_texts_file
-
-        if not yaml_path.exists():
-            raise FileNotFoundError(f"Reference texts file not found: {yaml_path}")
-
-        with open(yaml_path, "r", encoding="utf-8") as f:
-            data = yaml.safe_load(f)
-
-        texts = {}
-
-        for text_data in data.get("texts", []):
-            text_id = text_data["id"]
-            texts[text_id] = ReferenceText(
-                id=text_id,
-                title=text_data["title"],
-                author=text_data["author"],
-                year=text_data["year"],
-                content=text_data["text"].strip(),
-                style=text_data["style"],
-            )
-
+        """Load reference texts from the split layout (or legacy YAML)."""
+        texts = load_reference_texts(
+            base_dir=self.config.paths.base_dir,
+            legacy_file=self.config.paths.reference_texts_file,
+        )
         self._texts = texts
         self._log("info", f"Loaded {len(texts)} reference texts")
         return texts
@@ -186,22 +131,19 @@ class BenchmarkRunner:
             if code in self._languages
         ]
 
-    async def validate_setup(self) -> tuple[bool, list[str]]:
+    async def validate_setup(self, evaluate: bool = True) -> tuple[bool, list[str]]:
         """
         Validate the benchmark setup.
 
-        Returns:
-            Tuple of (all_valid, list of error messages)
+        Args:
+            evaluate: When False, skip evaluator connection checks.
         """
         errors = []
 
-        # Validate config
         config_errors = self.config.validate()
         errors.extend(config_errors)
 
-        # Test translation provider connection
         if self.config.translation_provider == "openrouter":
-            # Test OpenRouter for translation
             or_trans_ok, or_trans_msg = await test_openrouter_translation_connection(self.config)
             if not or_trans_ok:
                 errors.append(f"OpenRouter (translation): {or_trans_msg}")
@@ -213,50 +155,56 @@ class BenchmarkRunner:
                 errors.append(f"OpenAI-compatible (translation): {openai_msg}")
             else:
                 self._log("info", f"OpenAI-compatible (translation): {openai_msg}")
+        elif self.config.translation_provider == "poe":
+            if not self.config.poe.api_key:
+                errors.append("Poe API key not configured. Set POE_API_KEY in .env or use --poe-key.")
+            else:
+                self._log("info", "Poe (translation): API key present")
         else:
-            # Test Ollama connection
             ollama_ok, ollama_msg = await test_ollama_connection(self.config)
             if not ollama_ok:
                 errors.append(f"Ollama: {ollama_msg}")
             else:
                 self._log("info", f"Ollama: {ollama_msg}")
 
-        # Test evaluator provider connection
-        if self.config.evaluator_provider == "poe":
-            poe_ok, poe_msg = await test_poe_connection(self.config)
-            if not poe_ok:
-                errors.append(f"Poe (evaluation): {poe_msg}")
+        if evaluate:
+            if self.config.evaluator_provider == "poe":
+                poe_ok, poe_msg = await test_poe_connection(self.config)
+                if not poe_ok:
+                    errors.append(f"Poe (evaluation): {poe_msg}")
+                else:
+                    self._log("info", f"Poe (evaluation): {poe_msg}")
             else:
-                self._log("info", f"Poe (evaluation): {poe_msg}")
+                openrouter_ok, openrouter_msg = await test_openrouter_connection(self.config)
+                if not openrouter_ok:
+                    errors.append(f"OpenRouter (evaluation): {openrouter_msg}")
+                else:
+                    self._log("info", f"OpenRouter (evaluation): {openrouter_msg}")
         else:
-            openrouter_ok, openrouter_msg = await test_openrouter_connection(self.config)
-            if not openrouter_ok:
-                errors.append(f"OpenRouter (evaluation): {openrouter_msg}")
-            else:
-                self._log("info", f"OpenRouter (evaluation): {openrouter_msg}")
+            self._log("info", "Evaluator check skipped (--no-evaluate)")
 
         return len(errors) == 0, errors
+
+    def _resolve_lang_name(self, code: str) -> str:
+        """Resolve a language code to its display name (loaded data, then fallback map)."""
+        lang = self._languages.get(code)
+        if lang is not None:
+            return lang.name
+        return code_to_language_name(code)
 
     def _generate_jobs(
         self,
         models: list[str],
-        languages: list[Language],
+        pairs: list[tuple[str, str]],
         texts: list[ReferenceText],
-        existing_results: Optional[list[TranslationResult]] = None
+        existing_results: Optional[list[TranslationResult]] = None,
     ) -> Generator[TranslationRequest, None, None]:
         """
-        Generate translation jobs, skipping already completed ones.
+        Generate translation jobs for the given (source, target) pairs.
 
-        Args:
-            models: List of provider model names
-            languages: List of target languages
-            texts: List of reference texts
-            existing_results: Results from a previous run (for resumption)
-
-        Yields:
-            TranslationRequest objects
+        For each pair, only reference texts whose `source_language` matches the
+        pair's source code are emitted.
         """
-        # Build set of completed jobs for fast lookup
         completed = set()
         if existing_results:
             for result in existing_results:
@@ -264,35 +212,47 @@ class BenchmarkRunner:
                     key = (result.source_text_id, result.target_language, result.model)
                     completed.add(key)
 
-        # Generate jobs for all combinations
-        for model in models:
-            for language in languages:
-                for text in texts:
-                    key = (text.id, language.code, model)
-                    if key not in completed:
-                        yield TranslationRequest(
-                            text=text,
-                            target_language=language.code,
-                            target_language_name=language.name,
-                            model=model
-                        )
+        for src_code, tgt_code in pairs:
+            src_name = self._resolve_lang_name(src_code)
+            tgt_name = self._resolve_lang_name(tgt_code)
+            src_texts = [t for t in texts if t.source_language == src_code]
+            if not src_texts:
+                self._log("warning", f"No reference texts for source language '{src_code}', skipping pair {src_code}->{tgt_code}")
+                continue
+
+            for model in models:
+                for text in src_texts:
+                    key = (text.id, tgt_code, model)
+                    if key in completed:
+                        continue
+                    yield TranslationRequest(
+                        text=text,
+                        target_language=tgt_code,
+                        target_language_name=tgt_name,
+                        source_language=src_code,
+                        source_language_name=src_name,
+                        model=model,
+                    )
 
     async def run(
         self,
         models: list[str],
         language_codes: Optional[list[str]] = None,
-        resume_run: Optional[BenchmarkRun] = None
+        pairs: Optional[list[tuple[str, str]]] = None,
+        resume_run: Optional[BenchmarkRun] = None,
+        evaluate: bool = True,
     ) -> BenchmarkRun:
         """
         Execute a complete benchmark run.
 
         Args:
             models: List of provider model names to benchmark
-            language_codes: Language codes to test (None = quick test set)
+            language_codes: Target language codes (English source assumed). Used
+                only when `pairs` is None.
+            pairs: Explicit (source_code, target_code) pairs. Overrides `language_codes`.
             resume_run: Optional previous run to resume
-
-        Returns:
-            BenchmarkRun with all results
+            evaluate: When False, skip the LLM judge step entirely (translations
+                are produced with `scores=None`).
         """
         # Load data if not already loaded
         if not self._languages:
@@ -300,23 +260,35 @@ class BenchmarkRunner:
         if not self._texts:
             self.load_reference_texts()
 
-        # Determine languages to test
-        if language_codes is None:
-            language_codes = self.config.quick_languages
+        # Resolve pairs: explicit list wins, else build from language_codes assuming English source.
+        if pairs is None:
+            if language_codes is None:
+                language_codes = self.config.quick_languages
+            pairs = [("en", code) for code in language_codes]
 
-        languages = self.filter_languages(language_codes)
-        texts = list(self._texts.values())
+        # Drop pairs whose target language is unknown.
+        validated_pairs: list[tuple[str, str]] = []
+        for src_code, tgt_code in pairs:
+            if tgt_code not in self._languages:
+                self._log("warning", f"Unknown target language '{tgt_code}', skipping {src_code}->{tgt_code}")
+                continue
+            validated_pairs.append((src_code, tgt_code))
 
-        if not languages:
-            raise ValueError("No valid languages specified")
+        if not validated_pairs:
+            raise ValueError("No valid (source, target) pairs to run.")
         if not models:
             raise ValueError("No models specified")
 
-        # Determine evaluator model based on provider
+        texts = list(self._texts.values())
+        target_codes = sorted({tgt for _, tgt in validated_pairs})
+
+        # Determine evaluator model based on provider (label only — actual call gated by `evaluate`).
         if self.config.evaluator_provider == "poe":
             evaluator_model = self.config.poe.default_model
         else:
             evaluator_model = self.config.openrouter.default_model
+        if not evaluate:
+            evaluator_model = "skipped"
 
         # Create or resume run
         if resume_run:
@@ -328,49 +300,50 @@ class BenchmarkRunner:
                 run_id=str(uuid.uuid4())[:8],
                 started_at=datetime.now().isoformat(),
                 models=models,
-                languages=language_codes,
+                languages=target_codes,
                 evaluator_model=evaluator_model,
             )
             self._log("info", f"Starting new run {run.run_id}")
 
         # Log run parameters
+        pair_strs = [f"{s}->{t}" for s, t in validated_pairs]
         self._log("info", f"Models: {', '.join(models)}")
-        self._log("info", f"Languages: {', '.join([l.name for l in languages])}")
+        self._log("info", f"Pairs: {', '.join(pair_strs)}")
         self._log("info", f"Texts: {len(texts)}")
-        self._log("info", f"Total translations: {run.total_expected}")
+        if not evaluate:
+            self._log("info", "Auto-evaluation disabled (--no-evaluate). Translations will have scores=None.")
 
-        # Initialize translator and evaluator
+        # Initialize translator (and evaluator only if needed)
         self._translator = BenchmarkTranslator(
             self.config,
             self.log_callback,
             provider_type=self.config.translation_provider
         )
-        self._evaluator = TranslationEvaluator(
-            self.config, 
-            self.log_callback,
-            provider=self.config.evaluator_provider
-        )
+        if evaluate:
+            self._evaluator = TranslationEvaluator(
+                self.config,
+                self.log_callback,
+                provider=self.config.evaluator_provider
+            )
+        else:
+            self._evaluator = None
 
         try:
-            # Generate jobs
             jobs = list(self._generate_jobs(
                 models=models,
-                languages=languages,
+                pairs=validated_pairs,
                 texts=texts,
                 existing_results=run.results if resume_run else None
             ))
 
             self._log("info", f"Jobs to process: {len(jobs)}")
 
-            # Process jobs
             for i, job in enumerate(jobs):
                 self._progress("translation", i + 1, len(jobs))
 
-                # Translate
                 result = await self._translator.translate(job)
 
-                # Evaluate if translation succeeded
-                if result.success and result.translated_text:
+                if evaluate and result.success and result.translated_text and self._evaluator is not None:
                     source_text = self.get_text(result.source_text_id)
                     if source_text:
                         scores, eval_time = await self._evaluator.evaluate(
@@ -382,7 +355,6 @@ class BenchmarkRunner:
                         result.scores = scores
                         result.evaluation_time_ms = eval_time
 
-                        # Log score
                         self._log(
                             "info",
                             f"  Score: {scores.overall:.1f}/10 "
@@ -403,11 +375,13 @@ class BenchmarkRunner:
             self._log("info", "=" * 50)
             self._log("info", f"Run {run.run_id} completed")
             self._log("info", f"Total translations: {run.total_completed}")
-            self._log("info", f"Success rate: {sum(1 for r in run.results if r.success) / len(run.results) * 100:.1f}%")
+            if run.results:
+                success_rate = sum(1 for r in run.results if r.success) / len(run.results) * 100
+                self._log("info", f"Success rate: {success_rate:.1f}%")
 
-            # Evaluation cost summary
-            cost_summary = self._evaluator.get_cost_summary()
-            self._log("info", f"Evaluation cost: ${cost_summary['total_cost_usd']:.4f}")
+            if self._evaluator is not None:
+                cost_summary = self._evaluator.get_cost_summary()
+                self._log("info", f"Evaluation cost: ${cost_summary['total_cost_usd']:.4f}")
 
             return run
 

--- a/benchmark/schemas/language.schema.json
+++ b/benchmark/schemas/language.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/hydropix/TranslateBookWithLLM/schemas/language.schema.json",
+  "title": "TBL Benchmark Language",
+  "type": "object",
+  "required": ["code", "name", "native_name", "category"],
+  "additionalProperties": false,
+  "properties": {
+    "code": {
+      "type": "string",
+      "pattern": "^[a-zA-Z]{2,3}(-[A-Za-z0-9]{2,8})?$",
+      "description": "BCP-47-ish language code (e.g. 'fr', 'zh-Hans')"
+    },
+    "name": { "type": "string", "minLength": 1 },
+    "native_name": { "type": "string", "minLength": 1 },
+    "script": { "type": "string", "default": "Latin" },
+    "category": {
+      "enum": [
+        "european_major",
+        "asian",
+        "semitic",
+        "cyrillic",
+        "classical",
+        "minority"
+      ]
+    },
+    "rtl": { "type": "boolean", "default": false },
+    "difficulty": {
+      "enum": ["easy", "medium", "hard", "very_hard"]
+    }
+  }
+}

--- a/benchmark/schemas/model.schema.json
+++ b/benchmark/schemas/model.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/hydropix/TranslateBookWithLLM/schemas/model.schema.json",
+  "title": "TBL Benchmark Model Registry Entry",
+  "type": "object",
+  "required": ["id", "provider"],
+  "additionalProperties": false,
+  "properties": {
+    "id": { "type": "string", "minLength": 1 },
+    "provider": {
+      "enum": ["ollama", "openai", "openrouter", "gemini", "mistral", "deepseek", "poe", "nim"]
+    },
+    "context_window": { "type": "integer", "minimum": 0 },
+    "released_at": { "type": "string", "format": "date" },
+    "license": { "type": "string" },
+    "size_b_params": { "type": "number", "minimum": 0 },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "aliases": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Alternative IDs that map to this model"
+    },
+    "notes": { "type": "string", "maxLength": 1000 }
+  }
+}

--- a/benchmark/schemas/reference_text.schema.json
+++ b/benchmark/schemas/reference_text.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/hydropix/TranslateBookWithLLM/schemas/reference_text.schema.json",
+  "title": "TBL Benchmark Reference Text",
+  "type": "object",
+  "required": ["id", "title", "source_language", "text", "style"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9_]+$",
+      "description": "Unique snake_case identifier for the text"
+    },
+    "title": { "type": "string", "minLength": 1 },
+    "author": { "type": "string" },
+    "year": { "type": "integer" },
+    "source_language": {
+      "type": "string",
+      "pattern": "^[a-zA-Z]{2,3}(-[A-Za-z0-9]{2,8})?$"
+    },
+    "style": { "type": "string" },
+    "challenges": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "text": { "type": "string", "minLength": 1 },
+    "license": { "type": "string", "default": "public-domain" },
+    "era": { "type": "string" },
+    "character_count": { "type": "integer", "minimum": 0 }
+  }
+}

--- a/benchmark/schemas/submission.schema.json
+++ b/benchmark/schemas/submission.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/hydropix/TranslateBookWithLLM/schemas/submission.schema.json",
+  "title": "TBL Benchmark Submission",
+  "type": "object",
+  "required": ["schema_version", "submission", "environment", "model", "results"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": { "const": "1.0" },
+    "submission": {
+      "type": "object",
+      "required": ["submitted_by", "submitted_at"],
+      "additionalProperties": false,
+      "properties": {
+        "submitted_by": {
+          "type": "string",
+          "pattern": "^github:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,38})$",
+          "description": "GitHub identity in the form 'github:<username>'"
+        },
+        "submitted_at": { "type": "string", "format": "date-time" },
+        "notes": { "type": "string", "maxLength": 2000 }
+      }
+    },
+    "environment": {
+      "type": "object",
+      "required": ["tbl_version", "prompt_version", "judge_id"],
+      "additionalProperties": false,
+      "properties": {
+        "tbl_version": { "type": "string" },
+        "prompt_version": { "type": "string" },
+        "judge_id": { "type": "string" },
+        "judge_seed": { "type": "integer" },
+        "judge_temperature": { "type": "number", "minimum": 0, "maximum": 2 }
+      }
+    },
+    "model": {
+      "type": "object",
+      "required": ["provider", "id"],
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "enum": ["ollama", "openai", "openrouter", "gemini", "mistral", "deepseek", "poe", "nim"]
+        },
+        "id": { "type": "string", "minLength": 1 },
+        "context_window": { "type": "integer", "minimum": 0 },
+        "released_at": { "type": "string", "format": "date" },
+        "license": { "type": "string" },
+        "size_b_params": { "type": "number", "minimum": 0 }
+      }
+    },
+    "results": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/result" }
+    }
+  },
+  "$defs": {
+    "result": {
+      "type": "object",
+      "required": ["text_id", "source_lang", "target_lang", "output", "output_hash", "scores"],
+      "additionalProperties": false,
+      "properties": {
+        "text_id": { "type": "string", "minLength": 1 },
+        "source_lang": { "type": "string", "minLength": 2 },
+        "target_lang": { "type": "string", "minLength": 2 },
+        "output": { "type": "string" },
+        "output_hash": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "translation_latency_ms": { "type": "integer", "minimum": 0 },
+        "scores": {
+          "type": "object",
+          "required": ["accuracy", "fluency", "style", "overall"],
+          "additionalProperties": false,
+          "properties": {
+            "accuracy": { "type": "number", "minimum": 1, "maximum": 10 },
+            "fluency":  { "type": "number", "minimum": 1, "maximum": 10 },
+            "style":    { "type": "number", "minimum": 1, "maximum": 10 },
+            "overall":  { "type": "number", "minimum": 1, "maximum": 10 },
+            "feedback": { "type": "string", "maxLength": 1000 }
+          }
+        }
+      }
+    }
+  }
+}

--- a/benchmark/translator.py
+++ b/benchmark/translator.py
@@ -12,8 +12,22 @@ from typing import Optional, Callable, Union
 
 from benchmark.config import BenchmarkConfig
 from benchmark.models import ReferenceText, TranslationResult
-from src.core.llm import OllamaProvider, OpenAICompatibleProvider, OpenRouterProvider, LLMProvider
+from src.core.llm import OllamaProvider, OpenAICompatibleProvider, OpenRouterProvider, PoeProvider, LLMProvider
 from src.config import TRANSLATE_TAG_IN, TRANSLATE_TAG_OUT
+
+
+# Map BCP-47 codes to display names used in the translation prompt.
+_LANG_NAME = {
+    "en": "English", "fr": "French", "de": "German", "es": "Spanish",
+    "it": "Italian", "pt": "Portuguese", "ja": "Japanese", "ko": "Korean",
+    "zh-Hans": "Chinese (Simplified)", "zh-Hant": "Chinese (Traditional)",
+    "ru": "Russian", "ar": "Arabic", "vi": "Vietnamese", "id": "Indonesian",
+}
+
+
+def code_to_language_name(code: str, fallback: Optional[str] = None) -> str:
+    """Best-effort BCP-47 code → human display name. Falls back to the code."""
+    return _LANG_NAME.get(code, fallback or code)
 
 
 @dataclass
@@ -24,6 +38,8 @@ class TranslationRequest:
     target_language: str
     target_language_name: str
     model: str
+    source_language: str = "en"
+    source_language_name: str = "English"
 
 
 class BenchmarkTranslator:
@@ -62,6 +78,7 @@ class BenchmarkTranslator:
             "ollama": "Ollama",
             "openai": "OpenAI-compatible provider",
             "openrouter": "OpenRouter",
+            "poe": "Poe",
         }
         return labels.get(self.provider_type, self.provider_type)
 
@@ -82,6 +99,14 @@ class BenchmarkTranslator:
                 self._providers[model] = OpenRouterProvider(
                     api_key=self.config.openrouter.api_key,
                     model=model
+                )
+            elif self.provider_type == "poe":
+                if not self.config.poe.api_key:
+                    raise ValueError("Poe API key is required for translation. "
+                                     "Set POE_API_KEY in .env or use --poe-key")
+                self._providers[model] = PoeProvider(
+                    api_key=self.config.poe.api_key,
+                    model=model,
                 )
             elif self.provider_type == "openai":
                 self._providers[model] = OpenAICompatibleProvider(
@@ -199,7 +224,7 @@ Provide your translation now:"""
 
             system_prompt, user_prompt = self._build_prompt(
                 text=request.text.content,
-                source_language=self.config.source_language,
+                source_language=request.source_language_name,
                 target_language=request.target_language_name
             )
 

--- a/benchmark/wiki/generator.py
+++ b/benchmark/wiki/generator.py
@@ -9,10 +9,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-import yaml
 from jinja2 import Environment, FileSystemLoader
 
 from ..config import BenchmarkConfig, get_score_indicator
+from ..data_loader import load_languages, load_reference_texts
 from ..models import BenchmarkRun, LanguageCategory
 from ..results.storage import ResultsStorage
 
@@ -117,31 +117,33 @@ class WikiGenerator:
             lstrip_blocks=True,
         )
 
-        # Load language data
-        self._languages_data = self._load_languages()
+        # Load language data via the unified loader (split or legacy YAML).
+        self._languages = load_languages(
+            base_dir=self.config.paths.base_dir,
+            legacy_file=self.config.paths.languages_file,
+        )
 
-    def _load_languages(self) -> dict:
-        """Load language definitions from YAML."""
-        languages_file = self.config.paths.languages_file
-        if languages_file.exists():
-            with open(languages_file, "r", encoding="utf-8") as f:
-                return yaml.safe_load(f)
-        return {"categories": {}}
+    _CATEGORY_LABELS = {
+        LanguageCategory.EUROPEAN_MAJOR: "European Major Languages",
+        LanguageCategory.ASIAN: "Asian Languages",
+        LanguageCategory.SEMITIC: "Semitic Languages",
+        LanguageCategory.CYRILLIC: "Cyrillic Languages",
+        LanguageCategory.CLASSICAL: "Classical/Historical Languages",
+        LanguageCategory.MINORITY: "Minority/Regional Languages",
+    }
 
     def _get_language_info(self, code: str) -> dict:
         """Get language info by code."""
-        for category_data in self._languages_data.get("categories", {}).values():
-            for lang in category_data.get("languages", []):
-                if lang["code"] == code:
-                    return {
-                        "code": lang["code"],
-                        "name": lang["name"],
-                        "native_name": lang.get("native_name", lang["name"]),
-                        "script": lang.get("script", "Latin"),
-                        "category": category_data.get("name", "Unknown"),
-                        "is_rtl": lang.get("rtl", False),
-                    }
-        # Fallback for unknown codes
+        lang = self._languages.get(code)
+        if lang is not None:
+            return {
+                "code": lang.code,
+                "name": lang.name,
+                "native_name": lang.native_name,
+                "script": lang.script,
+                "category": self._CATEGORY_LABELS.get(lang.category, lang.category.value),
+                "is_rtl": lang.is_rtl,
+            }
         return {
             "code": code,
             "name": code,
@@ -214,14 +216,34 @@ class WikiGenerator:
 
         return self.output_dir
 
+    def _aggregation_summary_for_results(self, results: list) -> dict:
+        """Compute n_obs and verified ratio for a slice of results."""
+        n_obs_total = sum(getattr(r, "n_obs", 1) for r in results)
+        n_results = len(results)
+        verified = sum(1 for r in results if getattr(r, "verified", True))
+        return {
+            "n_obs_total": n_obs_total,
+            "verified_results": verified,
+            "self_reported_results": n_results - verified,
+            "verified_badge": (
+                "verified" if n_results > 0 and verified == n_results
+                else ("self-reported" if verified == 0 else "mixed")
+            ),
+        }
+
     def _generate_home(self, run: BenchmarkRun) -> None:
         """Generate Home.md page."""
         template = self._env.get_template("home.md.j2")
 
         # Calculate model rankings
         model_stats = run.get_model_stats()
+        results_by_model: dict = {}
+        for r in run.results:
+            results_by_model.setdefault(r.model, []).append(r)
+
         model_rankings = []
         for stats in sorted(model_stats, key=lambda x: x.avg_overall, reverse=True):
+            agg = self._aggregation_summary_for_results(results_by_model.get(stats.model, []))
             model_rankings.append({
                 "name": stats.model,
                 "page_name": self._model_page_name(stats.model),
@@ -231,13 +253,19 @@ class WikiGenerator:
                 "avg_style": stats.avg_style,
                 "indicator": get_score_indicator(stats.avg_overall),
                 "languages_tested": stats.successful_translations,
+                **agg,
             })
 
         # Calculate language rankings
         language_stats = run.get_language_stats()
+        results_by_lang: dict = {}
+        for r in run.results:
+            results_by_lang.setdefault(r.target_language, []).append(r)
+
         language_rankings = []
         for stats in sorted(language_stats, key=lambda x: x.avg_overall, reverse=True):
             lang_info = self._get_language_info(stats.language_code)
+            agg = self._aggregation_summary_for_results(results_by_lang.get(stats.language_code, []))
             language_rankings.append({
                 "name": lang_info["name"],
                 "native_name": lang_info["native_name"],
@@ -246,6 +274,7 @@ class WikiGenerator:
                 "indicator": get_score_indicator(stats.avg_overall),
                 "best_model": stats.best_model or "N/A",
                 "total_translations": stats.total_translations,
+                **agg,
             })
 
         # Group languages by category
@@ -268,20 +297,26 @@ class WikiGenerator:
     def _generate_all_languages_page(self, run: BenchmarkRun) -> None:
         """Generate All-Languages.md page."""
         language_stats = run.get_language_stats()
+        results_by_lang: dict = {}
+        for r in run.results:
+            results_by_lang.setdefault(r.target_language, []).append(r)
 
-        headers = ["Language", "Native Name", "Category", "Avg Score", "Best Model"]
+        headers = ["Language", "Native Name", "Category", "Avg Score", "Best Model", "Obs", "Verified"]
         rows = []
 
         for stats in sorted(language_stats, key=lambda x: x.avg_overall, reverse=True):
             lang_info = self._get_language_info(stats.language_code)
             indicator = get_score_indicator(stats.avg_overall)
             page_name = self._language_page_name(lang_info['name'])
+            agg = self._aggregation_summary_for_results(results_by_lang.get(stats.language_code, []))
             rows.append([
                 f"[{lang_info['name']}]({page_name})",
                 lang_info['native_name'],
                 lang_info['category'],
                 f"{indicator} {stats.avg_overall:.1f}",
                 stats.best_model or "N/A",
+                str(agg["n_obs_total"]),
+                agg["verified_badge"],
             ])
 
         table = format_markdown_table(headers, rows)
@@ -292,13 +327,17 @@ class WikiGenerator:
     def _generate_all_models_page(self, run: BenchmarkRun) -> None:
         """Generate All-Models.md page."""
         model_stats = run.get_model_stats()
+        results_by_model: dict = {}
+        for r in run.results:
+            results_by_model.setdefault(r.model, []).append(r)
 
-        headers = ["Model", "Avg Score", "Accuracy", "Fluency", "Style", "Languages"]
+        headers = ["Model", "Avg Score", "Accuracy", "Fluency", "Style", "Languages", "Obs", "Verified"]
         rows = []
 
         for stats in sorted(model_stats, key=lambda x: x.avg_overall, reverse=True):
             indicator = get_score_indicator(stats.avg_overall)
             page_name = self._model_page_name(stats.model)
+            agg = self._aggregation_summary_for_results(results_by_model.get(stats.model, []))
             rows.append([
                 f"[{stats.model}]({page_name})",
                 f"{indicator} {stats.avg_overall:.1f}",
@@ -306,6 +345,8 @@ class WikiGenerator:
                 f"{stats.avg_fluency:.1f}",
                 f"{stats.avg_style:.1f}",
                 str(stats.successful_translations),
+                str(agg["n_obs_total"]),
+                agg["verified_badge"],
             ])
 
         table = format_markdown_table(headers, rows)
@@ -482,28 +523,20 @@ class WikiGenerator:
         """Group language rankings by category."""
         categories_map: dict = {}
 
-        for lang in language_rankings:
-            lang_info = None
-            for category_key, category_data in self._languages_data.get("categories", {}).items():
-                for l in category_data.get("languages", []):
-                    if l["name"] == lang["name"]:
-                        category_name = category_data.get("name", "Other")
-                        if category_name not in categories_map:
-                            categories_map[category_name] = {
-                                "name": category_name,
-                                "languages": [],
-                            }
-                        categories_map[category_name]["languages"].append(lang)
-                        lang_info = l
-                        break
-                if lang_info:
-                    break
+        # Build name -> category-label map from the loaded languages.
+        name_to_category = {
+            lang.name: self._CATEGORY_LABELS.get(lang.category, lang.category.value)
+            for lang in self._languages.values()
+        }
 
-            # If not found, add to Other
-            if not lang_info:
-                if "Other" not in categories_map:
-                    categories_map["Other"] = {"name": "Other", "languages": []}
-                categories_map["Other"]["languages"].append(lang)
+        for lang in language_rankings:
+            category_name = name_to_category.get(lang["name"], "Other")
+            if category_name not in categories_map:
+                categories_map[category_name] = {
+                    "name": category_name,
+                    "languages": [],
+                }
+            categories_map[category_name]["languages"].append(lang)
 
         return list(categories_map.values())
 
@@ -610,10 +643,9 @@ class WikiGenerator:
         }
 
     def _load_reference_texts(self) -> dict:
-        """Load reference texts from YAML."""
-        ref_file = self.config.paths.reference_texts_file
-        if ref_file.exists():
-            with open(ref_file, "r", encoding="utf-8") as f:
-                data = yaml.safe_load(f)
-                return {t["id"]: t for t in data.get("texts", [])}
-        return {}
+        """Load reference texts as a flat {id: dict} map for template usage."""
+        texts = load_reference_texts(
+            base_dir=self.config.paths.base_dir,
+            legacy_file=self.config.paths.reference_texts_file,
+        )
+        return {t.id: t.to_dict() for t in texts.values()}

--- a/benchmark/wiki/templates/home.md.j2
+++ b/benchmark/wiki/templates/home.md.j2
@@ -4,6 +4,8 @@
 
 This wiki contains translation quality benchmarks for various LLM models across {{ total_languages }} languages.
 
+> **Methodology v2** — judge: Claude Opus 4.7 applying the formal [rubric v1](https://github.com/hydropix/TranslateBookWithLLM/blob/main/docs/JUDGE_RUBRIC.md). Multiple source languages, 8 canonical pairs, aggregated scoring. Previous benchmark archived under [Archive-Index](Archive-Index).
+
 ## Score Legend
 
 | Indicator | Range | Label |
@@ -76,7 +78,8 @@ Best translation quality by target language:
 - **By Language:** [All Languages](All-Languages)
 - **By Model:** [All Models](All-Models)
 - **Benchmark Documentation:** [How to Run Benchmarks](Benchmark-System)
-- **Raw Data:** [Download JSON](https://github.com/hydropix/TranslateBookWithLLM/tree/main/benchmark_results)
+- **Raw Data:** [Download JSON](https://github.com/hydropix/TranslateBookWithLLM/tree/main/benchmark/data/submissions)
+- **Archived v1 benchmark:** [Archive-Index](Archive-Index) — previous methodology, kept for reference
 
 ---
 

--- a/benchmark/wiki/templates/home.md.j2
+++ b/benchmark/wiki/templates/home.md.j2
@@ -20,10 +20,10 @@ This wiki contains translation quality benchmarks for various LLM models across 
 
 Overall performance across all tested languages:
 
-| Rank | Model | Avg Score | Accuracy | Fluency | Style | Languages Tested |
-|------|-------|-----------|----------|---------|-------|------------------|
+| Rank | Model | Avg Score | Accuracy | Fluency | Style | Languages | Obs | Verified |
+|------|-------|-----------|----------|---------|-------|-----------|-----|----------|
 {% for model in model_rankings %}
-| {{ loop.index }} | [{{ model.name }}]({{ model.page_name }}) | {{ model.indicator }} {{ model.avg_overall|round(1) }} | {{ model.avg_accuracy|round(1) }} | {{ model.avg_fluency|round(1) }} | {{ model.avg_style|round(1) }} | {{ model.languages_tested }} |
+| {{ loop.index }} | [{{ model.name }}]({{ model.page_name }}) | {{ model.indicator }} {{ model.avg_overall|round(1) }} | {{ model.avg_accuracy|round(1) }} | {{ model.avg_fluency|round(1) }} | {{ model.avg_style|round(1) }} | {{ model.languages_tested }} | {{ model.n_obs_total | default(model.languages_tested) }} | {{ model.verified_badge | default("verified") }} |
 {% endfor %}
 
 ---
@@ -32,10 +32,10 @@ Overall performance across all tested languages:
 
 Best translation quality by target language:
 
-| Rank | Language | Native | Avg Score | Best Model | Tests |
-|------|----------|--------|-----------|------------|-------|
+| Rank | Language | Native | Avg Score | Best Model | Tests | Obs | Verified |
+|------|----------|--------|-----------|------------|-------|-----|----------|
 {% for lang in language_rankings[:15] %}
-| {{ loop.index }} | [{{ lang.name }}]({{ lang.page_name }}) | {{ lang.native_name }} | {{ lang.indicator }} {{ lang.avg_overall|round(1) }} | {{ lang.best_model }} | {{ lang.total_translations }} |
+| {{ loop.index }} | [{{ lang.name }}]({{ lang.page_name }}) | {{ lang.native_name }} | {{ lang.indicator }} {{ lang.avg_overall|round(1) }} | {{ lang.best_model }} | {{ lang.total_translations }} | {{ lang.n_obs_total | default(lang.total_translations) }} | {{ lang.verified_badge | default("verified") }} |
 {% endfor %}
 
 {% if language_rankings|length > 15 %}

--- a/docs/BENCHMARK_WORKFLOW.md
+++ b/docs/BENCHMARK_WORKFLOW.md
@@ -213,6 +213,52 @@ future Claude version (e.g. Opus 5) re-evaluates the same translations:
 
 ---
 
+## Switching the live wiki from v1 to v2
+
+The v2 system (this doc) coexists with the v1 wiki only through a one-shot
+**archive step**: every existing v1 wiki page is renamed with an `Archive-`
+prefix, internal cross-page links are rewritten so the archived pages still
+work standalone, and an `Archive-Index.md` is published as the entry point.
+After that, the v2 publish-wiki workflow can run without colliding.
+
+Run this **before merging the v2 branch to `main`**:
+
+```bash
+# Dry-run first to see what would be renamed
+python scripts/archive_v1_wiki.py --dry-run
+
+# Apply (commits + pushes to the wiki repo)
+python scripts/archive_v1_wiki.py --message "Archive v1 benchmark"
+
+# If you want to inspect the commit before pushing:
+python scripts/archive_v1_wiki.py --no-push
+# ...then `git -C .wiki_repo_archive push` when ready
+```
+
+What the script does:
+
+1. Clones the wiki repo into `.wiki_repo_archive/` (gitignored).
+2. Lists every `*.md` at the wiki root that is not already prefixed `Archive-`.
+3. Inside each one, rewrites cross-page links so `[Foo](Bar)` becomes
+   `[Foo](Archive-Bar)` for any link whose target is one of the pages being
+   archived.
+4. Renames the files (`Home.md` → `Archive-Home.md`, `Language-French.md` →
+   `Archive-Language-French.md`, etc.).
+5. Generates `Archive-Index.md` listing every archived page, grouped by
+   category (landing, cross-cutting tables, per-language, per-model).
+6. Commits and pushes.
+
+The v2 home template (`benchmark/wiki/templates/home.md.j2`) already includes
+a banner pointing to `Archive-Index`, so once the v2 wiki regenerates after
+the merge, visitors land on the v2 home and can click through to the
+archived v1 if they need historical scores.
+
+The `publish-wiki.yml` workflow's cleanup step only deletes `Home.md`,
+`All-Languages.md`, `All-Models.md`, `Language-*.md`, `Model-*.md` — it does
+not touch `Archive-*` pages, so the archive survives every future republish.
+
+---
+
 ## Rescoring an existing submission with a fresh judge
 
 If a stronger judge becomes available later (or you just want a second

--- a/docs/BENCHMARK_WORKFLOW.md
+++ b/docs/BENCHMARK_WORKFLOW.md
@@ -1,0 +1,281 @@
+# Benchmark Workflow — End-to-End Procedure
+
+The canonical playbook for producing translations and evaluating them via
+**manual LLM-as-judge** (Claude Code, Cursor, etc.). Following this doc keeps
+results comparable across sessions and contributors.
+
+If you want a fully automated path with an auto-judge (no human in the loop),
+see [CONTRIBUTING_BENCHMARK.md](CONTRIBUTING_BENCHMARK.md) instead.
+
+---
+
+## Quick prompt to start a future Claude Code session
+
+> "Evaluate benchmark run `<RUN_ID>` for model `<MODEL_ID>`. Apply
+> [docs/JUDGE_RUBRIC.md](JUDGE_RUBRIC.md) strictly and follow the procedure in
+> [docs/BENCHMARK_WORKFLOW.md](BENCHMARK_WORKFLOW.md)."
+
+That single sentence should let any new Claude session pick up exactly where
+the previous one left off — both files are self-contained and auto-loadable.
+
+---
+
+## The 8 canonical Quick pairs
+
+Every model is benchmarked on this same set of language pairs (chosen via a
+market study of real user demand — see chat history for sources):
+
+```
+en:zh-Hans   en:es   en:fr   en:vi
+ja:en   ko:en   zh-Hans:en   ja:zh-Hans
+```
+
+For Phase 1 (translation), pass them as `--pairs` exactly. Don't substitute
+without justification — comparability across models depends on this set staying
+fixed.
+
+---
+
+## Phase 1 — Produce translations
+
+For **each model** to benchmark, run one of:
+
+```bash
+# Local Ollama
+python -m benchmark.cli run -p ollama -m <model-id> --no-evaluate \
+  --pairs en:zh-Hans en:es en:fr en:vi ja:en ko:en zh-Hans:en ja:zh-Hans
+
+# Poe (uses POE_API_KEY from .env)
+python -m benchmark.cli run -p poe -m <model-id> --no-evaluate \
+  --pairs en:zh-Hans en:es en:fr en:vi ja:en ko:en zh-Hans:en ja:zh-Hans
+
+# OpenRouter (uses OPENROUTER_API_KEY from .env)
+python -m benchmark.cli run -p openrouter -m <model-id> --no-evaluate \
+  --pairs en:zh-Hans en:es en:fr en:vi ja:en ko:en zh-Hans:en ja:zh-Hans
+```
+
+**Critical flags:**
+- `--no-evaluate` — skips the auto-judge so the run finishes faster and we
+  control the scoring entirely in Phase 2.
+- `--pairs` — uses the explicit pair list (different source languages allowed).
+  Without it, the runner defaults to English source and ignores `ja/ko/zh-Hans`
+  texts.
+
+The CLI prints a `<RUN_ID>` (8 hex chars). Note it. The output is
+`benchmark_results/<RUN_ID>.json` with `scores: null` on every result.
+
+**Expected volume per run:** ~45 translations on the canonical 8 pairs (10 EN
+texts × 4 EN→X targets + 4 X→en pairs from non-EN texts).
+
+---
+
+## Phase 2 — Manual evaluation in Claude Code
+
+This phase is collaborative. The user drives the CLI; the assistant (Claude)
+acts as the judge.
+
+### What the user types
+
+Open a Claude Code session and prompt:
+
+> "Evaluate benchmark run `<RUN_ID>`. Follow `docs/BENCHMARK_WORKFLOW.md` and
+> apply `docs/JUDGE_RUBRIC.md`."
+
+Then let the assistant work. No further commands needed from the user during
+the evaluation itself.
+
+### What the assistant must do (Claude protocol)
+
+Execute these steps mechanically, in order:
+
+#### Step 1 — Load both reference documents
+Read [docs/JUDGE_RUBRIC.md](JUDGE_RUBRIC.md) (penalty table, scale anchors,
+ceilings, dispersion rule) and this file in full. Treat them as binding.
+
+#### Step 2 — Dump the brief
+```bash
+python scripts/dump_for_evaluation.py <RUN_ID> --batch-size 15 --out plan/eval_<RUN_ID>.md
+```
+Produces one or more `plan/eval_<RUN_ID>_batch*.md` files.
+
+#### Step 3 — Read every batch in full
+Each translation has a stable `eval_id`, the source text, the model's output,
+and the declared `challenges`. Don't skim — score each translation on its own
+merits.
+
+#### Step 4 — Score using the rubric
+For each translation:
+- Identify all errors (contresens, untranslated source words, script
+  mismatches, grammar errors, lost rhetoric, period-wrong vocabulary…).
+- Apply the penalty table (rubric §3): `accuracy`, `fluency`, `style` start
+  at 10, deduct per detected issue.
+- Compute `overall` as a holistic call constrained by rubric §4 (hard
+  ceiling 9.0 without human reference comparison; if any dimension < 6.0,
+  overall ≤ 6.0; etc.).
+- Write a 1–2 sentence `feedback` documenting the deductions (rubric §7).
+  Specific, auditable, with the penalty values.
+
+If multiple model runs cover the same `(text_id, target_lang)` triples (cross-
+model comparison), apply rubric §5: rank the N outputs, enforce ≥0.3 point
+difference between adjacent ranks on `overall`.
+
+#### Step 5 — Write the JSON reply
+Single file: `plan/eval_<RUN_ID>_rubric_v1.json`. Format is a flat JSON array:
+
+```json
+[
+  {"eval_id": "<10-hex>", "scores": {
+    "accuracy": 0.0, "fluency": 0.0, "style": 0.0, "overall": 0.0,
+    "feedback": "..."
+  }},
+  ...
+]
+```
+
+One object per `eval_id` from the brief. Don't omit any.
+
+#### Step 6 — Apply the scores
+```bash
+python scripts/apply_evaluations.py <RUN_ID> plan/eval_<RUN_ID>_rubric_v1.json \
+  --judge-id <judge-model>-rubric-v1
+```
+
+Where `<judge-model>` is the LLM acting as judge:
+- `claude-opus-4-7` (current Claude Code default for Bruno's setup)
+- `claude-sonnet-4-6`
+- `gemini-3-pro`
+- `gpt-5`
+
+The full `judge_id` therefore looks like `claude-opus-4-7-rubric-v1`. This
+identifier appears on the wiki next to every score.
+
+The script is idempotent — rerunning is safe.
+
+#### Step 7 — Report distribution
+End the turn with:
+- Per-pair averages (`en→zh-Hans`, `ja→en`, etc.)
+- Global average and number of evaluations
+- Notable findings (best/worst translations, recurring failure modes)
+- Comparison with prior runs if available
+
+---
+
+## Phase 3 — Submit and publish
+
+Once a run is fully evaluated, convert it to a community submission:
+
+```bash
+python -m benchmark.cli submit benchmark_results/<RUN_ID>.json \
+  --by github:<your-username> \
+  --provider <ollama|poe|openrouter|openai> \
+  --judge-id <judge-model>-rubric-v1
+```
+
+This produces a validated submission at:
+```
+benchmark/data/submissions/<DATE>_<USER>_<MODEL-SLUG>.json
+```
+
+Verify the schema:
+```bash
+python scripts/validate_submission.py benchmark/data/submissions/<DATE>_<USER>_<MODEL-SLUG>.json
+```
+
+Commit and push. The `publish-wiki` GitHub Action regenerates the wiki on
+merge to `main`. The aggregator merges multiple submissions covering the same
+`(model, text, target_lang)` triple by **median** and surfaces an `n_obs`
+column on the wiki.
+
+---
+
+## File map
+
+| Path | Role | Tracked in git? |
+|---|---|---|
+| [docs/JUDGE_RUBRIC.md](JUDGE_RUBRIC.md) | The rubric the judge applies (penalty table, scale anchors) | ✅ |
+| [docs/BENCHMARK_WORKFLOW.md](BENCHMARK_WORKFLOW.md) | This doc — the procedure | ✅ |
+| `benchmark_results/<RUN_ID>.json` | Translations + scores in place | ❌ (gitignored) |
+| `plan/eval_<RUN_ID>_*.md`, `plan/eval_<RUN_ID>_*.json` | Per-session brief and reply | ❌ (gitignored) |
+| `benchmark/data/submissions/*.json` | Final submissions, schema-validated | ✅ |
+| [benchmark/schemas/submission.schema.json](../benchmark/schemas/submission.schema.json) | Strict schema for submissions | ✅ |
+
+---
+
+## What changes between sessions
+
+The only thing that drifts session-to-session is the **judge model**. If a
+future Claude version (e.g. Opus 5) re-evaluates the same translations:
+- Use a different `judge_id`: `claude-opus-5-rubric-v1`.
+- The aggregator considers it as a different observation; both scores end up
+  in the wiki under the same `(model, text, lang)` cell, separated by judge.
+- The rubric version stays `v1` as long as `docs/JUDGE_RUBRIC.md` doesn't
+  change. If you bump the rubric to v2, also bump the judge_id suffix.
+
+---
+
+## Rescoring an existing submission with a fresh judge
+
+If a stronger judge becomes available later (or you just want a second
+opinion), the model **outputs are preserved verbatim** in
+`benchmark/data/submissions/<file>.json` and can be re-evaluated without
+re-running the translations.
+
+The full rescore path:
+
+```bash
+# 1. Reconstruct a runnable JSON from the historical submission
+python scripts/submission_to_run.py benchmark/data/submissions/<file>.json
+# captures: RUN_ID=<new-id>
+
+# 2. Standard manual eval flow (steps 4-6 of Phase 2 above)
+python scripts/dump_for_evaluation.py <RUN_ID> --batch-size 15 --out plan/eval_<RUN_ID>.md
+# ... judge reads, scores, writes plan/eval_<RUN_ID>_rubric_v1.json ...
+python scripts/apply_evaluations.py <RUN_ID> plan/eval_<RUN_ID>_rubric_v1.json --judge-id <new-judge-id>
+
+# 3. Submit as a new observation under the SAME model+provider
+python -m benchmark.cli submit benchmark_results/<RUN_ID>.json \
+  --by github:<original-submitter> \
+  --provider <original-provider> \
+  --judge-id <new-judge-id>
+```
+
+Or, if you're driving from a Claude Code session, the `/benchmark-rescore-submission`
+skill chains all of this automatically — only Step 3 (submit) stays manual.
+
+The aggregator merges both observations into a single wiki cell with `n_obs=2`
+and the **median** of the scores. To audit the difference between the original
+and the new judge on the wiki, look at the per-language pages — they list each
+observation separately when there are multiple.
+
+---
+
+## Common edge cases
+
+**The run has scores already (auto-judge ran first).**
+`dump_for_evaluation.py` only dumps results with `scores: null`. If you want
+to re-evaluate translations that already have scores, you'll need to clear
+them first (or add a `--rescore-all` flag — not currently implemented).
+
+**A pair like `ko:en` produces 0 translations.**
+Check that `benchmark/data/languages/en.yaml` and the source text exists in
+`benchmark/data/reference_texts/ko/`. Missing language entries are silently
+dropped from `--pairs`.
+
+**The submission CLI complains "no usable results".**
+The translation provider failed for this model. Check `benchmark_results/<RUN_ID>.json`
+for `error` fields and rerun the `benchmark.cli run` command to fix the
+provider config.
+
+**The judge_id is wrong on a submission already pushed.**
+Re-apply with the correct `--judge-id` via `apply_evaluations.py`, then
+re-`submit`, then commit the corrected submission file (overwrites the old
+one in `benchmark/data/submissions/`).
+
+---
+
+## Why this exists
+
+Without this doc, every new contributor (or new Claude session) reinvents the
+procedure, drifts off the canonical 8 pairs, uses a different judge_id format,
+or skips the rubric — and the wiki accumulates incomparable scores. Following
+this playbook keeps the benchmark scientifically meaningful over time.

--- a/docs/CONTRIBUTING_BENCHMARK.md
+++ b/docs/CONTRIBUTING_BENCHMARK.md
@@ -1,0 +1,169 @@
+# Contributing benchmark results
+
+The TranslateBookWithLLM benchmark is **community-driven**. You can contribute
+results for any model the project doesn't already track by opening a Pull
+Request that adds a single JSON file under
+[`benchmark/data/submissions/`](../benchmark/data/submissions/).
+
+A GitHub Action validates every PR against the schema and replays a sample of
+the results (when the model is replayable from CI). On merge, the wiki is
+regenerated automatically.
+
+This page walks you through the full workflow. Submitting a model takes ~30
+minutes, almost all of it spent waiting for translation/evaluation calls.
+
+---
+
+## 1. Run the benchmark locally
+
+Prereq: a working Python 3.11+ env with this repo installed (`pip install -r requirements.txt`).
+
+Pick the provider that matches your model and run the benchmark CLI. Examples:
+
+```bash
+# Cloud (replayable in CI):
+python -m benchmark.cli run \
+  --provider openrouter \
+  --openrouter-key $OPENROUTER_API_KEY \
+  -m anthropic/claude-haiku-4-5
+
+# Local Ollama (will be marked self-reported):
+python -m benchmark.cli run \
+  --provider ollama \
+  -m qwen3:14b
+
+# Specific languages:
+python -m benchmark.cli run -p openrouter -m google/gemini-3-flash-preview \
+  -l fr de ja zh-Hans
+```
+
+The run is saved to `benchmark_results/<run_id>.json`.
+
+> **Tip:** start with a small language subset (`-l fr de ja`) to confirm your
+> setup works before launching a long full run.
+
+---
+
+## 2. Convert the run into a submission
+
+```bash
+python -m benchmark.cli submit benchmark_results/<run_id>.json \
+  --by github:<your-username> \
+  --provider openrouter \
+  --judge-id google/gemini-3-flash-preview
+```
+
+This writes a validated submission file to
+`benchmark/data/submissions/<date>_<username>_<model-slug>.json` and prints the
+git commands you need next.
+
+The CLI computes `output_hash` for each translation, fills in metadata
+(`tbl_version`, `prompt_version`, `judge_id`, …), and validates the JSON
+against [`benchmark/schemas/submission.schema.json`](../benchmark/schemas/submission.schema.json)
+locally before writing the file.
+
+---
+
+## 3. Open a Pull Request
+
+```bash
+git checkout -b submit/<model-slug>
+git add benchmark/data/submissions/<date>_<username>_<model-slug>.json
+git commit -s -m "submit: <model-id> benchmark results"
+gh pr create --title "Submit <model-id> benchmark results"
+```
+
+The `Validate Benchmark Submission` workflow will:
+
+1. Run schema validation on every changed submission file.
+2. Sample ~10% of results and **replay** them: re-translate with the same
+   provider/model and re-evaluate; flag results whose chrF vs. the submitted
+   output is < 0.85 **and** whose overall score differs by more than 1 point.
+3. For local models (Ollama), do cheap sanity checks instead: detect output
+   language, check length plausibility. The submission is then marked
+   `self-reported` in the wiki.
+4. Post a Markdown report on the PR.
+
+Address any reported issues by force-pushing a corrected file.
+
+---
+
+## 4. After merge
+
+The `Publish Benchmark Wiki` workflow runs on `main` whenever
+`benchmark/data/**` changes. It:
+
+1. Aggregates all submissions (`benchmark/cli aggregate-submissions`).
+2. Conflicts on `(model, text, target_lang)` are resolved by **median** of the
+   four scores; the representative output text is the one closest to the
+   median overall score.
+3. Regenerates the wiki Markdown and pushes to the GitHub wiki repo.
+
+Each row in the wiki shows the number of observations (`Obs`) and a verified /
+self-reported / mixed badge.
+
+---
+
+## File format reference
+
+The full JSON schema is in
+[`benchmark/schemas/submission.schema.json`](../benchmark/schemas/submission.schema.json).
+A minimal example:
+
+```json
+{
+  "schema_version": "1.0",
+  "submission": {
+    "submitted_by": "github:hydropix",
+    "submitted_at": "2026-05-09T10:00:00Z"
+  },
+  "environment": {
+    "tbl_version": "v0.1.0",
+    "prompt_version": "v1",
+    "judge_id": "google/gemini-3-flash-preview"
+  },
+  "model": {
+    "provider": "openrouter",
+    "id": "anthropic/claude-haiku-4-5"
+  },
+  "results": [
+    {
+      "text_id": "pride_prejudice",
+      "source_lang": "en",
+      "target_lang": "fr",
+      "output": "...",
+      "output_hash": "sha256:<64-hex>",
+      "scores": {
+        "accuracy": 8.5,
+        "fluency": 9.0,
+        "style": 7.5,
+        "overall": 8.3
+      }
+    }
+  ]
+}
+```
+
+Reference texts and language codes live in
+[`benchmark/data/`](../benchmark/data/) — pick `text_id` values from
+`benchmark/data/reference_texts/<lang>/*.yaml` and `target_lang` codes from
+`benchmark/data/languages/*.yaml`.
+
+---
+
+## FAQ
+
+**Can I submit results for a private model?**
+Yes, but it will be marked `self-reported` because CI cannot replay it.
+
+**Two contributors tested the same `(model, text, lang)` — whose result wins?**
+Neither: the aggregator takes the median of all observations and shows the
+number of observations in the wiki.
+
+**Do submissions expire when a new model version ships?**
+Not automatically. The wiki keeps historical entries; we may add a UI filter
+later.
+
+**Where do I report bugs in the schema or workflow?**
+Open an issue at
+[github.com/hydropix/TranslateBookWithLLM/issues](https://github.com/hydropix/TranslateBookWithLLM/issues).

--- a/docs/JUDGE_RUBRIC.md
+++ b/docs/JUDGE_RUBRIC.md
@@ -1,0 +1,171 @@
+# TranslateBookWithLLM — Judge Rubric (v1)
+
+**Version:** `v1`
+**Identifier to record in submissions:** `<judge-id>-rubric-v1` (e.g.
+`claude-opus-4-7-rubric-v1`, `gemini-3-pro-rubric-v1`)
+
+This document defines how a translation is scored in the benchmark. Any judge —
+human, LLM-as-judge, or otherwise — must apply this rubric to make scores
+comparable across submissions and over time.
+
+If you change the rubric (new dimensions, new penalty values), bump the version
+to `v2` and start a new wiki series. Never silently change the meaning of `v1`.
+
+---
+
+## 1. Dimensions
+
+Each translation is scored on four dimensions, each in `[1.0, 10.0]` with
+decimal precision:
+
+| Dimension | What it measures |
+|---|---|
+| **accuracy** | Preservation of meaning. No additions, no omissions, no contresens, no hallucinations. |
+| **fluency** | Naturalness in the target language. Grammar, syntax, idiomaticity, no untranslated source words, no script mismatches. |
+| **style** | Register, tone, period vocabulary, literary voice, rhetorical devices (irony, parallelism, etc.). |
+| **overall** | Holistic judgement. **Not the average.** Weighted by what matters most for this passage, with hard ceilings (see §4). |
+
+---
+
+## 2. Anchored scale
+
+Scores are anchored to **professional human translation as the reference**.
+This is a hard, non-negotiable framing — every judge calibrates against it.
+
+| Score | Anchor description |
+|---|---|
+| **10** | Equivalent to a published reference translation by a recognized literary translator (e.g. Lydia Davis, Penguin Classics, Pléiade). **Effectively unreachable** by an LLM in current state of the art. |
+| **9** | Excellent professional translation, non-literary tier. Could be published with light editing. Quibbles are stylistic, not factual. |
+| **8** | Very good. The reader gets the full meaning and tone, but loses 1–2 nuances or makes a faux-sens mineur. |
+| **7** | Good in the main, but 2–3 notable errors of register, idiom, or specialized terminology. A reader misses something they shouldn't. |
+| **6** | Comprehensible but clearly clumsy. Multiple problematic word choices. |
+| **5** | Usable only with editorial intervention. Real meaning errors or fluency breaks. |
+| **4** | Significantly impaired. Frequent contresens or sentence-level breakdowns. |
+| **3** | Passages incomprehensible or radically distorted. |
+| **2** | Mostly wrong, hallucinations dominant. |
+| **1** | Non-translation: wrong target language, source copied verbatim, refusal, or empty. |
+
+**Hard cap at 9.0** when no reference human translation is consulted. Reserve
+9.5–10 only when the judge has a published reference in front of them and the
+LLM output matches or surpasses it.
+
+---
+
+## 3. Penalty table — start from 10, deduct
+
+Apply these per detected issue. Multiple issues compound (additively) within a
+dimension. Cap the result at the anchor scale (no negative scores).
+
+### Accuracy penalties
+
+| Issue | Penalty |
+|---|---|
+| Contresens / radical meaning reversal on a key sentence | **−2.0** |
+| Hallucination of facts not in the source (place name, date, number) | **−2.0** |
+| Source word/phrase left untranslated in target (e.g. English "Providence" inside Chinese) | **−1.5** |
+| Significant omission (a clause or named entity dropped) | **−1.0** |
+| Specialized term wrong (botanical, marine, scientific, legal, etc.) | **−0.5** to **−1.0** |
+| Minor semantic drift on a non-load-bearing word | **−0.3** |
+
+### Fluency penalties
+
+| Issue | Penalty |
+|---|---|
+| Grammar error breaking the sentence | **−1.5** |
+| Mixed scripts in target (traditional chars in zh-Hans, Latin word inside CJK, etc.) | **−1.0** |
+| Awkward construction reading as machine-translated | **−0.5** to **−1.0** |
+| Wrong target-language punctuation (e.g. English quotes in French dialogue) | **−0.3** |
+| Pronoun inconsistency or unnecessary subject restatement | **−0.3** to **−0.5** |
+| Calque/anglicism that has a native equivalent | **−0.5** |
+
+### Style penalties
+
+| Issue | Penalty |
+|---|---|
+| Lost a signature rhetorical device (irony, parallelism, archaic register) | **−1.0** to **−1.5** |
+| Period-inappropriate vocabulary (modern slang in 19th-c. text) | **−1.0** |
+| Register flattened (formal → neutral, gnomic → narrative) | **−0.5** to **−1.0** |
+| Weakened idiom into bland equivalent | **−0.3** |
+
+---
+
+## 4. Overall — hard ceilings
+
+`overall` is the judge's holistic call, but constrained:
+
+- If `accuracy < 6.0` → `overall ≤ 6.0`. A translation that distorts meaning is not "good", whatever its prose.
+- If `fluency < 5.0` → `overall ≤ 6.0`. An unreadable translation is not usable.
+- If any dimension is `≤ 3.0` → `overall ≤ 4.0`.
+- `overall` should not exceed the **minimum** of `accuracy, fluency, style` by more than 0.5. (Prevents a high overall masking a single damning weakness.)
+- Without a published reference comparison, **`overall` cap is 9.0**.
+
+---
+
+## 5. Comparative dispersion (when judging multiple models on the same triple)
+
+When a judge scores N translations of the **same `(text_id, target_lang)`**
+triple from N different models, it must:
+
+1. **Rank** them 1st, 2nd, ... Nth.
+2. Reflect this ranking in the scores: minimum **0.3** points difference between adjacent ranks on `overall`.
+3. If two outputs are genuinely indistinguishable, they may share a rank — but document this in the feedback ("tied with model X").
+
+This forces the judge out of a flat "everything is 8" comfort zone.
+
+---
+
+## 6. Worked example
+
+**Source (English, *The Picture of Dorian Gray*, 1890):**
+> The studio was filled with the rich odour of roses, and when the light summer wind stirred amidst the trees of the garden, there came through the open door the heavy scent of the lilac, or the more delicate perfume of the pink-flowering thorn.
+
+**Translation (gemma3:27b → French):**
+> L'atelier était empli du riche parfum des roses, et lorsque la légère brise d'été s'agitait parmi les arbres du jardin, une lourde senteur de lilas, ou le parfum plus délicat de l'églantine rose, parvenait par la porte ouverte. Du coin du divan recouvert de sacs à dos persans sur lequel il était allongé...
+
+**Issues:**
+
+| Issue | Dimension | Penalty |
+|---|---|---|
+| `pink-flowering thorn` → `églantine rose` (wild rose, not hawthorn) | accuracy | −0.5 |
+| `Persian saddle-bags` → `sacs à dos persans` (= backpacks; should be "sacoches de selle") | accuracy | −1.0 |
+| `laburnum` left untranslated (FR = "cytise") | accuracy | −1.5 |
+| `miel-sucrées et miel-colorées` — clumsy compound coinage | fluency | −0.5 |
+| `sacs à dos` — modern term in late-19th-c. literary text | style | −0.5 |
+
+**Scores:**
+- accuracy: `10 − 0.5 − 1.0 − 1.5 = 7.0`
+- fluency: `10 − 0.5 = 9.5`, but capped at 9.0 (no reference). → **9.0**. Actually one bigger issue isn't there, so 9.0 is justified. Re-check: any awkwardness? The sentence reads but the compound is clunky → **8.5**.
+- style: `10 − 0.5 = 9.5` → cap at 9.0. The piece overall reads ornate. **8.5** to leave room for a better model.
+- overall: floor by min(7.0, 8.5, 8.5) + 0.5 = **7.0** seems right; the botanical/material errors are noticeable in a Wilde passage where the imagery IS the point.
+
+**Final:** `accuracy=7.0, fluency=8.5, style=8.5, overall=7.0`
+
+---
+
+## 7. Feedback field
+
+Each evaluation MUST include a 1–2 sentence `feedback` documenting the
+deductions. Future judges and contributors should be able to audit the score.
+Examples:
+
+- ✅ "Hallucinates 'Jongno' for 동소문; misreads 문안에 parenthetical as 'her grounds'. (−2.0 accuracy)"
+- ✅ "Gnomic Stoic register flattened to plain narrative; '为所欲为' for 'Do, soul, do' is a contresens. (−2.0 acc, −1.0 style)"
+- ❌ "Good translation overall." (no audit trail)
+- ❌ "Captures the meaning well." (no specifics)
+
+---
+
+## 8. Operational notes
+
+- **Don't average.** `overall` is a holistic call within the ceilings, not `(accuracy + fluency + style) / 3`.
+- **Don't be charitable to LLM output.** If a human professional wouldn't ship it, it isn't a 9.
+- **Be willing to use 5, 4, 3.** Most LLM outputs in cross-language pairs deserve 6–8. Reserve 9 for excellence.
+- **Re-test yourself.** Every 50 evaluations, re-judge 3 of your earliest scores. If they drift more than ±0.5 from your original, recalibrate.
+
+---
+
+## 9. Versioning
+
+- This is **v1**. Recorded as `claude-opus-4-7-rubric-v1` (or any `<judge-id>-rubric-v1`).
+- A `v2` rubric must be a separate document. Wiki tables surface the rubric version next to scores.
+- Submissions made under different rubric versions are aggregated separately on the wiki ("scores under rubric v1" / "scores under rubric v2"). Don't mix.

--- a/scripts/apply_evaluations.py
+++ b/scripts/apply_evaluations.py
@@ -1,0 +1,156 @@
+"""
+Apply manual evaluations (JSON array of {eval_id, scores}) back to a run.
+
+Reads the JSON reply produced by an evaluator (Claude Code session, manual
+review, anything else) and patches the corresponding `TranslationResult`
+entries in the run JSON. Idempotent: re-applying the same JSON is a no-op.
+
+Usage:
+    python scripts/apply_evaluations.py <run_id> <evaluations.json> [--judge-id NAME] [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from benchmark.config import BenchmarkConfig  # noqa: E402
+from benchmark.models import EvaluationScores  # noqa: E402
+from benchmark.results.storage import ResultsStorage  # noqa: E402
+
+
+def make_eval_id(text_id: str, target_lang: str, model: str) -> str:
+    raw = f"{text_id}|{target_lang}|{model}".encode("utf-8")
+    return hashlib.sha1(raw).hexdigest()[:10]
+
+
+def _load_evaluations(path: Path) -> list[dict]:
+    """Accept either a top-level JSON array, or a code-fenced JSON block, or a list field."""
+    raw = path.read_text(encoding="utf-8").strip()
+
+    # Strip markdown code fences if present
+    if raw.startswith("```"):
+        first_nl = raw.find("\n")
+        if first_nl != -1:
+            raw = raw[first_nl + 1:]
+        if raw.endswith("```"):
+            raw = raw[:-3]
+        raw = raw.strip()
+
+    data = json.loads(raw)
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for key in ("evaluations", "results", "scores"):
+            if key in data and isinstance(data[key], list):
+                return data[key]
+    raise ValueError(f"Could not extract a JSON array from {path}")
+
+
+def _validate_scores(scores: dict) -> tuple[bool, str]:
+    required = {"accuracy", "fluency", "style", "overall"}
+    missing = required - scores.keys()
+    if missing:
+        return False, f"missing keys: {sorted(missing)}"
+    for key in required:
+        v = scores[key]
+        if not isinstance(v, (int, float)) or not (1.0 <= float(v) <= 10.0):
+            return False, f"{key} must be in [1, 10], got {v}"
+    return True, ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("run_id", help="Benchmark run ID to update")
+    parser.add_argument("evaluations", type=Path, help="Path to the JSON file with evaluator scores")
+    parser.add_argument("--judge-id", help="Judge identity to record in run.evaluator_model")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would change, don't write")
+    parser.add_argument("--strict", action="store_true", help="Fail on unmatched eval_ids")
+    args = parser.parse_args()
+
+    config = BenchmarkConfig()
+    storage = ResultsStorage(config)
+    run = storage.load_run(args.run_id)
+    if run is None:
+        print(f"Run {args.run_id} not found.", file=sys.stderr)
+        return 1
+
+    if not args.evaluations.is_file():
+        print(f"Evaluations file not found: {args.evaluations}", file=sys.stderr)
+        return 1
+
+    try:
+        evals = _load_evaluations(args.evaluations)
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(f"Failed to parse {args.evaluations}: {exc}", file=sys.stderr)
+        return 1
+
+    # Index existing results by eval_id for fast patching.
+    by_id: dict[str, int] = {}
+    for idx, r in enumerate(run.results):
+        eid = make_eval_id(r.source_text_id, r.target_language, r.model)
+        by_id[eid] = idx
+
+    applied = 0
+    skipped_invalid = 0
+    skipped_missing = 0
+
+    for entry in evals:
+        eid = entry.get("eval_id")
+        scores = entry.get("scores")
+        if not eid or not isinstance(scores, dict):
+            skipped_invalid += 1
+            print(f"  [skip] malformed entry: {entry}", file=sys.stderr)
+            continue
+
+        ok, why = _validate_scores(scores)
+        if not ok:
+            skipped_invalid += 1
+            print(f"  [skip] {eid}: {why}", file=sys.stderr)
+            continue
+
+        if eid not in by_id:
+            skipped_missing += 1
+            msg = f"  [skip] no result with eval_id={eid}"
+            if args.strict:
+                print(msg + " (strict mode → failing)", file=sys.stderr)
+                return 1
+            print(msg, file=sys.stderr)
+            continue
+
+        result = run.results[by_id[eid]]
+        result.scores = EvaluationScores(
+            accuracy=float(scores["accuracy"]),
+            fluency=float(scores["fluency"]),
+            style=float(scores["style"]),
+            overall=float(scores["overall"]),
+            feedback=str(scores.get("feedback") or "").strip() or None,
+        )
+        applied += 1
+
+    if args.judge_id:
+        run.evaluator_model = args.judge_id
+
+    print(f"Applied: {applied}")
+    if skipped_invalid:
+        print(f"Skipped (invalid scores): {skipped_invalid}")
+    if skipped_missing:
+        print(f"Skipped (eval_id not found): {skipped_missing}")
+
+    if args.dry_run:
+        print("[dry-run] not writing changes.")
+        return 0
+
+    storage.save_run(run)
+    print(f"Run {run.run_id} saved.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/archive_v1_wiki.py
+++ b/scripts/archive_v1_wiki.py
@@ -1,0 +1,305 @@
+"""
+One-shot archive of the v1 benchmark wiki.
+
+Renames every existing Markdown page at the wiki root with an `Archive-`
+prefix, rewrites internal cross-page links inside those pages so they keep
+pointing to each other (not to the future v2 pages of the same name), and
+generates an `Archive-Index.md` landing page that lists the archived content.
+
+Run this BEFORE merging the v2 benchmark to `main`. After this commit on the
+wiki, the `publish-wiki` GitHub Action regenerates the standard pages
+(`Home.md`, `All-Languages.md`, etc.) which sit next to the `Archive-*` pages
+without colliding.
+
+Usage:
+
+    python scripts/archive_v1_wiki.py [--dry-run] [--no-push] [--message MSG]
+
+Environment:
+
+    WIKI_REPO_URL — wiki git URL. Defaults to the project's wiki repo.
+                    Use the form `https://x-access-token:<TOKEN>@github.com/<owner>/<repo>.wiki.git`
+                    to push without prompting for credentials.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_WIKI_URL = os.getenv(
+    "WIKI_REPO_URL",
+    "https://github.com/hydropix/TranslateBookWithLLM.wiki.git",
+)
+CLONE_DIR = REPO_ROOT / ".wiki_repo_archive"
+
+
+def run_git(args: list[str], cwd: Path, check: bool = True) -> subprocess.CompletedProcess:
+    """Run a git command in `cwd`. Exits on failure unless check=False."""
+    result = subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        capture_output=True,
+        text=True,
+    )
+    if check and result.returncode != 0:
+        print(f"git {' '.join(args)} failed:", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        sys.exit(1)
+    return result
+
+
+def clone_wiki(url: str, dest: Path) -> None:
+    if dest.exists():
+        shutil.rmtree(dest, ignore_errors=True)
+    print(f"Cloning {url} -> {dest}")
+    result = subprocess.run(
+        ["git", "clone", url, str(dest)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"Clone failed:\n{result.stderr}", file=sys.stderr)
+        print(
+            "If the wiki has no pages yet, create at least one page on GitHub "
+            "before running this script.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def list_v1_pages(wiki_dir: Path) -> list[Path]:
+    """Markdown files at the wiki root that are not already archived."""
+    return sorted(
+        p for p in wiki_dir.glob("*.md")
+        if p.is_file() and not p.name.startswith("Archive-")
+    )
+
+
+_LINK_RE = re.compile(r"\]\(([^)]+)\)")
+
+
+def rewrite_links(content: str, renamed_pages: dict[str, str]) -> str:
+    """
+    Inside a markdown body, replace `](Old-Page)` with `](Archive-Old-Page)`
+    when `Old-Page` is in `renamed_pages`.
+
+    Skips external URLs (anything containing `://`), anchors (`#...`),
+    and paths with slashes.
+    """
+
+    def replacer(match: re.Match[str]) -> str:
+        target = match.group(1).strip()
+        if not target or target.startswith("#") or "://" in target or "/" in target:
+            return match.group(0)
+        # Page references can have or omit `.md`. Normalize.
+        bare = target.removesuffix(".md")
+        if bare in renamed_pages:
+            new_target = renamed_pages[bare]
+            # Preserve `.md` suffix if it was there.
+            if target.endswith(".md"):
+                new_target = f"{new_target}.md"
+            return f"]({new_target})"
+        return match.group(0)
+
+    return _LINK_RE.sub(replacer, content)
+
+
+def build_index(archived: list[str]) -> str:
+    """Generate Archive-Index.md content from the list of archived filenames."""
+    home = [n for n in archived if n == "Archive-Home.md"]
+    overview = [
+        n for n in archived
+        if n in ("Archive-All-Languages.md", "Archive-All-Models.md")
+    ]
+    languages = sorted(n for n in archived if n.startswith("Archive-Language-"))
+    models = sorted(n for n in archived if n.startswith("Archive-Model-"))
+    others = sorted(
+        n for n in archived
+        if n not in (*home, *overview, *languages, *models)
+    )
+
+    lines: list[str] = [
+        "# Archived Benchmark (v1)",
+        "",
+        "These pages are the previous version of the TranslateBookWithLLM benchmark,",
+        "kept here for historical reference.",
+        "",
+        "## What changed in v2",
+        "",
+        "- **Stronger judge.** v1 used `gemini-3-flash-preview`; v2 uses Claude Opus 4.7 applying a formal rubric (`docs/JUDGE_RUBRIC.md`).",
+        "- **Multiple source languages.** v1 only translated from English. v2 covers 8 canonical pairs, including `ja:en`, `ko:en`, `zh-Hans:en`, and `ja:zh-Hans`.",
+        "- **17 reference texts** across literary, scientific, philosophical, narrative and essay registers (vs 5 19th-c. English novels in v1).",
+        "- **Aggregated scoring.** Multiple contributors can submit results for the same `(model, text, language)` triple; the wiki shows the median and the number of observations.",
+        "",
+        "For the current benchmark see [Home](Home).",
+        "",
+        "---",
+        "",
+        "## Archived pages",
+        "",
+    ]
+
+    if home:
+        lines.append("### Landing page")
+        lines.append("")
+        for n in home:
+            page = n.removesuffix(".md")
+            lines.append(f"- [Archived Home]({page})")
+        lines.append("")
+
+    if overview:
+        lines.append("### Cross-cutting tables")
+        lines.append("")
+        for n in overview:
+            page = n.removesuffix(".md")
+            label = (
+                page.replace("Archive-All-Languages", "All Languages")
+                    .replace("Archive-All-Models", "All Models")
+            )
+            lines.append(f"- [{label}]({page})")
+        lines.append("")
+
+    if languages:
+        lines.append("### Per-language pages")
+        lines.append("")
+        for n in languages:
+            page = n.removesuffix(".md")
+            label = page.replace("Archive-Language-", "").replace("-", " ").strip().title()
+            lines.append(f"- [{label}]({page})")
+        lines.append("")
+
+    if models:
+        lines.append("### Per-model pages")
+        lines.append("")
+        for n in models:
+            page = n.removesuffix(".md")
+            label = page.replace("Archive-Model-", "").replace("-", " ").strip()
+            lines.append(f"- [{label}]({page})")
+        lines.append("")
+
+    if others:
+        lines.append("### Other archived pages")
+        lines.append("")
+        for n in others:
+            page = n.removesuffix(".md")
+            lines.append(f"- [{page}]({page})")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def archive(wiki_dir: Path, *, dry_run: bool) -> int:
+    pages = list_v1_pages(wiki_dir)
+    if not pages:
+        print("No v1 pages to archive (no *.md at root, or all already prefixed).")
+        return 0
+
+    renamed: dict[str, str] = {p.stem: f"Archive-{p.stem}" for p in pages}
+
+    print(f"Found {len(pages)} v1 page(s) to archive:")
+    for p in pages:
+        print(f"  {p.name:40s} -> Archive-{p.name}")
+
+    if dry_run:
+        print()
+        print("[dry-run] no changes made.")
+        return len(pages)
+
+    # 1. Rewrite cross-references in every page that's about to be archived.
+    for p in pages:
+        original = p.read_text(encoding="utf-8")
+        rewritten = rewrite_links(original, renamed)
+        if rewritten != original:
+            p.write_text(rewritten, encoding="utf-8")
+
+    # 2. Rename the files.
+    archived_names: list[str] = []
+    for p in pages:
+        new_path = p.parent / f"Archive-{p.name}"
+        p.rename(new_path)
+        archived_names.append(new_path.name)
+
+    # 3. Generate the index.
+    index_content = build_index(archived_names)
+    (wiki_dir / "Archive-Index.md").write_text(index_content, encoding="utf-8")
+    archived_names.append("Archive-Index.md")
+
+    print()
+    print(f"Wrote Archive-Index.md and renamed {len(pages)} page(s).")
+    return len(pages)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Clone, list what would be archived, but make no changes.",
+    )
+    parser.add_argument(
+        "--no-push",
+        action="store_true",
+        help="Commit changes to the wiki clone but don't push.",
+    )
+    parser.add_argument(
+        "--message",
+        default="Archive v1 benchmark — renamed pages with Archive- prefix",
+        help="Commit message used on the wiki.",
+    )
+    parser.add_argument(
+        "--wiki-url",
+        default=DEFAULT_WIKI_URL,
+        help="Wiki git URL (defaults to project's wiki repo or $WIKI_REPO_URL).",
+    )
+    args = parser.parse_args()
+
+    clone_wiki(args.wiki_url, CLONE_DIR)
+
+    n_archived = archive(CLONE_DIR, dry_run=args.dry_run)
+    if args.dry_run:
+        print(f"\nClone left at {CLONE_DIR} for inspection. Re-run without --dry-run to apply.")
+        return 0
+
+    if n_archived == 0:
+        return 0
+
+    # Commit + push
+    run_git(["add", "-A"], CLONE_DIR)
+    status = run_git(["status", "--porcelain"], CLONE_DIR, check=False)
+    if not status.stdout.strip():
+        print("No changes to commit.")
+        return 0
+
+    run_git(["commit", "-m", args.message], CLONE_DIR)
+
+    if args.no_push:
+        print(f"\nCommitted in {CLONE_DIR}. Push manually when ready:")
+        print(f"  git -C {CLONE_DIR} push")
+        return 0
+
+    print("Pushing to wiki remote...")
+    push_result = run_git(["push"], CLONE_DIR, check=False)
+    if push_result.returncode != 0:
+        print("Push failed:", file=sys.stderr)
+        print(push_result.stderr, file=sys.stderr)
+        print(
+            "\nThe wiki is committed locally. Set WIKI_REPO_URL with a token "
+            "or push manually from "
+            f"{CLONE_DIR}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nDone. The wiki home is now `Home.md` (will be regenerated by the v2 publish workflow).")
+    print("Archived content lives under the `Archive-*` prefix and `Archive-Index.md`.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dump_for_evaluation.py
+++ b/scripts/dump_for_evaluation.py
@@ -1,0 +1,154 @@
+"""
+Dump the unscored translations of a benchmark run as a Markdown brief, ready
+to paste into a Claude conversation for manual evaluation.
+
+Each translation gets:
+  - a short stable `eval_id` (sha1 of source_text_id|target_lang|model, 10 chars)
+  - the source text + its declared challenges
+  - the translation produced by the model
+  - a one-line response template at the end
+
+The expected reply format is a single JSON array of objects, each with
+`eval_id` + `scores` (accuracy, fluency, style, overall, feedback). Save the
+reply to a file and feed it to `apply_evaluations.py`.
+
+Usage:
+    python scripts/dump_for_evaluation.py <run_id> [--batch-size N] [--out brief.md]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from benchmark.config import BenchmarkConfig  # noqa: E402
+from benchmark.data_loader import load_reference_texts  # noqa: E402
+from benchmark.results.storage import ResultsStorage  # noqa: E402
+
+
+def make_eval_id(text_id: str, target_lang: str, model: str) -> str:
+    raw = f"{text_id}|{target_lang}|{model}".encode("utf-8")
+    return hashlib.sha1(raw).hexdigest()[:10]
+
+
+def build_brief(run, ref_texts: dict, batch_size: int) -> list[str]:
+    """Return one Markdown blob per batch."""
+    pending = [r for r in run.results if r.success and r.translated_text and r.scores is None]
+    if not pending:
+        return []
+
+    batches: list[str] = []
+    for i in range(0, len(pending), batch_size):
+        chunk = pending[i:i + batch_size]
+        lines: list[str] = []
+        lines.append(f"# Evaluation brief — batch {i // batch_size + 1} of {(len(pending) + batch_size - 1) // batch_size}")
+        lines.append("")
+        lines.append(f"Run: `{run.run_id}` — {len(chunk)} translation(s) to score")
+        lines.append("")
+        lines.append("**Rubric** (1.0–10.0 each, decimals allowed):")
+        lines.append("- `accuracy` — preservation of meaning, no additions or omissions")
+        lines.append("- `fluency` — natural target-language phrasing, grammar, idiomaticity")
+        lines.append("- `style` — register, tone, literary voice, period vocabulary fidelity")
+        lines.append("- `overall` — global judgement (not the average; your weighted call)")
+        lines.append("- `feedback` — 1–2 sentences explaining the overall score")
+        lines.append("")
+        lines.append("---")
+        lines.append("")
+
+        for r in chunk:
+            ref = ref_texts.get(r.source_text_id)
+            eval_id = make_eval_id(r.source_text_id, r.target_language, r.model)
+            lines.append(f"## eval_id: `{eval_id}`")
+            lines.append("")
+            lines.append(f"- **text_id**: `{r.source_text_id}` — *{ref.title if ref else '?'}* ({ref.author if ref else '?'}, {ref.year if ref else '?'})")
+            lines.append(f"- **source_lang**: `{ref.source_language if ref else '?'}`")
+            lines.append(f"- **target_lang**: `{r.target_language}`")
+            lines.append(f"- **model**: `{r.model}`")
+            if ref and ref.challenges:
+                lines.append(f"- **challenges to weigh**: {'; '.join(ref.challenges)}")
+            lines.append("")
+            lines.append("### Source")
+            lines.append("```")
+            lines.append((ref.content if ref else "<missing reference>").strip())
+            lines.append("```")
+            lines.append("")
+            lines.append("### Translation")
+            lines.append("```")
+            lines.append(r.translated_text.strip())
+            lines.append("```")
+            lines.append("")
+
+        lines.append("---")
+        lines.append("")
+        lines.append("## Reply format")
+        lines.append("")
+        lines.append("Respond **only** with a JSON array, one object per `eval_id`:")
+        lines.append("")
+        lines.append("```json")
+        lines.append("[")
+        for r in chunk:
+            eval_id = make_eval_id(r.source_text_id, r.target_language, r.model)
+            lines.append('  {"eval_id": "' + eval_id + '", "scores": {"accuracy": 0.0, "fluency": 0.0, "style": 0.0, "overall": 0.0, "feedback": ""}},')
+        # Strip trailing comma on the last entry for valid JSON
+        if lines[-1].endswith(","):
+            lines[-1] = lines[-1][:-1]
+        lines.append("]")
+        lines.append("```")
+        lines.append("")
+        batches.append("\n".join(lines))
+
+    return batches
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("run_id", help="Benchmark run ID to dump")
+    parser.add_argument("--batch-size", type=int, default=15, help="Translations per Markdown batch (default: 15)")
+    parser.add_argument("--out", type=Path, help="Write to this file/prefix instead of stdout. With multiple batches, '_batch1.md' etc. are appended.")
+    args = parser.parse_args()
+
+    config = BenchmarkConfig()
+    storage = ResultsStorage(config)
+    run = storage.load_run(args.run_id)
+    if run is None:
+        print(f"Run {args.run_id} not found.", file=sys.stderr)
+        return 1
+
+    ref_texts = load_reference_texts(
+        base_dir=config.paths.base_dir,
+        legacy_file=config.paths.reference_texts_file,
+    )
+
+    batches = build_brief(run, ref_texts, args.batch_size)
+
+    if not batches:
+        print("No unscored successful translations to evaluate.")
+        return 0
+
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        if len(batches) == 1:
+            args.out.write_text(batches[0], encoding="utf-8")
+            print(f"Wrote {args.out} ({len(batches[0])} chars)")
+        else:
+            stem = args.out.with_suffix("")
+            for i, b in enumerate(batches, start=1):
+                p = stem.with_name(f"{stem.name}_batch{i}{args.out.suffix}")
+                p.write_text(b, encoding="utf-8")
+                print(f"Wrote {p}")
+    else:
+        for i, b in enumerate(batches):
+            if i > 0:
+                print("\n\n" + "=" * 80 + "\n\n")
+            print(b)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migrate_yaml.py
+++ b/scripts/migrate_yaml.py
@@ -1,0 +1,162 @@
+"""
+One-shot migration: split monolithic benchmark YAML files into per-entry files.
+
+Reads:
+  - benchmark/languages.yaml         (categorized list of languages)
+  - benchmark/reference_texts.yaml   (list of reference texts)
+
+Writes:
+  - benchmark/data/languages/<code>.yaml
+  - benchmark/data/reference_texts/<source_lang>/<id>.yaml
+
+Idempotent: re-running overwrites existing files with the latest source.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LEGACY_LANGUAGES = REPO_ROOT / "benchmark" / "languages.yaml"
+LEGACY_REFERENCE_TEXTS = REPO_ROOT / "benchmark" / "reference_texts.yaml"
+DATA_DIR = REPO_ROOT / "benchmark" / "data"
+LANGUAGES_OUT = DATA_DIR / "languages"
+REFERENCE_TEXTS_OUT = DATA_DIR / "reference_texts"
+
+
+_LANG_TO_CODE = {
+    "english": "en",
+    "french": "fr",
+    "german": "de",
+    "spanish": "es",
+    "italian": "it",
+    "portuguese": "pt",
+    "japanese": "ja",
+    "chinese": "zh-Hans",
+}
+
+
+def _normalize_source_language(value: str) -> str:
+    """Accept either a language code or a language name; return a code."""
+    if not value:
+        return "en"
+    v = value.strip()
+    if len(v) <= 8 and "-" in v or (len(v) <= 3 and v.isalpha()):
+        # Looks like a code already.
+        return v
+    return _LANG_TO_CODE.get(v.lower(), v.lower()[:2])
+
+
+def split_languages(src: Path, dst_dir: Path) -> int:
+    if not src.exists():
+        print(f"[skip] languages source not found: {src}", file=sys.stderr)
+        return 0
+
+    with src.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    count = 0
+
+    for cat_key, cat_data in (data.get("categories") or {}).items():
+        for lang in cat_data.get("languages") or []:
+            entry = {
+                "code": str(lang["code"]),
+                "name": lang["name"],
+                "native_name": lang.get("native_name", lang["name"]),
+                "script": lang.get("script", "Latin"),
+                "category": cat_key,
+                "rtl": bool(lang.get("rtl", False)),
+            }
+            if "difficulty" in lang:
+                entry["difficulty"] = lang["difficulty"]
+
+            out_path = dst_dir / f"{entry['code']}.yaml"
+            with out_path.open("w", encoding="utf-8") as f:
+                yaml.safe_dump(entry, f, allow_unicode=True, sort_keys=False)
+            count += 1
+
+    return count
+
+
+def split_reference_texts(src: Path, dst_dir: Path) -> int:
+    if not src.exists():
+        print(f"[skip] reference texts source not found: {src}", file=sys.stderr)
+        return 0
+
+    with src.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    count = 0
+
+    for text in data.get("texts") or []:
+        source_lang = _normalize_source_language(text.get("source_language", "en"))
+        text_id = text["id"]
+
+        entry = {
+            "id": text_id,
+            "title": text["title"],
+            "author": text.get("author", "Unknown"),
+            "year": text.get("year"),
+            "source_language": source_lang,
+            "style": text.get("style", ""),
+            "challenges": list(text.get("challenges", [])),
+            "text": text["text"].strip(),
+            "license": text.get("license", "public-domain"),
+        }
+        if "era" in text:
+            entry["era"] = text["era"]
+        if "character_count" in text:
+            entry["character_count"] = text["character_count"]
+
+        lang_dir = dst_dir / source_lang
+        lang_dir.mkdir(parents=True, exist_ok=True)
+
+        out_path = lang_dir / f"{text_id}.yaml"
+        with out_path.open("w", encoding="utf-8") as f:
+            yaml.safe_dump(entry, f, allow_unicode=True, sort_keys=False, width=4096)
+        count += 1
+
+    return count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--languages-src",
+        type=Path,
+        default=LEGACY_LANGUAGES,
+        help="Path to the legacy languages YAML.",
+    )
+    parser.add_argument(
+        "--reference-texts-src",
+        type=Path,
+        default=LEGACY_REFERENCE_TEXTS,
+        help="Path to the legacy reference_texts YAML.",
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=DATA_DIR,
+        help="Destination data directory.",
+    )
+    args = parser.parse_args()
+
+    languages_dir = args.data_dir / "languages"
+    reference_texts_dir = args.data_dir / "reference_texts"
+
+    n_lang = split_languages(args.languages_src, languages_dir)
+    n_text = split_reference_texts(args.reference_texts_src, reference_texts_dir)
+
+    print(f"Wrote {n_lang} language files to {languages_dir}")
+    print(f"Wrote {n_text} reference text files to {reference_texts_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/replay_submission.py
+++ b/scripts/replay_submission.py
@@ -1,0 +1,308 @@
+"""
+Replay a sample of submitted benchmark results to detect divergence.
+
+For cloud providers (openai, openrouter, gemini, mistral, deepseek, poe, nim):
+    1. Pick a random `--sample-pct` of results from each submission.
+    2. Re-translate the same source text with the same provider/model.
+    3. Compare the new output to the submitted output via chrF; compare the
+       newly judged overall score to the submitted overall score.
+    4. Flag a result as divergent if chrF < `--chrf-threshold` *and* the score
+       diff exceeds `--max-divergence`.
+
+For local providers (ollama, or anything else): full replay isn't possible from
+CI, so we do cheap sanity checks instead:
+    - `langdetect` says the output is in the claimed target language.
+    - The output length is within [50%, 200%] of the source length.
+    - The submission is annotated `self_reported: true` in the report.
+
+Outputs a Markdown report at `--report` (default `replay_report.md`). Exits
+non-zero when too many divergences are detected.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import random
+import statistics
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from benchmark.aggregator import CLOUD_PROVIDERS  # noqa: E402
+from benchmark.data_loader import load_reference_texts  # noqa: E402
+
+
+def _chrf(reference: str, candidate: str, n: int = 4) -> float:
+    """A lightweight chrF score (character n-gram F1, n=1..n)."""
+    if not reference or not candidate:
+        return 0.0
+
+    ref = reference.replace("\n", " ").strip()
+    cand = candidate.replace("\n", " ").strip()
+    if ref == cand:
+        return 1.0
+
+    f_scores = []
+    for k in range(1, n + 1):
+        ref_ngrams = Counter(ref[i:i + k] for i in range(len(ref) - k + 1))
+        cand_ngrams = Counter(cand[i:i + k] for i in range(len(cand) - k + 1))
+        if not ref_ngrams or not cand_ngrams:
+            continue
+        common = sum((ref_ngrams & cand_ngrams).values())
+        if common == 0:
+            f_scores.append(0.0)
+            continue
+        precision = common / sum(cand_ngrams.values())
+        recall = common / sum(ref_ngrams.values())
+        f_scores.append(2 * precision * recall / (precision + recall))
+
+    return sum(f_scores) / len(f_scores) if f_scores else 0.0
+
+
+def _check_language(text: str, expected_code: str) -> tuple[bool, str]:
+    try:
+        from langdetect import detect, DetectorFactory  # type: ignore
+        DetectorFactory.seed = 0
+    except ImportError:
+        return True, "langdetect-missing"
+
+    try:
+        detected = detect(text)
+    except Exception as exc:  # langdetect raises a generic exception on failure
+        return False, f"detect-failed:{exc}"
+
+    expected = expected_code.split("-")[0].lower()
+    if detected.lower().startswith(expected):
+        return True, detected
+    return False, detected
+
+
+def _length_plausibility(source: str, output: str) -> bool:
+    if not source:
+        return True
+    ratio = len(output) / max(1, len(source))
+    return 0.5 <= ratio <= 2.0
+
+
+def _load_reference(text_id: str, ref_texts) -> Optional[object]:
+    return ref_texts.get(text_id)
+
+
+async def _replay_cloud_sample(
+    submission: dict,
+    sample: list[dict],
+    ref_texts: dict,
+    chrf_threshold: float,
+    max_divergence: float,
+) -> list[dict]:
+    """Re-run translation+evaluation for cloud-provider submissions."""
+    from benchmark.config import BenchmarkConfig
+    from benchmark.evaluator import TranslationEvaluator
+    from benchmark.translator import BenchmarkTranslator, TranslationRequest
+
+    provider = submission["model"]["provider"]
+    model_id = submission["model"]["id"]
+    judge_id = submission.get("environment", {}).get("judge_id", "")
+
+    config = BenchmarkConfig.from_cli_args(
+        translation_provider=provider if provider in {"ollama", "openai", "openrouter"} else "openrouter",
+    )
+
+    translator = BenchmarkTranslator(config, provider_type=config.translation_provider)
+    evaluator = TranslationEvaluator(config, provider=config.evaluator_provider)
+
+    findings: list[dict] = []
+    try:
+        for r in sample:
+            ref = _load_reference(r["text_id"], ref_texts)
+            if ref is None:
+                findings.append({
+                    "text_id": r["text_id"],
+                    "target_lang": r["target_lang"],
+                    "status": "missing-reference",
+                })
+                continue
+
+            req = TranslationRequest(
+                text=ref,
+                target_language=r["target_lang"],
+                target_language_name=r["target_lang"],
+                model=model_id,
+            )
+
+            replay = await translator.translate(req)
+
+            if not replay.success:
+                findings.append({
+                    "text_id": r["text_id"],
+                    "target_lang": r["target_lang"],
+                    "status": "translation-failed",
+                    "error": replay.error,
+                })
+                continue
+
+            replay_scores, _ = await evaluator.evaluate(
+                source_text=ref,
+                translated_text=replay.translated_text,
+                target_language=r["target_lang"],
+                target_language_name=r["target_lang"],
+            )
+
+            chrf = _chrf(r["output"], replay.translated_text)
+            score_diff = abs(replay_scores.overall - r["scores"]["overall"])
+            divergent = chrf < chrf_threshold and score_diff > max_divergence
+
+            findings.append({
+                "text_id": r["text_id"],
+                "target_lang": r["target_lang"],
+                "status": "divergent" if divergent else "ok",
+                "chrf": round(chrf, 3),
+                "submitted_overall": r["scores"]["overall"],
+                "replay_overall": round(replay_scores.overall, 2),
+                "score_diff": round(score_diff, 2),
+                "judge_id": judge_id,
+            })
+    finally:
+        await translator.close()
+        await evaluator.close()
+
+    return findings
+
+
+def _heuristic_sample(
+    submission: dict,
+    sample: list[dict],
+    ref_texts: dict,
+) -> list[dict]:
+    """Sanity checks for non-replayable submissions (e.g. local Ollama)."""
+    findings: list[dict] = []
+    for r in sample:
+        ref = _load_reference(r["text_id"], ref_texts)
+        source = ref.content if ref is not None else ""
+        ok_lang, detected = _check_language(r["output"], r["target_lang"])
+        ok_len = _length_plausibility(source, r["output"])
+        status = "ok" if (ok_lang and ok_len) else "suspicious"
+        findings.append({
+            "text_id": r["text_id"],
+            "target_lang": r["target_lang"],
+            "status": status,
+            "lang_detected": detected,
+            "lang_ok": ok_lang,
+            "length_ok": ok_len,
+        })
+    return findings
+
+
+def _render_report(submissions_report: list[dict]) -> str:
+    out = ["# Replay Report", ""]
+    for entry in submissions_report:
+        out.append(f"## `{entry['file']}`")
+        out.append("")
+        out.append(f"- Submitted by: `{entry['submitted_by']}`")
+        out.append(f"- Provider: `{entry['provider']}`")
+        out.append(f"- Model: `{entry['model_id']}`")
+        out.append(f"- Verified mode: `{entry['mode']}`")
+        out.append(f"- Sampled: {entry['n_sampled']} / {entry['n_total']} results")
+        out.append(f"- Divergent / suspicious: {entry['n_divergent']}")
+        if entry["mode"] == "self_reported":
+            out.append("- _Marked as self-reported in the wiki because the model is not replayable in CI._")
+
+        if entry["findings"]:
+            out.append("")
+            out.append("| text | lang | status | details |")
+            out.append("|------|------|--------|---------|")
+            for f in entry["findings"]:
+                details = ", ".join(f"{k}={v}" for k, v in f.items() if k not in {"text_id", "target_lang", "status"})
+                out.append(f"| {f['text_id']} | {f['target_lang']} | {f['status']} | {details} |")
+        out.append("")
+    return "\n".join(out) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--files", nargs="+", required=True, help="Submission JSON files to replay.")
+    parser.add_argument("--sample-pct", type=float, default=10.0, help="Percent of results to sample per file (1-100).")
+    parser.add_argument("--max-divergence", type=float, default=1.0, help="Score diff threshold above which a result is flagged.")
+    parser.add_argument("--chrf-threshold", type=float, default=0.85, help="chrF threshold below which outputs differ significantly.")
+    parser.add_argument("--max-divergence-rate", type=float, default=0.34, help="Fail when more than this fraction of sampled results diverge.")
+    parser.add_argument("--report", default="replay_report.md", help="Where to write the Markdown report.")
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    random.seed(args.seed)
+    sample_ratio = max(0.0, min(1.0, args.sample_pct / 100.0))
+
+    ref_texts = load_reference_texts(
+        base_dir=REPO_ROOT / "benchmark",
+        legacy_file=REPO_ROOT / "benchmark" / "reference_texts.yaml",
+    )
+
+    submissions_report: list[dict] = []
+    fail_overall = False
+
+    for file_str in args.files:
+        path = Path(file_str)
+        if not path.is_file():
+            print(f"[skip] {path}: not found", file=sys.stderr)
+            continue
+
+        with path.open("r", encoding="utf-8") as f:
+            submission = json.load(f)
+
+        results = submission.get("results", [])
+        if not results:
+            continue
+
+        provider = submission["model"]["provider"]
+        is_cloud = provider in CLOUD_PROVIDERS
+
+        n_sample = max(1, int(round(len(results) * sample_ratio)))
+        sample = random.sample(results, min(n_sample, len(results)))
+
+        if is_cloud:
+            mode = "verified"
+            findings = asyncio.run(_replay_cloud_sample(
+                submission, sample, ref_texts,
+                chrf_threshold=args.chrf_threshold,
+                max_divergence=args.max_divergence,
+            ))
+            divergent = [f for f in findings if f["status"] == "divergent"]
+        else:
+            mode = "self_reported"
+            findings = _heuristic_sample(submission, sample, ref_texts)
+            divergent = [f for f in findings if f["status"] != "ok"]
+
+        rate = len(divergent) / len(sample) if sample else 0
+        if mode == "verified" and rate > args.max_divergence_rate:
+            fail_overall = True
+
+        submissions_report.append({
+            "file": str(path),
+            "submitted_by": submission.get("submission", {}).get("submitted_by", "unknown"),
+            "provider": provider,
+            "model_id": submission["model"]["id"],
+            "mode": mode,
+            "n_total": len(results),
+            "n_sampled": len(sample),
+            "n_divergent": len(divergent),
+            "findings": findings,
+        })
+
+    Path(args.report).write_text(_render_report(submissions_report), encoding="utf-8")
+    print(f"Report written to {args.report}")
+
+    if fail_overall:
+        print("Replay detected too many divergences for at least one submission.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/submission_to_run.py
+++ b/scripts/submission_to_run.py
@@ -1,0 +1,156 @@
+"""
+Reconstruct a `benchmark_results/<RUN_ID>.json` from an existing submission.
+
+Use case: re-evaluate a historical submission with a stronger / newer judge,
+without re-running the translations. The script preserves the model outputs
+verbatim and clears the scores so the standard `dump_for_evaluation.py` →
+score → `apply_evaluations.py` → `submit` pipeline applies as usual, but
+produces a new submission with a different `judge_id`.
+
+Usage:
+    python scripts/submission_to_run.py benchmark/data/submissions/<file>.json
+    python scripts/submission_to_run.py <file>.json --out-id mycustom2026
+
+The reconstructed run is written under `benchmark_results/<RUN_ID>.json`. The
+script prints the chosen RUN_ID on the last line so it can be captured by a
+wrapper or a Claude skill.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from benchmark.config import BenchmarkConfig  # noqa: E402
+from benchmark.models import (  # noqa: E402
+    BenchmarkRun,
+    TranslationResult,
+)
+
+
+def _validate_submission(submission: dict) -> list[str]:
+    """Best-effort schema check; returns a list of error strings."""
+    schema_path = REPO_ROOT / "benchmark" / "schemas" / "submission.schema.json"
+    if not schema_path.is_file():
+        return [f"Schema file missing: {schema_path}"]
+
+    try:
+        import jsonschema
+    except ImportError:
+        return ["WARN: jsonschema not installed; skipping schema validation"]
+
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    validator = jsonschema.Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(submission), key=lambda e: list(e.absolute_path))
+    return [
+        f"{'/'.join(str(p) for p in err.absolute_path) or '<root>'}: {err.message}"
+        for err in errors
+    ]
+
+
+def submission_to_run(
+    submission: dict,
+    *,
+    run_id: str,
+) -> BenchmarkRun:
+    """Build a BenchmarkRun whose results carry the submission's outputs but no scores."""
+    model_id = submission["model"]["id"]
+    provider = submission["model"]["provider"]
+    submitted_by = submission.get("submission", {}).get("submitted_by", "unknown")
+    original_judge = submission.get("environment", {}).get("judge_id", "unknown")
+
+    target_codes = sorted({r["target_lang"] for r in submission["results"]})
+
+    now = datetime.now(timezone.utc).isoformat()
+    run = BenchmarkRun(
+        run_id=run_id,
+        started_at=now,
+        completed_at=now,
+        models=[model_id],
+        languages=target_codes,
+        evaluator_model="skipped",
+        results=[],
+        status="completed",
+    )
+
+    note = (
+        f"reconstructed from submission by {submitted_by} "
+        f"(original judge: {original_judge})"
+    )
+
+    for r in submission["results"]:
+        run.results.append(TranslationResult(
+            source_text_id=r["text_id"],
+            target_language=r["target_lang"],
+            model=model_id,
+            translated_text=r["output"],
+            scores=None,
+            translation_time_ms=int(r.get("translation_latency_ms") or 0),
+            evaluation_time_ms=0,
+            timestamp=now,
+            error=None,
+            n_obs=1,
+            verified=(provider != "ollama"),
+            contributors=[submitted_by],
+        ))
+
+    return run
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("submission", type=Path, help="Path to the submission JSON to rescore")
+    parser.add_argument("--out-id", help="Custom run_id for the reconstructed run (default: random 8-hex)")
+    parser.add_argument("--allow-invalid", action="store_true", help="Skip schema validation of the source submission")
+    args = parser.parse_args()
+
+    if not args.submission.is_file():
+        print(f"Submission file not found: {args.submission}", file=sys.stderr)
+        return 1
+
+    try:
+        with args.submission.open("r", encoding="utf-8") as f:
+            submission = json.load(f)
+    except json.JSONDecodeError as exc:
+        print(f"Failed to parse submission JSON: {exc}", file=sys.stderr)
+        return 1
+
+    if not args.allow_invalid:
+        errors = _validate_submission(submission)
+        # The first item may be a "WARN:" line meaning jsonschema isn't installed.
+        if errors and not errors[0].startswith("WARN:"):
+            print(f"Submission failed schema validation ({len(errors)} error(s)):", file=sys.stderr)
+            for err in errors[:10]:
+                print(f"  - {err}", file=sys.stderr)
+            print("Use --allow-invalid to bypass.", file=sys.stderr)
+            return 1
+        elif errors:
+            print(errors[0], file=sys.stderr)
+
+    run_id = args.out_id or uuid.uuid4().hex[:8]
+    run = submission_to_run(submission, run_id=run_id)
+
+    config = BenchmarkConfig()
+    out_path = config.paths.results_dir / f"{run.run_id}.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(run.to_json(), encoding="utf-8")
+
+    print(f"Reconstructed {len(run.results)} result(s) from {args.submission.name}")
+    print(f"Original judge:    {submission.get('environment', {}).get('judge_id', 'unknown')}")
+    print(f"Original model:    {submission['model']['id']} ({submission['model']['provider']})")
+    print(f"Languages covered: {', '.join(run.languages)}")
+    print(f"Run JSON:          {out_path}")
+    print()
+    print(f"RUN_ID={run.run_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -1,0 +1,87 @@
+"""
+Validate one or more benchmark submission JSON files against the schema.
+
+Usage:
+    python scripts/validate_submission.py path/to/sub1.json [path/to/sub2.json ...]
+
+Exit code 0 if all submissions are valid, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Iterable
+
+import jsonschema
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = REPO_ROOT / "benchmark" / "schemas" / "submission.schema.json"
+
+
+def _load_schema() -> dict:
+    with SCHEMA_PATH.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _format_error(err: jsonschema.ValidationError) -> str:
+    location = "/".join(str(p) for p in err.absolute_path) or "<root>"
+    return f"{location}: {err.message}"
+
+
+def validate(path: Path, validator: jsonschema.Draft202012Validator) -> list[str]:
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        return [f"Failed to read JSON: {exc}"]
+
+    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path))
+    return [_format_error(e) for e in errors]
+
+
+def run(paths: Iterable[Path]) -> int:
+    schema = _load_schema()
+    validator = jsonschema.Draft202012Validator(schema)
+
+    failed = 0
+    paths = list(paths)
+    if not paths:
+        print("No submission files provided.")
+        return 0
+
+    for path in paths:
+        if not path.is_file():
+            print(f"[FAIL] {path}: file not found")
+            failed += 1
+            continue
+
+        errors = validate(path, validator)
+        if errors:
+            print(f"[FAIL] {path} ({len(errors)} error(s)):")
+            for err in errors[:25]:
+                print(f"  - {err}")
+            if len(errors) > 25:
+                print(f"  ... and {len(errors) - 25} more")
+            failed += 1
+        else:
+            print(f"[OK]   {path}")
+
+    if failed:
+        print(f"\n{failed} of {len(paths)} submission(s) failed validation.")
+        return 1
+    print(f"\nAll {len(paths)} submission(s) are valid.")
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 0
+    paths = [Path(p) for p in sys.argv[1:]]
+    return run(paths)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Complete rework of the benchmark system. Lives in parallel with v1 — **the wiki workflow is gated on push to main, so this branch does not affect the live wiki**.

## What's in

**Data layout**
- Split monolithic YAMLs into per-entry files under `benchmark/data/`
- 17 reference texts across 6 source languages (en, fr, de, es, ja, ko, zh-Hans)
- 45 target languages
- New `benchmark/data/submissions/` for community contributions

**Schemas + validation**
- 4 JSON Schema files (submission, language, reference_text, model)
- `scripts/validate_submission.py` for local + CI checks

**CLI**
- `--pairs` flag (source:target) replaces en-only `--languages`
- `--no-evaluate` for manual judging workflows
- Poe added as a translation provider
- New `submit` and `aggregate-submissions` commands

**Manual evaluation pipeline**
- `scripts/dump_for_evaluation.py` — dumps a brief for a human/LLM judge
- `scripts/apply_evaluations.py` — patches a run with judge scores
- `scripts/submission_to_run.py` — re-evaluate a historical submission

**Aggregation + wiki**
- `benchmark/aggregator.py` merges submissions via median, exposes `n_obs` and verified/self-reported badges
- Wiki templates updated to surface those columns

**GitHub Actions**
- `validate-submission.yml` — schema validation + replay sampling on PR
- `publish-wiki.yml` — regenerates wiki on merge to main

**Documentation**
- `docs/JUDGE_RUBRIC.md` — formal scoring rubric v1 (anchored 1-10 scale, penalty table, hard ceilings)
- `docs/BENCHMARK_WORKFLOW.md` — end-to-end procedure
- `docs/CONTRIBUTING_BENCHMARK.md` — contributor guide

## Status

Draft. Iterating on:
- [ ] Run benchmark on the 4 chosen models (gemma3:27b done, gemini-3-flash-preview / mistral-medium-3.1 / gpt-5-mini pending)
- [ ] Decide wiki cohabitation strategy (V1 archive prefix vs namespace)
- [ ] Validate the publish-wiki workflow on a test wiki before merge

## Test plan
- [x] All 18 reference texts load and pass JSON Schema
- [x] CLI `--pairs` and `--no-evaluate` flags work end-to-end
- [x] Submit → aggregate → wiki pipeline tested with a synthetic submission
- [x] `submission_to_run.py` reconstructs a re-evaluable run JSON from a submission
- [x] Aggregator merges 2 observations on the same triple with `n_obs=2` and median scores
- [ ] Real run end-to-end (gemma3:27b done, awaiting Poe runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)