### PR TITLE
fix(web): honest completion heading when chunks are left untranslated

### DIFF
--- a/src/web/static/js/translation/translation-tracker.js
+++ b/src/web/static/js/translation/translation-tracker.js
@@ -789,7 +789,13 @@ export const TranslationTracker = {
         icon.textContent = 'warning';
         heading.appendChild(icon);
         const headingText = document.createElement('span');
-        headingText.textContent = t('translation:completion_warning_heading');
+        // When chunks were left in the source language (Phase 3 fallback) or
+        // outright failed, the optimistic "translations are correct" heading is
+        // misleading — surface the missing-content message instead.
+        const hasUntranslatedContent = untranslated > 0 || failed > 0;
+        headingText.textContent = t(hasUntranslatedContent
+            ? 'translation:completion_warning_heading_untranslated'
+            : 'translation:completion_warning_heading');
         heading.appendChild(headingText);
         block.appendChild(heading);
 

--- a/src/web/static/locales/de/translation.json
+++ b/src/web/static/locales/de/translation.json
@@ -104,6 +104,7 @@
   "completion_fallback_chunks": "{{count}} Formatierungs-Fallback(s)",
   "completion_placeholder_errors": "{{count}} Formatierungsmangel",
   "completion_warning_heading": "Die Übersetzungen sind korrekt — nur die Formatierung könnte Aufmerksamkeit benötigen",
+  "completion_warning_heading_untranslated": "Einige Chunks konnten nicht übersetzt werden und verbleiben in der Ausgangssprache",
   "completion_warning_token_alignment": "{{count}} Chunk(s) mit ungefährer Tag-Platzierung",
   "completion_warning_untranslated": "{{count}} Chunk(s) in Ausgangssprache belassen",
   "completion_warning_placeholder_errors": "{{count}} Formatierungsmangel",

--- a/src/web/static/locales/en/translation.json
+++ b/src/web/static/locales/en/translation.json
@@ -104,6 +104,7 @@
   "completion_fallback_chunks": "{{count}} formatting fallback(s)",
   "completion_placeholder_errors": "{{count}} formatting issue(s)",
   "completion_warning_heading": "Translations are correct — only the formatting may need attention",
+  "completion_warning_heading_untranslated": "Some chunks could not be translated and remain in the source language",
   "completion_warning_token_alignment": "{{count}} chunk(s) with approximate tag placement",
   "completion_warning_untranslated": "{{count}} chunk(s) kept in source language",
   "completion_warning_placeholder_errors": "{{count}} formatting issue(s)",

--- a/src/web/static/locales/es/translation.json
+++ b/src/web/static/locales/es/translation.json
@@ -104,6 +104,7 @@
   "completion_fallback_chunks": "{{count}} fallback(s) de formato",
   "completion_placeholder_errors": "{{count}} imperfección(es) de formato",
   "completion_warning_heading": "Las traducciones son correctas — solo el formato puede requerir atención",
+  "completion_warning_heading_untranslated": "Algunos fragmentos no se pudieron traducir y permanecen en el idioma original",
   "completion_warning_token_alignment": "{{count}} fragmento(s) con colocación aproximada de etiquetas",
   "completion_warning_untranslated": "{{count}} fragmento(s) conservados en el idioma original",
   "completion_warning_placeholder_errors": "{{count}} imperfección(es) de formato",

--- a/src/web/static/locales/fr/translation.json
+++ b/src/web/static/locales/fr/translation.json
@@ -104,6 +104,7 @@
   "completion_fallback_chunks": "{{count}} repli(s) de formatage",
   "completion_placeholder_errors": "{{count}} imperfection(s) de formatage",
   "completion_warning_heading": "Les traductions sont correctes — seul le formatage peut nécessiter de l'attention",
+  "completion_warning_heading_untranslated": "Certains chunks n'ont pas pu être traduits et restent dans la langue source",
   "completion_warning_token_alignment": "{{count}} chunk(s) avec placement de balises approximatif",
   "completion_warning_untranslated": "{{count}} chunk(s) laissé(s) dans la langue source",
   "completion_warning_placeholder_errors": "{{count}} imperfection(s) de formatage",

--- a/src/web/static/locales/ja/translation.json
+++ b/src/web/static/locales/ja/translation.json
@@ -104,6 +104,7 @@
   "completion_fallback_chunks": "書式フォールバック {{count}} 件",
   "completion_placeholder_errors": "書式の不備 {{count}} 件",
   "completion_warning_heading": "翻訳は正しいですが、書式のみ確認が必要です",
+  "completion_warning_heading_untranslated": "一部のチャンクは翻訳できず、ソース言語のまま残っています",
   "completion_warning_token_alignment": "タグ配置が近似的なチャンク {{count}} 件",
   "completion_warning_untranslated": "原文のままのチャンク {{count}} 件",
   "completion_warning_placeholder_errors": "書式の不備 {{count}} 件",

--- a/src/web/static/locales/ko/translation.json
+++ b/src/web/static/locales/ko/translation.json
@@ -104,6 +104,7 @@
   "completion_fallback_chunks": "서식 폴백 {{count}}건",
   "completion_placeholder_errors": "서식 미흡 {{count}}건",
   "completion_warning_heading": "번역은 정확합니다 — 서식만 확인이 필요할 수 있습니다",
+  "completion_warning_heading_untranslated": "일부 청크를 번역하지 못해 원본 언어로 남아 있습니다",
   "completion_warning_token_alignment": "태그 위치가 근사적인 청크 {{count}}개",
   "completion_warning_untranslated": "원문 그대로 유지된 청크 {{count}}개",
   "completion_warning_placeholder_errors": "서식 미흡 {{count}}건",

--- a/src/web/static/locales/zh-CN/translation.json
+++ b/src/web/static/locales/zh-CN/translation.json
@@ -104,6 +104,7 @@
   "completion_fallback_chunks": "{{count}} 次排版回退",
   "completion_placeholder_errors": "{{count}} 处排版瑕疵",
   "completion_warning_heading": "翻译正确 — 仅排版可能需要留意",
+  "completion_warning_heading_untranslated": "部分分块无法翻译，仍保留为原文语言",
   "completion_warning_token_alignment": "{{count}} 个分块的标签位置为近似放置",
   "completion_warning_untranslated": "{{count}} 个分块保留为原文",
   "completion_warning_placeholder_errors": "{{count}} 处排版瑕疵",


### PR DESCRIPTION
## Context

Raised in #196: the EPUB pipeline can finish a job with chunks left in the source language (Phase 3 untranslated fallback) while the completion card still claims the translation is correct.

## Problem

The completion warning card always used the heading *"Translations are correct, only the formatting may need attention"*, regardless of the failure type. When `fallback_used > 0` (untranslated chunks) or `failed_chunks > 0`, that heading directly contradicted the breakdown line below it (*"N chunks kept in source language"*).

The untranslated count was already surfaced in the breakdown and in the live recommendations, so nothing was shipped silently, but the headline wording was misleading.

## Change

- `translation-tracker.js`: the heading is now conditional. When there are untranslated or failed chunks it uses a dedicated key; otherwise it keeps the original formatting-only heading.
- Added `completion_warning_heading_untranslated` to all 7 locales (en source of truth, plus fr/es/de/zh-CN/ja/ko), reusing each locale's existing chunk terminology.

The string goes through `t()` inside the render path that re-runs on completion, so it stays reactive to UI language switches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)