### PR TITLE
Fix EPUB NCX TOC translation and update DeepSeek defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,11 +85,12 @@ MISTRAL_MODEL=mistral-large-latest
 # DeepSeek Settings (Chinese LLM, very cost-effective)
 # Get your API key at: https://platform.deepseek.com/
 DEEPSEEK_API_KEY=
-DEEPSEEK_MODEL=deepseek-chat
-# Available models: deepseek-chat (V3, fast, 64K), deepseek-v4-flash, deepseek-v4-pro
+DEEPSEEK_MODEL=deepseek-v4-pro
+# Available models: deepseek-v4-pro, deepseek-v4-flash
+# Legacy aliases deepseek-chat and deepseek-reasoner are scheduled for deprecation on 2026-07-24.
 # DEEPSEEK_API_ENDPOINT=https://api.deepseek.com/chat/completions  # Optional, default endpoint
-# V4 models (deepseek-v4-*) enable thinking by default, wasting ~10-25x tokens on
-# translation. Leave true to disable it; set false to keep reasoning enabled.
+# V4 models (deepseek-v4-*) support thinking mode. Leave true to disable it for translation;
+# set false to keep reasoning enabled.
 DEEPSEEK_DISABLE_THINKING=true
 
 # Poe Settings (Multi-provider access: Claude, GPT, Gemini, Llama, Grok, and more)

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ python translate.py -i book.txt --provider mistral \
 
 # With DeepSeek
 python translate.py -i book.txt --provider deepseek \
-    --deepseek_api_key YOUR_KEY -m deepseek-chat -tl French
+    --deepseek_api_key YOUR_KEY -m deepseek-v4-pro -tl French
 
 # With Poe
 python translate.py -i book.txt --provider poe \

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -137,7 +137,7 @@ python translate.py -i book.txt -o book_fr.txt \
 python translate.py -i book.txt -o book_fr.txt \
     --provider deepseek \
     --deepseek_api_key xxx \
-    -m deepseek-chat
+    -m deepseek-v4-pro
 
 # Poe
 python translate.py -i book.txt -o book_fr.txt \

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -192,7 +192,9 @@ Chinese LLM provider with 64K context and OpenAI-compatible API. Supports thinki
 
 ### Models
 
-- `deepseek-chat` — general chat (V3)
+- `deepseek-v4-pro` — high-quality model
+- `deepseek-v4-flash` — faster economical model
+- `deepseek-chat` — legacy alias scheduled for deprecation on 2026-07-24
 - `deepseek-reasoner` — reasoning model with `<think>` blocks
 
 ### Setup
@@ -206,7 +208,7 @@ Chinese LLM provider with 64K context and OpenAI-compatible API. Supports thinki
 python translate.py -i book.txt -o book_fr.txt \
     --provider deepseek \
     --deepseek_api_key your-key \
-    -m deepseek-chat
+    -m deepseek-v4-pro
 ```
 
 Pricing: [api-docs.deepseek.com/quick_start/pricing](https://api-docs.deepseek.com/quick_start/pricing)

--- a/src/api/blueprints/config_routes.py
+++ b/src/api/blueprints/config_routes.py
@@ -314,8 +314,8 @@ def create_config_blueprint(server_session_id=None):
         """Get available models from DeepSeek API"""
         api_key = _resolve_api_key(provided_api_key, 'DEEPSEEK_API_KEY', _config.DEEPSEEK_API_KEY)
 
-        # Use DEEPSEEK_MODEL from .env, fallback to deepseek-chat
-        default_model = _config.DEEPSEEK_MODEL if _config.DEEPSEEK_MODEL else "deepseek-chat"
+        # Use DEEPSEEK_MODEL from .env, fallback to the current DeepSeek recommended model.
+        default_model = _config.DEEPSEEK_MODEL if _config.DEEPSEEK_MODEL else "deepseek-v4-pro"
 
         if not api_key:
             return jsonify({

--- a/src/config.py
+++ b/src/config.py
@@ -101,7 +101,7 @@ _RELOADABLE_ENV_SETTINGS = (
     ('MISTRAL_API_KEY',     'MISTRAL_API_KEY',     ''),
     ('MISTRAL_MODEL',       'MISTRAL_MODEL',       'mistral-large-latest'),
     ('DEEPSEEK_API_KEY',    'DEEPSEEK_API_KEY',    ''),
-    ('DEEPSEEK_MODEL',      'DEEPSEEK_MODEL',      'deepseek-chat'),
+    ('DEEPSEEK_MODEL',      'DEEPSEEK_MODEL',      'deepseek-v4-pro'),
     ('POE_API_KEY',         'POE_API_KEY',         ''),
     ('POE_MODEL',           'POE_MODEL',           'Claude-Sonnet-4'),
     ('NIM_API_KEY',         'NIM_API_KEY',         ''),

--- a/src/core/epub/translator.py
+++ b/src/core/epub/translator.py
@@ -16,6 +16,7 @@ import tempfile
 import aiofiles
 from typing import Dict, Any, Optional, Callable, Tuple, List
 from pathlib import Path
+from urllib.parse import unquote
 from lxml import etree
 
 from src.config import (
@@ -198,6 +199,15 @@ async def translate_epub_file(
 
             # 4. Save translated files
             await _save_translated_files(
+                parsed_xhtml_docs=results['parsed_docs'],
+                log_callback=log_callback
+            )
+
+            # 4.5. Update NCX table-of-contents labels from translated XHTML
+            # headings. This preserves <content src="..."> jump targets while
+            # localizing the reader's side-panel TOC for EPUB2 books.
+            _update_ncx_toc_labels_from_translated_docs(
+                opf_dir=manifest_data['opf_dir'],
                 parsed_xhtml_docs=results['parsed_docs'],
                 log_callback=log_callback
             )
@@ -1047,6 +1057,156 @@ async def _save_translated_files(
         except Exception as e_write:
             if log_callback:
                 log_callback("epub_write_error", f"Error writing '{file_path_abs}': {e_write}")
+
+
+def _update_ncx_toc_labels_from_translated_docs(
+    opf_dir: str,
+    parsed_xhtml_docs: Dict[str, etree._Element],
+    log_callback: Optional[Callable] = None
+) -> Dict[str, int]:
+    """
+    Update EPUB2 NCX TOC labels using translated XHTML headings.
+
+    The NCX side-panel TOC stores display labels separately from the XHTML body
+    in ``navLabel/text`` nodes. Body translation does not touch those labels,
+    so this helper maps each NCX ``content src`` target back to the already
+    translated XHTML document and copies the translated heading text into the
+    NCX label. The ``content src`` attribute is never modified, preserving
+    reader navigation.
+    """
+    stats = {"updated": 0, "unchanged": 0, "errors": 0}
+    opf_dir_path = Path(opf_dir)
+    ncx_paths = list(opf_dir_path.glob("*.ncx"))
+    if not ncx_paths:
+        return stats
+
+    docs_by_path = {
+        os.path.normcase(os.path.abspath(path)): doc
+        for path, doc in parsed_xhtml_docs.items()
+    }
+    ns = {"ncx": "http://www.daisy.org/z3986/2005/ncx/"}
+
+    for ncx_path in ncx_paths:
+        try:
+            parser = etree.XMLParser(encoding="utf-8", recover=True, remove_blank_text=False)
+            tree = etree.parse(str(ncx_path), parser)
+            changed = False
+
+            for nav_point in tree.findall(".//ncx:navPoint", namespaces=ns):
+                text_el = nav_point.find("./ncx:navLabel/ncx:text", namespaces=ns)
+                content_el = nav_point.find("./ncx:content", namespaces=ns)
+                if text_el is None or content_el is None:
+                    stats["unchanged"] += 1
+                    continue
+
+                src = content_el.get("src")
+                if not src:
+                    stats["unchanged"] += 1
+                    continue
+
+                translated_title = _get_translated_title_for_ncx_src(
+                    src=src,
+                    opf_dir=opf_dir,
+                    docs_by_path=docs_by_path
+                )
+                if not translated_title:
+                    stats["unchanged"] += 1
+                    continue
+
+                if text_el.text != translated_title:
+                    text_el.text = translated_title
+                    changed = True
+                    stats["updated"] += 1
+                else:
+                    stats["unchanged"] += 1
+
+            if changed:
+                tree.write(
+                    str(ncx_path),
+                    encoding="utf-8",
+                    xml_declaration=True,
+                    pretty_print=True
+                )
+        except Exception as exc:
+            stats["errors"] += 1
+            if log_callback:
+                log_callback("epub_ncx_toc_error", f"Could not update NCX TOC '{ncx_path}': {exc}")
+
+    if log_callback and (stats["updated"] or stats["errors"]):
+        log_callback(
+            "epub_ncx_toc_updated",
+            f"📚 NCX TOC labels updated: {stats['updated']} updated, "
+            f"{stats['unchanged']} unchanged, {stats['errors']} errors"
+        )
+
+    return stats
+
+
+def _get_translated_title_for_ncx_src(
+    src: str,
+    opf_dir: str,
+    docs_by_path: Dict[str, etree._Element]
+) -> Optional[str]:
+    href, fragment = _split_ncx_src(src)
+    if not href:
+        return None
+
+    file_path = os.path.normcase(os.path.abspath(os.path.join(opf_dir, href)))
+    doc_root = docs_by_path.get(file_path)
+    if doc_root is None:
+        return None
+
+    if fragment:
+        anchor = _find_element_by_id_or_name(doc_root, fragment)
+        if anchor is not None:
+            title = _extract_heading_text_near_anchor(anchor)
+            if title:
+                return title
+
+    return _extract_first_heading_text(doc_root)
+
+
+def _split_ncx_src(src: str) -> Tuple[str, Optional[str]]:
+    href, _, fragment = src.partition("#")
+    return unquote(href), unquote(fragment) if fragment else None
+
+
+def _find_element_by_id_or_name(doc_root: etree._Element, fragment: str) -> Optional[etree._Element]:
+    for element in doc_root.iter():
+        if element.get("id") == fragment or element.get("name") == fragment:
+            return element
+    return None
+
+
+def _extract_heading_text_near_anchor(anchor: etree._Element) -> Optional[str]:
+    current = anchor
+    while current is not None:
+        if _local_name(current) in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+            return _normalized_element_text(current)
+        current = current.getparent()
+
+    return _normalized_element_text(anchor)
+
+
+def _extract_first_heading_text(doc_root: etree._Element) -> Optional[str]:
+    for element in doc_root.iter():
+        if _local_name(element) in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+            title = _normalized_element_text(element)
+            if title:
+                return title
+    return None
+
+
+def _normalized_element_text(element: etree._Element) -> Optional[str]:
+    text = " ".join("".join(element.itertext()).split())
+    return text or None
+
+
+def _local_name(element: etree._Element) -> str:
+    try:
+        return etree.QName(element).localname.lower()
+    except ValueError:
+        return str(element.tag).split("}", 1)[-1].lower()
 
 
 def _repackage_epub(

--- a/src/core/llm/providers/deepseek.py
+++ b/src/core/llm/providers/deepseek.py
@@ -28,17 +28,18 @@ class DeepSeekProvider(LLMProvider):
     Provider for DeepSeek API.
 
     DeepSeek provides powerful language models with excellent price/performance:
-        - deepseek-chat: Fast and economical model for translation
+        - deepseek-v4-pro: Recommended high-quality model for translation
+        - deepseek-v4-flash: Faster economical model
 
     Configuration:
         endpoint: https://api.deepseek.com/chat/completions
-        model: Model identifier (e.g., "deepseek-chat")
+        model: Model identifier (e.g., "deepseek-v4-pro")
         api_key: DeepSeek API key
 
     Example:
         >>> provider = DeepSeekProvider(
         ...     api_key="your-api-key",
-        ...     model="deepseek-chat"
+        ...     model="deepseek-v4-pro"
         ... )
         >>> response = await provider.generate("Translate: Hello")
     """
@@ -47,6 +48,8 @@ class DeepSeekProvider(LLMProvider):
     MODELS_URL = "https://api.deepseek.com/models"
 
     MODEL_CONTEXT_SIZES = {
+        "deepseek-v4-pro": 64000,
+        "deepseek-v4-flash": 64000,
         "deepseek-chat": 64000,
         "deepseek-reasoner": 64000,
         "deepseek-coder": 16000,
@@ -54,9 +57,8 @@ class DeepSeekProvider(LLMProvider):
     }
 
     FALLBACK_MODELS = [
-        "deepseek-chat",
-        "deepseek-v4-flash",
         "deepseek-v4-pro",
+        "deepseek-v4-flash",
     ]
 
     THINKING_MODELS = ["deepseek-reasoner", "deepseek-r1"]
@@ -65,7 +67,7 @@ class DeepSeekProvider(LLMProvider):
     def __init__(
         self,
         api_key: Union[str, List[str]],
-        model: str = "deepseek-chat",
+        model: str = "deepseek-v4-pro",
         api_endpoint: Optional[str] = None,
         disable_thinking: bool = True
     ):
@@ -74,7 +76,7 @@ class DeepSeekProvider(LLMProvider):
 
         Args:
             api_key: DeepSeek API key
-            model: Model identifier (default: deepseek-chat)
+            model: Model identifier (default: deepseek-v4-pro)
             api_endpoint: Optional custom API endpoint
             disable_thinking: For models that think by default (V4 family),
                 inject ``thinking={"type":"disabled"}`` to skip reasoning tokens.

--- a/src/web/static/js/providers/provider-manager.js
+++ b/src/web/static/js/providers/provider-manager.js
@@ -59,7 +59,8 @@ const OPENAI_MODELS = [
  * Fallback DeepSeek models list (used when API fetch fails)
  */
 const DEEPSEEK_FALLBACK_MODELS = [
-    { value: 'deepseek-chat', label: 'DeepSeek Chat (V3)' },
+    { value: 'deepseek-v4-pro', label: 'DeepSeek V4 Pro' },
+    { value: 'deepseek-v4-flash', label: 'DeepSeek V4 Flash' },
     { value: 'deepseek-reasoner', label: 'DeepSeek Reasoner (Thinking)' }
 ];
 
@@ -1040,7 +1041,7 @@ export const ProviderManager = {
                 // Use fallback list
                 const errorMessage = data.error || 'Could not load models from DeepSeek API';
                 MessageLogger.showMessage(`${errorMessage}. Using fallback list.`, 'warning');
-                populateModelSelect(DEEPSEEK_FALLBACK_MODELS, 'deepseek-chat', 'deepseek');
+                populateModelSelect(DEEPSEEK_FALLBACK_MODELS, 'deepseek-v4-pro', 'deepseek');
                 MessageLogger.addLog(`Using fallback DeepSeek models list`);
 
                 StateManager.setState('models.availableModels', DEEPSEEK_FALLBACK_MODELS.map(m => m.value));
@@ -1050,7 +1051,7 @@ export const ProviderManager = {
             // Use fallback list on error
             MessageLogger.showMessage(`Error: ${error.message}. Using fallback list.`, 'warning');
             MessageLogger.addLog(`DeepSeek API error: ${error.message}. Using fallback list.`);
-            populateModelSelect(DEEPSEEK_FALLBACK_MODELS, 'deepseek-chat', 'deepseek');
+            populateModelSelect(DEEPSEEK_FALLBACK_MODELS, 'deepseek-v4-pro', 'deepseek');
 
             StateManager.setState('models.availableModels', DEEPSEEK_FALLBACK_MODELS.map(m => m.value));
             StatusManager.setConnected('deepseek', DEEPSEEK_FALLBACK_MODELS.length);

--- a/tests/unit/epub/test_ncx_toc_labels.py
+++ b/tests/unit/epub/test_ncx_toc_labels.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+
+from lxml import etree
+
+from src.core.epub.translator import _update_ncx_toc_labels_from_translated_docs
+
+
+NCX_NS = "http://www.daisy.org/z3986/2005/ncx/"
+
+
+def _xhtml_with_heading(anchor_id: str, heading_text: str) -> etree._Element:
+    return etree.fromstring(
+        f"""<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <body>
+    <h2><a id="{anchor_id}"/>{heading_text}</h2>
+    <p>Translated body.</p>
+  </body>
+</html>""".encode("utf-8")
+    )
+
+
+def test_updates_ncx_nav_labels_from_translated_xhtml_without_changing_jump_targets(tmp_path: Path):
+    opf_dir = tmp_path / "OEBPS"
+    opf_dir.mkdir()
+    chapter_path = opf_dir / "chapter1.xhtml"
+    chapter_path.write_text("<html/>", encoding="utf-8")
+
+    ncx_path = opf_dir / "toc.ncx"
+    ncx_path.write_text(
+        f"""<?xml version="1.0" encoding="utf-8"?>
+<ncx xmlns="{NCX_NS}" version="2005-1">
+  <navMap>
+    <navPoint id="nav1" playOrder="1">
+      <navLabel><text>Chapter 1: Original Title</text></navLabel>
+      <content src="chapter1.xhtml#chapter-one"/>
+    </navPoint>
+  </navMap>
+</ncx>""",
+        encoding="utf-8",
+    )
+
+    parsed_docs = {
+        str(chapter_path): _xhtml_with_heading(
+            "chapter-one",
+            "第一章：译后标题",
+        )
+    }
+
+    result = _update_ncx_toc_labels_from_translated_docs(
+        opf_dir=str(opf_dir),
+        parsed_xhtml_docs=parsed_docs,
+    )
+
+    tree = etree.parse(str(ncx_path))
+    ns = {"ncx": NCX_NS}
+    assert result == {"updated": 1, "unchanged": 0, "errors": 0}
+    assert tree.findtext(".//ncx:navLabel/ncx:text", namespaces=ns) == "第一章：译后标题"
+    assert tree.find(".//ncx:content", namespaces=ns).get("src") == "chapter1.xhtml#chapter-one"
+
+
+def test_uses_first_heading_when_ncx_target_has_no_fragment(tmp_path: Path):
+    opf_dir = tmp_path / "OEBPS"
+    opf_dir.mkdir()
+    chapter_path = opf_dir / "chapter2.xhtml"
+    chapter_path.write_text("<html/>", encoding="utf-8")
+
+    ncx_path = opf_dir / "toc.ncx"
+    ncx_path.write_text(
+        f"""<?xml version="1.0" encoding="utf-8"?>
+<ncx xmlns="{NCX_NS}" version="2005-1">
+  <navMap>
+    <navPoint id="nav2" playOrder="2">
+      <navLabel><text>Chapter 2: Original Title</text></navLabel>
+      <content src="chapter2.xhtml"/>
+    </navPoint>
+  </navMap>
+</ncx>""",
+        encoding="utf-8",
+    )
+
+    parsed_docs = {
+        str(chapter_path): _xhtml_with_heading(
+            "unused-anchor",
+            "第二章：无片段目标",
+        )
+    }
+
+    result = _update_ncx_toc_labels_from_translated_docs(
+        opf_dir=str(opf_dir),
+        parsed_xhtml_docs=parsed_docs,
+    )
+
+    tree = etree.parse(str(ncx_path))
+    assert result["updated"] == 1
+    assert tree.findtext(".//{http://www.daisy.org/z3986/2005/ncx/}text") == "第二章：无片段目标"


### PR DESCRIPTION
Update EPUB post-processing so translated XHTML headings are synchronized back into toc.ncx navLabel text while preserving each content src jump target. This fixes EPUB2 reader sidebars that displayed English chapter titles after body translation.

Switch DeepSeek defaults and documentation to deepseek-v4-pro, keep V4 thinking disabled by default for translation, and refresh frontend/backend fallback model choices.

Tests: pytest tests\\unit\\epub\\test_ncx_toc_labels.py tests\\test_epub_xhtml_lang_attributes.py tests\\unit\\epub\\test_tag_preservation.py tests\\unit\\epub\\test_tag_classifier.py -q