### PR TITLE
feat(llm): add LiteLLM as a CLI-only gateway provider

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,10 @@ Pillow>=10.0.0
 mammoth>=1.0.0
 python-docx>=1.1.0
 
+# LiteLLM gateway (100+ providers, CLI-only) - OPTIONAL
+# Enables --provider litellm. Lazy-imported, so not required unless used.
+#   pip install "litellm>=1.65,<1.85"
+
 # Chatterbox TTS (GPU-accelerated local TTS) - OPTIONAL
 # These dependencies have strict numpy version requirements that may conflict.
 # Install separately if needed:

--- a/src/config.py
+++ b/src/config.py
@@ -106,6 +106,10 @@ _RELOADABLE_ENV_SETTINGS = (
     ('POE_MODEL',           'POE_MODEL',           'Claude-Sonnet-4'),
     ('NIM_API_KEY',         'NIM_API_KEY',         ''),
     ('NIM_MODEL',           'NIM_MODEL',           'meta/llama-3.1-8b-instruct'),
+    # LiteLLM gateway (CLI-only). Provider-prefixed model name, e.g.
+    # "anthropic/claude-sonnet-4-6". Keys are read from each provider's native
+    # env var (OPENAI_API_KEY, ANTHROPIC_API_KEY, ...), not from a single key.
+    ('LITELLM_MODEL',       'LITELLM_MODEL',       ''),
     ('OUTPUT_FILENAME_PATTERN', 'OUTPUT_FILENAME_PATTERN', '{originalName} ({targetLang}).{ext}'),
     ('DISABLE_AUTO_PAUSE',   'DISABLE_AUTO_PAUSE',   'false'),
     # Webhook notifications — kept here so the web UI can change them at runtime

--- a/src/core/llm/factory.py
+++ b/src/core/llm/factory.py
@@ -14,7 +14,8 @@ from src.config import (
     DEEPSEEK_API_KEY, DEEPSEEK_MODEL, DEEPSEEK_API_ENDPOINT,
     DEEPSEEK_DISABLE_THINKING,
     POE_API_KEY, POE_MODEL, POE_API_ENDPOINT,
-    NIM_API_KEY, NIM_MODEL, NIM_API_ENDPOINT
+    NIM_API_KEY, NIM_MODEL, NIM_API_ENDPOINT,
+    LITELLM_MODEL
 )
 from .base import LLMProvider, normalize_api_keys
 from .providers.ollama import OllamaProvider
@@ -24,6 +25,7 @@ from .providers.openrouter import OpenRouterProvider
 from .providers.mistral import MistralProvider
 from .providers.deepseek import DeepSeekProvider
 from .providers.poe import PoeProvider
+from .providers.litellm import LiteLLMProvider
 
 
 def _require_key(raw, error_message: str):
@@ -46,7 +48,7 @@ def create_llm_provider(provider_type: str = "ollama", **kwargs) -> LLMProvider:
     automatically switches to Gemini provider.
 
     Args:
-        provider_type: Type of provider ("ollama", "openai", "gemini", "openrouter", "mistral", "deepseek", "poe")
+        provider_type: Type of provider ("ollama", "openai", "gemini", "openrouter", "mistral", "deepseek", "poe", "nim", "litellm")
         **kwargs: Provider-specific parameters:
             - api_endpoint: API endpoint URL (Ollama, OpenAI)
             - model: Model name/identifier
@@ -162,6 +164,16 @@ def create_llm_provider(provider_type: str = "ollama", **kwargs) -> LLMProvider:
             model=kwargs.get("model", NIM_MODEL),
             api_endpoint=kwargs.get("api_endpoint", NIM_API_ENDPOINT),
             provider_name="nim",
+        )
+
+    elif provider_type.lower() == "litellm":
+        # LiteLLM reads credentials from each provider's native env var, so no
+        # key is required here. api_base is taken only from a dedicated kwarg,
+        # never from the generic `endpoint` (which defaults to the Ollama URL).
+        return LiteLLMProvider(
+            model=kwargs.get("model") or LITELLM_MODEL or DEFAULT_MODEL,
+            api_key=kwargs.get("api_key") or kwargs.get("litellm_api_key"),
+            api_base=kwargs.get("litellm_api_base"),
         )
 
     else:

--- a/src/core/llm/providers/litellm.py
+++ b/src/core/llm/providers/litellm.py
@@ -1,0 +1,175 @@
+"""
+LiteLLM provider implementation.
+
+Routes to 100+ LLM providers (OpenAI, Anthropic, Gemini, Bedrock, Vertex AI,
+Groq, etc.) through a single unified interface using provider-prefixed model
+names. LiteLLM is a client-side library, not a hosted gateway: it runs in this
+process and dispatches each call to the underlying provider's native API.
+
+API keys are read from each provider's native environment variable
+(OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, ...) unless an explicit
+key is passed. This is why the factory does not plumb a single LiteLLM key.
+
+Optional dependency: pip install "litellm>=1.65,<1.85"
+
+Example:
+    >>> provider = LiteLLMProvider(model="anthropic/claude-sonnet-4-6")
+    >>> response = await provider.generate("Translate: Hello")
+"""
+
+import asyncio
+from typing import Optional, Union, List
+
+from src.config import REQUEST_TIMEOUT, MAX_TRANSLATION_ATTEMPTS, TEMPERATURE
+from ..base import LLMProvider, LLMResponse
+from ..exceptions import ContextOverflowError
+
+
+# Substrings that mark a provider-side context/length overflow, surfaced as
+# ContextOverflowError so the chunking layer can react (shrink and retry).
+_CONTEXT_OVERFLOW_KEYWORDS = (
+    "context_length", "maximum context", "token limit",
+    "too many tokens", "reduce the length", "max_tokens",
+    "context window", "exceeds", "context window exceeded",
+)
+
+# LiteLLM exception qualnames worth retrying with backoff (transient).
+_TRANSIENT_EXCEPTIONS = (
+    "litellm.exceptions.RateLimitError",
+    "litellm.exceptions.APIConnectionError",
+    "litellm.exceptions.Timeout",
+    "litellm.exceptions.InternalServerError",
+    "litellm.exceptions.ServiceUnavailableError",
+)
+
+
+class LiteLLMProvider(LLMProvider):
+    """
+    Provider that uses LiteLLM to reach 100+ LLM providers.
+
+    Model names carry a provider prefix that selects the route AND the
+    expected credential env var:
+        - "openai/gpt-4o"            -> OPENAI_API_KEY
+        - "anthropic/claude-sonnet-4-6" -> ANTHROPIC_API_KEY
+        - "gemini/gemini-2.5-flash"  -> GEMINI_API_KEY
+        - "bedrock/anthropic.claude-v2" -> AWS_* env vars
+
+    LiteLLM handles authentication and parameter translation itself, so this
+    wrapper stays thin and does not use the base KeyPool.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        api_key: Optional[Union[str, List[str]]] = None,
+        api_base: Optional[str] = None,
+    ):
+        """
+        Initialize the LiteLLM provider.
+
+        Args:
+            model: Provider-prefixed model name (e.g. "anthropic/claude-sonnet-4-6").
+            api_key: Optional explicit key. When omitted, LiteLLM reads the
+                provider's native env var. A KeyPool is created only when a key
+                is given so the inherited `api_key` property stays consistent.
+            api_base: Optional custom endpoint (self-hosted gateways, proxies).
+        """
+        super().__init__(model, api_keys=api_key, provider_name="litellm")
+        self.api_base = api_base
+
+    def _build_kwargs(self) -> dict:
+        """Assemble the keyword arguments forwarded to litellm.acompletion."""
+        kwargs: dict = {"drop_params": True, "temperature": TEMPERATURE}
+        # api_key resolves through the base property (KeyPool peek) when an
+        # explicit key was provided; otherwise None -> LiteLLM uses env vars.
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if self.api_base:
+            kwargs["api_base"] = self.api_base
+        return kwargs
+
+    async def generate(
+        self,
+        prompt: str,
+        timeout: int = REQUEST_TIMEOUT,
+        system_prompt: Optional[str] = None,
+    ) -> Optional[LLMResponse]:
+        """
+        Generate text via LiteLLM.
+
+        Args:
+            prompt: The user prompt (content to translate).
+            timeout: Request timeout in seconds.
+            system_prompt: Optional system prompt (role/instructions).
+
+        Returns:
+            LLMResponse with content and token usage, or None on failure.
+
+        Raises:
+            ImportError: If the optional `litellm` package is not installed.
+            ContextOverflowError: If the input exceeds the model's context window.
+        """
+        try:
+            import litellm
+        except ImportError as e:
+            raise ImportError(
+                "LiteLLM provider requires the 'litellm' package. "
+                'Install it with: pip install "litellm>=1.65,<1.85"'
+            ) from e
+
+        messages = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": prompt})
+
+        kwargs = self._build_kwargs()
+
+        for attempt in range(MAX_TRANSLATION_ATTEMPTS):
+            try:
+                response = await litellm.acompletion(
+                    model=self.model,
+                    messages=messages,
+                    timeout=timeout,
+                    **kwargs,
+                )
+
+                choice = response.choices[0]
+                content = getattr(choice.message, "content", "") or ""
+
+                usage = getattr(response, "usage", None)
+                prompt_tokens = getattr(usage, "prompt_tokens", 0) if usage else 0
+                completion_tokens = getattr(usage, "completion_tokens", 0) if usage else 0
+
+                # Plain ASCII: an emoji here crashes on Windows cp1252 consoles,
+                # and a failing print would be caught below as a request error.
+                print(f"[LiteLLM] ({self.model}): {prompt_tokens}+{completion_tokens} tokens")
+
+                return LLMResponse(
+                    content=content,
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    context_used=prompt_tokens + completion_tokens,
+                    context_limit=0,  # Unknown across providers; not enforced here.
+                    was_truncated=False,
+                )
+
+            except Exception as e:
+                error_str = str(e).lower()
+                if any(kw in error_str for kw in _CONTEXT_OVERFLOW_KEYWORDS):
+                    raise ContextOverflowError(f"LiteLLM context overflow: {e}") from e
+
+                qualname = f"{type(e).__module__}.{type(e).__name__}"
+                is_last = attempt >= MAX_TRANSLATION_ATTEMPTS - 1
+                print(
+                    f"[LiteLLM] Error (attempt {attempt + 1}/"
+                    f"{MAX_TRANSLATION_ATTEMPTS}): {e}"
+                )
+                if is_last:
+                    return None
+
+                if qualname in _TRANSIENT_EXCEPTIONS:
+                    await asyncio.sleep(min(2 ** (attempt + 1), 10))
+                else:
+                    await asyncio.sleep(2)
+
+        return None

--- a/tests/standalone/manual_litellm_smoke.py
+++ b/tests/standalone/manual_litellm_smoke.py
@@ -1,0 +1,108 @@
+"""
+Smoke test for the LiteLLM provider.
+
+Verifies that the project's factory wiring can route a real translation through
+LiteLLM end to end, using a provider-prefixed model and the matching native
+credential from .env. This is the test that proves the feature actually works
+against a live API, beyond the stubbed unit tests.
+
+Requires the optional dependency:
+    pip install "litellm>=1.65,<1.85"
+
+Run from repo root:
+    python tests/standalone/manual_litellm_smoke.py
+
+By default it routes to gemini/gemini-2.5-flash (cheap, uses GEMINI_API_KEY).
+Override the model via the LITELLM_MODEL env var to test another provider.
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+# Force UTF-8 on stdout/stderr so library logs containing emoji don't crash on
+# Windows consoles that default to cp1252.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
+# Make `src` importable when invoked directly.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT))
+
+# Importing src.config calls load_dotenv() on the repo's .env, so the native
+# provider keys (GEMINI_API_KEY, OPENAI_API_KEY, ...) become visible.
+from src import config  # noqa: F401
+from src.core.llm.factory import create_llm_provider
+
+DEFAULT_MODEL = "gemini/gemini-2.5-flash"
+
+SOURCE_TEXT = "The quick brown fox jumps over the lazy dog."
+SYSTEM_PROMPT = (
+    "You are a professional translator. Translate the user's text from English "
+    "into French. Wrap the translation between <TRANSLATION> and </TRANSLATION> "
+    "tags and output nothing else."
+)
+USER_PROMPT = f"<TRANSLATION>\n{SOURCE_TEXT}\n</TRANSLATION>"
+
+# Map a model prefix to the native env var LiteLLM expects, so we can give a
+# clear precondition error instead of a cryptic auth failure.
+_PREFIX_TO_ENV = {
+    "gemini/": "GEMINI_API_KEY",
+    "openai/": "OPENAI_API_KEY",
+    "anthropic/": "ANTHROPIC_API_KEY",
+    "mistral/": "MISTRAL_API_KEY",
+    "deepseek/": "DEEPSEEK_API_KEY",
+}
+
+
+async def run() -> int:
+    try:
+        import litellm  # noqa: F401
+    except ImportError:
+        print('FAIL: litellm not installed. Run: pip install "litellm>=1.65,<1.85"')
+        return 1
+
+    model = os.getenv("LITELLM_MODEL", "").strip() or DEFAULT_MODEL
+
+    required_env = next(
+        (env for prefix, env in _PREFIX_TO_ENV.items() if model.startswith(prefix)),
+        None,
+    )
+    if required_env and not os.getenv(required_env, "").strip():
+        print(f"FAIL: {required_env} is not set in .env (required for model '{model}')")
+        return 1
+
+    print("Provider: litellm")
+    print(f"Model:    {model}")
+    print(f"Source:   {SOURCE_TEXT}")
+    print()
+
+    provider = create_llm_provider("litellm", model=model)
+    try:
+        response = await provider.generate(USER_PROMPT, system_prompt=SYSTEM_PROMPT)
+    finally:
+        await provider.close()
+
+    if response is None:
+        print("FAIL: provider returned None (request failed after retries)")
+        return 1
+
+    print(f"Raw response:\n{response.content}\n")
+
+    translation = provider.extract_translation(response.content)
+    if not translation or not translation.strip():
+        print("FAIL: could not extract translation from <TRANSLATION> tags")
+        return 1
+
+    print(f"Translation: {translation.strip()}")
+    print(f"Tokens:      {response.prompt_tokens}+{response.completion_tokens}")
+    print("\nPASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(run()))

--- a/tests/unit/test_litellm_provider.py
+++ b/tests/unit/test_litellm_provider.py
@@ -1,0 +1,174 @@
+"""
+Unit tests for the LiteLLM provider.
+
+LiteLLM is stubbed via sys.modules so these tests never touch the network and
+do not require the optional `litellm` package to be installed. The real
+end-to-end behaviour is covered by tests/standalone/manual_litellm_smoke.py.
+"""
+
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+
+def _install_litellm_stub():
+    fake = types.ModuleType("litellm")
+    fake.acompletion = mock.AsyncMock(name="litellm.acompletion")
+    sys.modules["litellm"] = fake
+    return fake
+
+
+@pytest.fixture(autouse=True)
+def litellm_stub():
+    fake = _install_litellm_stub()
+    yield fake
+    sys.modules.pop("litellm", None)
+
+
+def _mock_response(content="Hello!", prompt_tokens=10, completion_tokens=5):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+        usage=SimpleNamespace(
+            prompt_tokens=prompt_tokens, completion_tokens=completion_tokens
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_calls_acompletion(litellm_stub):
+    litellm_stub.acompletion.return_value = _mock_response("translated text")
+
+    from src.core.llm.providers.litellm import LiteLLMProvider
+
+    provider = LiteLLMProvider(model="anthropic/claude-haiku-4-5", api_key="sk-test")
+    result = await provider.generate("Translate this")
+
+    litellm_stub.acompletion.assert_called_once()
+    kwargs = litellm_stub.acompletion.call_args.kwargs
+    assert kwargs["model"] == "anthropic/claude-haiku-4-5"
+    assert kwargs["api_key"] == "sk-test"
+    assert kwargs["drop_params"] is True
+    assert result.content == "translated text"
+    assert result.prompt_tokens == 10
+    assert result.completion_tokens == 5
+
+
+@pytest.mark.asyncio
+async def test_generate_forwards_temperature(litellm_stub):
+    litellm_stub.acompletion.return_value = _mock_response()
+
+    from src.config import TEMPERATURE
+    from src.core.llm.providers.litellm import LiteLLMProvider
+
+    provider = LiteLLMProvider(model="openai/gpt-4o", api_key="k")
+    await provider.generate("Hello")
+
+    kwargs = litellm_stub.acompletion.call_args.kwargs
+    assert kwargs["temperature"] == TEMPERATURE
+
+
+@pytest.mark.asyncio
+async def test_generate_omits_blank_credentials(litellm_stub):
+    litellm_stub.acompletion.return_value = _mock_response()
+
+    from src.core.llm.providers.litellm import LiteLLMProvider
+
+    # No key and no api_base: LiteLLM should fall back to native env vars.
+    provider = LiteLLMProvider(model="openai/gpt-4o")
+    await provider.generate("Hello")
+
+    kwargs = litellm_stub.acompletion.call_args.kwargs
+    assert "api_key" not in kwargs
+    assert "api_base" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_generate_forwards_system_prompt(litellm_stub):
+    litellm_stub.acompletion.return_value = _mock_response()
+
+    from src.core.llm.providers.litellm import LiteLLMProvider
+
+    provider = LiteLLMProvider(model="openai/gpt-4o", api_key="k")
+    await provider.generate("Translate this", system_prompt="You are a translator")
+
+    kwargs = litellm_stub.acompletion.call_args.kwargs
+    messages = kwargs["messages"]
+    assert messages[0]["role"] == "system"
+    assert messages[0]["content"] == "You are a translator"
+    assert messages[1]["role"] == "user"
+    assert messages[1]["content"] == "Translate this"
+
+
+@pytest.mark.asyncio
+async def test_generate_forwards_api_base(litellm_stub):
+    litellm_stub.acompletion.return_value = _mock_response()
+
+    from src.core.llm.providers.litellm import LiteLLMProvider
+
+    provider = LiteLLMProvider(
+        model="openai/gpt-4o", api_key="k", api_base="https://proxy.example/v1"
+    )
+    await provider.generate("Hello")
+
+    kwargs = litellm_stub.acompletion.call_args.kwargs
+    assert kwargs["api_base"] == "https://proxy.example/v1"
+
+
+@pytest.mark.asyncio
+async def test_context_overflow_is_raised(litellm_stub):
+    litellm_stub.acompletion.side_effect = RuntimeError(
+        "This model's maximum context length is 8192 tokens"
+    )
+
+    from src.core.llm.providers.litellm import LiteLLMProvider
+    from src.core.llm.exceptions import ContextOverflowError
+
+    provider = LiteLLMProvider(model="openai/gpt-4o", api_key="k")
+    with pytest.raises(ContextOverflowError):
+        await provider.generate("way too long")
+
+
+def test_init_does_not_shadow_base_api_key_property():
+    """Regression: the base class exposes `api_key` as a read-only property.
+
+    A previous draft assigned `self.api_key = ...` in __init__, which raised
+    AttributeError on instantiation against the current base class. Construction
+    must succeed and the property must stay readable.
+    """
+    from src.core.llm.providers.litellm import LiteLLMProvider
+
+    # No explicit key -> no KeyPool -> property returns None, never raises.
+    provider = LiteLLMProvider(model="openai/gpt-4o")
+    assert provider.api_key is None
+
+    # Explicit key -> readable through the inherited KeyPool-backed property.
+    provider_with_key = LiteLLMProvider(model="openai/gpt-4o", api_key="sk-test")
+    assert provider_with_key.api_key == "sk-test"
+
+
+def test_factory_creates_litellm_provider():
+    from src.core.llm.factory import create_llm_provider
+    from src.core.llm.providers.litellm import LiteLLMProvider
+
+    provider = create_llm_provider(
+        "litellm", model="anthropic/claude-haiku-4-5", api_key="k"
+    )
+    assert isinstance(provider, LiteLLMProvider)
+    assert provider.model == "anthropic/claude-haiku-4-5"
+
+
+def test_factory_ignores_generic_endpoint_for_api_base():
+    """The txt/srt pipeline passes the Ollama endpoint as `endpoint`; LiteLLM
+    must not adopt it as api_base or native routing would break."""
+    from src.core.llm.factory import create_llm_provider
+
+    provider = create_llm_provider(
+        "litellm",
+        model="gemini/gemini-2.5-flash",
+        endpoint="http://localhost:11434/api/generate",
+    )
+    assert provider.api_base is None

--- a/translate.py
+++ b/translate.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     parser.add_argument("-tl", "--target_lang", default=DEFAULT_TARGET_LANGUAGE, help=f"Target language (default: {DEFAULT_TARGET_LANGUAGE}).")
     parser.add_argument("-m", "--model", default=DEFAULT_MODEL, help=f"LLM model (default: {DEFAULT_MODEL}).")
     parser.add_argument("--api_endpoint", default=API_ENDPOINT, help=f"API endpoint for Ollama or OpenAI-compatible servers (llama.cpp, LM Studio, vLLM, etc.) (default: {API_ENDPOINT}).")
-    parser.add_argument("--provider", default=LLM_PROVIDER, choices=["ollama", "gemini", "openai", "openrouter", "mistral", "deepseek", "poe", "nim"], help=f"LLM provider (default: {LLM_PROVIDER}). Use 'openai' for any OpenAI-compatible server.")
+    parser.add_argument("--provider", default=LLM_PROVIDER, choices=["ollama", "gemini", "openai", "openrouter", "mistral", "deepseek", "poe", "nim", "litellm"], help=f"LLM provider (default: {LLM_PROVIDER}). Use 'openai' for any OpenAI-compatible server. Use 'litellm' to reach 100+ providers via a provider-prefixed model name (e.g. anthropic/claude-sonnet-4-6); keys are read from each provider's native env var (OPENAI_API_KEY, ANTHROPIC_API_KEY, ...).")
     parser.add_argument("--gemini_api_key", default=GEMINI_API_KEY, help="Google Gemini API key (required if using gemini provider).")
     parser.add_argument("--openai_api_key", default=OPENAI_API_KEY, help="OpenAI API key (required for OpenAI cloud, not needed for local servers).")
     parser.add_argument("--openrouter_api_key", default=OPENROUTER_API_KEY, help="OpenRouter API key (required if using openrouter provider).")
@@ -61,10 +61,12 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # Auto-select default model based on provider if not explicitly set
-    from src.config import NIM_MODEL, MISTRAL_MODEL, DEEPSEEK_MODEL, POE_MODEL, OPENROUTER_MODEL, GEMINI_MODEL
+    from src.config import NIM_MODEL, MISTRAL_MODEL, DEEPSEEK_MODEL, POE_MODEL, OPENROUTER_MODEL, GEMINI_MODEL, LITELLM_MODEL
     if args.model == DEFAULT_MODEL:
         if args.provider == "nim" and NIM_MODEL:
             args.model = NIM_MODEL
+        elif args.provider == "litellm" and LITELLM_MODEL:
+            args.model = LITELLM_MODEL
         elif args.provider == "mistral" and MISTRAL_MODEL:
             args.model = MISTRAL_MODEL
         elif args.provider == "deepseek" and DEEPSEEK_MODEL:
@@ -117,6 +119,13 @@ if __name__ == "__main__":
         parser.error("--poe_api_key is required when using poe provider. Get your key at https://poe.com/api_key")
     if args.provider == "nim" and not args.nim_api_key:
         parser.error("--nim_api_key is required when using nim provider. Get your key at https://build.nvidia.com/")
+    # LiteLLM needs a provider-prefixed model name; the default Ollama model
+    # won't route. Keys come from each provider's native env var, so we only
+    # guard the model here rather than an API key.
+    if args.provider == "litellm" and args.model == DEFAULT_MODEL:
+        parser.error("litellm provider requires a provider-prefixed model. "
+                     "Set LITELLM_MODEL in .env or pass -m, e.g. "
+                     "-m anthropic/claude-sonnet-4-6")
 
     # Refinement is monolingual: mismatched source/target almost always
     # means the user forgot. Warn but proceed using target_lang.


### PR DESCRIPTION
## Summary

Adds LiteLLM as a **CLI-only** provider, reaching 100+ providers through a
single interface via provider-prefixed model names
(e.g. `anthropic/claude-sonnet-4-6`, `gemini/gemini-2.5-flash`).

LiteLLM is a client-side library: it runs in-process and dispatches each call
to the underlying provider's native API. It is lazy-imported and optional, so
it adds no hard dependency and is intentionally **not** exposed in the web UI.

Based on #157 by @RheagalFire, rebased onto the current provider architecture
(see the note on that PR for why a rewrite was needed).

## Changes

- `src/core/llm/providers/litellm.py` — new `LiteLLMProvider`. Lazy-imports
  `litellm`, forwards `TEMPERATURE`, detects context overflow, retries transient
  errors. Does **not** assign `self.api_key` (the base class now exposes it as a
  read-only, KeyPool-backed property).
- `src/core/llm/factory.py` — `litellm` branch. `api_base` is read only from a
  dedicated kwarg, never from the generic `endpoint` (which defaults to the
  Ollama URL and would break native routing).
- `src/config.py` — `LITELLM_MODEL` (reloadable, empty by default).
- `translate.py` — `litellm` added to `--provider`, default-model selection, and
  a guard that asks for a provider-prefixed model. No API-key flag: keys come
  from each provider's native env var (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, …).
- `requirements.txt` — optional, commented `litellm>=1.65,<1.85`.

## Tests

- `tests/unit/test_litellm_provider.py` — 9 stubbed unit tests, including a
  regression for the `api_key`-property collision and a guard that the generic
  `endpoint` is not adopted as `api_base`.
- `tests/standalone/manual_litellm_smoke.py` — real round-trip smoke test.
- Verified manually: full end-to-end CLI translation through
  `gemini/gemini-2.5-flash` produces correct output.
- Full suite green: **1124 passed, 1 skipped**. Factory import works without
  `litellm` installed.

## Notes

- Console output is ASCII; an emoji `print()` crashed on Windows cp1252 and was
  caught as a request failure. The same latent bug exists in other providers,
  tracked in #184.

Supersedes #157.
