### PR TITLE
fix(glossary): resolve __USE_ENV__ sentinel in NER endpoint (#200)

### DIFF
--- a/src/api/api_keys.py
+++ b/src/api/api_keys.py
@@ -1,0 +1,62 @@
+"""
+Shared API-key resolution for the HTTP layer.
+
+The frontend never sends a real key when one is configured in ``.env``: it
+sends the ``__USE_ENV__`` sentinel instead (see ``ApiKeyUtils.getValue`` in
+``api-key-utils.js``). Every endpoint that accepts a per-request key must turn
+that sentinel — and any empty value — back into the configured key.
+
+This logic was previously copy-pasted into four blueprints
+(translation/sample/config/glossary). Diverging copies caused issue #200:
+the glossary NER endpoint forwarded the literal ``__USE_ENV__`` to Gemini,
+which rejected it as an invalid key. Keep the single source of truth here.
+"""
+import os
+
+# Marker the frontend sends when the key field is empty but a key is
+# configured in .env. Resolved back to the real env value server-side.
+USE_ENV_SENTINEL = '__USE_ENV__'
+
+# Provider -> conventional env var holding its API key.
+PROVIDER_ENV_VARS = {
+    'gemini': 'GEMINI_API_KEY',
+    'openai': 'OPENAI_API_KEY',
+    'openrouter': 'OPENROUTER_API_KEY',
+    'mistral': 'MISTRAL_API_KEY',
+    'deepseek': 'DEEPSEEK_API_KEY',
+    'poe': 'POE_API_KEY',
+    'nim': 'NIM_API_KEY',
+}
+
+
+def provider_env_var(provider):
+    """Return the env var name conventionally used for a provider's API key.
+
+    Returns ``''`` for providers that need no key (e.g. ``ollama``) or unknown
+    provider names.
+    """
+    return PROVIDER_ENV_VARS.get((provider or '').lower(), '')
+
+
+def resolve_api_key(value, env_var_name, config_default=''):
+    """Resolve a per-request API-key value to the key to actually use.
+
+    A real key (anything truthy that isn't the ``__USE_ENV__`` sentinel) is
+    returned unchanged — including multi-key, comma-separated strings, which
+    provider constructors split for key rotation. Otherwise the value falls
+    back to the environment variable, then to ``config_default``.
+
+    Args:
+        value: Value from the request (a real key, ``'__USE_ENV__'``, or empty).
+        env_var_name: Env var to fall back to. Empty/None skips the env lookup.
+        config_default: Last-resort default (e.g. the value loaded into the
+            config module at import time) when the env var is unset.
+
+    Returns:
+        The resolved key string (possibly empty if nothing is configured).
+    """
+    if value and value != USE_ENV_SENTINEL:
+        return value
+    if not env_var_name:
+        return config_default
+    return os.getenv(env_var_name, config_default)

--- a/src/api/blueprints/config_routes.py
+++ b/src/api/blueprints/config_routes.py
@@ -50,6 +50,7 @@ import src.config as _config
 from src.config import reload_config
 from src import __version__
 from src.core.llm.base import normalize_api_keys
+from src.api.api_keys import resolve_api_key as _resolve_api_key
 
 # Setup logger for this module
 logger = logging.getLogger('config_routes')
@@ -262,17 +263,6 @@ def create_config_blueprint(server_session_id=None):
         return jsonify({
             "max_tokens_per_chunk": _config.MAX_TOKENS_PER_CHUNK
         })
-
-    def _resolve_api_key(provided_key, env_var_name, config_default):
-        """Resolve API key from provided value, .env marker, or config default.
-
-        Returns the raw (possibly comma-separated) value — provider constructors
-        normalize via base.py. Callers that bypass providers (e.g. listing
-        endpoints using requests.get directly) must call _first_key() themselves.
-        """
-        if provided_key and provided_key != '__USE_ENV__':
-            return provided_key
-        return os.getenv(env_var_name, config_default)
 
     def _first_key(raw):
         """Pick the first usable key from a (possibly comma-separated) value.

--- a/src/api/blueprints/glossary_routes.py
+++ b/src/api/blueprints/glossary_routes.py
@@ -10,7 +10,6 @@ import asyncio
 import csv
 import io
 import logging
-import os
 import posixpath
 import re
 import zipfile
@@ -25,6 +24,7 @@ from src.core.glossary import build_glossary_block, filter_glossary
 from src.core.glossary import suggest_terms as ner_suggest_terms
 from src.core.glossary.models import GlossaryConfig
 from src.core.llm.exceptions import RateLimitError
+from src.api.api_keys import provider_env_var, resolve_api_key
 
 _NER_UPLOAD_MAX_BYTES = 100 * 1024 * 1024
 _NER_TEXT_EXTS = {'.txt', '.srt'}
@@ -853,20 +853,15 @@ def create_glossary_blueprint(store: Optional[GlossaryStore] = None):
             model = data.get('model') or _config.DEFAULT_MODEL
             api_endpoint = data.get('api_endpoint') or _config.API_ENDPOINT
 
-            api_key = data.get('api_key')
-            if not api_key:
-                env_key_map = {
-                    'gemini': 'GEMINI_API_KEY',
-                    'openai': 'OPENAI_API_KEY',
-                    'openrouter': 'OPENROUTER_API_KEY',
-                    'mistral': 'MISTRAL_API_KEY',
-                    'deepseek': 'DEEPSEEK_API_KEY',
-                    'poe': 'POE_API_KEY',
-                    'nim': 'NIM_API_KEY',
-                }
-                env_var = env_key_map.get(provider_type)
-                if env_var:
-                    api_key = os.getenv(env_var) or getattr(_config, env_var, None)
+            # The frontend sends the '__USE_ENV__' sentinel (or nothing) when the
+            # key field is empty but a key is configured in .env; resolve_api_key
+            # turns that back into the real, possibly multi-key, env value.
+            env_var = provider_env_var(provider_type)
+            api_key = resolve_api_key(
+                data.get('api_key'),
+                env_var,
+                getattr(_config, env_var, '') if env_var else '',
+            ) or None
 
             try:
                 provider = create_llm_provider(

--- a/src/api/blueprints/sample_routes.py
+++ b/src/api/blueprints/sample_routes.py
@@ -29,6 +29,8 @@ from src.core.glossary.models import GlossaryConfig
 from src.core.llm.factory import create_llm_provider
 from src.core.pricing.pricing_data import get_default_pricing
 from src.core.sampling import cap_chunk_text, select_sample_indices
+from src.api.api_keys import provider_env_var as _provider_env_var
+from src.api.api_keys import resolve_api_key as _resolve_api_key
 from src.core.text_processor import split_text_into_chunks
 from src.prompts.prompts import (
     generate_refinement_prompt, generate_translation_prompt,
@@ -70,30 +72,6 @@ def _small_document_warning(total: int, count: int, requested: int) -> Dict[str,
         "code": "warning_small_document",
         "params": {"total": total, "count": count, "requested": requested},
     }
-
-
-def _resolve_api_key(value: Any, env_var_name: str) -> str:
-    """Resolve `__USE_ENV__` placeholder to the actual env var value.
-
-    Mirrors `_resolve_api_key` in translation_routes.py — kept inline to avoid
-    cross-blueprint imports.
-    """
-    if value == "__USE_ENV__" or not value:
-        return os.getenv(env_var_name, "")
-    return value
-
-
-def _provider_env_var(provider: str) -> str:
-    """Return the env var name conventionally used for a provider's API key."""
-    return {
-        "gemini": "GEMINI_API_KEY",
-        "openai": "OPENAI_API_KEY",
-        "openrouter": "OPENROUTER_API_KEY",
-        "mistral": "MISTRAL_API_KEY",
-        "deepseek": "DEEPSEEK_API_KEY",
-        "poe": "POE_API_KEY",
-        "nim": "NIM_API_KEY",
-    }.get(provider.lower(), "")
 
 
 def _extract_plain_text(file_path: str, file_type: str) -> str:

--- a/src/api/blueprints/translation_routes.py
+++ b/src/api/blueprints/translation_routes.py
@@ -16,6 +16,7 @@ from src.config import (
     MAX_PARALLEL_TRANSLATIONS,
 )
 from src.tts.tts_config import TTSConfig
+from src.api.api_keys import resolve_api_key as _resolve_api_key
 
 
 def _clamp_parallel_workers(value):
@@ -30,23 +31,6 @@ def _clamp_parallel_workers(value):
         return max(1, min(MAX_PARALLEL_TRANSLATIONS, int(value)))
     except (TypeError, ValueError):
         return PARALLEL_TRANSLATIONS
-
-
-def _resolve_api_key(value, env_var_name):
-    """
-    Resolve API key value from request or environment.
-
-    Args:
-        value: Value from request (can be actual key, '__USE_ENV__', or empty)
-        env_var_name: Name of environment variable to fall back to
-
-    Returns:
-        Resolved API key string
-    """
-    if value == '__USE_ENV__' or not value:
-        # Use environment variable
-        return os.getenv(env_var_name, '')
-    return value
 
 
 # Cloud providers whose key lives in config['<provider>_api_key'] and env var

--- a/tests/unit/glossary/test_ner_endpoint.py
+++ b/tests/unit/glossary/test_ner_endpoint.py
@@ -115,5 +115,66 @@ class TestSuggestTermsRateLimit:
         assert body["retry_after"] is None
 
 
+class _CapturingProvider:
+    """Stand-in provider that records init kwargs and returns no candidates."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    async def suggest(self, *args, **kwargs):  # pragma: no cover - unused
+        return [], []
+
+    async def close(self):
+        pass
+
+
+class TestSuggestTermsApiKeyResolution:
+    """The endpoint must resolve the '__USE_ENV__' sentinel to the env key.
+
+    Regression for issue #200: with keys configured in .env, the frontend
+    sends api_key='__USE_ENV__'. The endpoint used to forward that literal
+    string to the provider, yielding 'API key not valid' from Gemini.
+    """
+
+    def _create_glossary(self, store):
+        return store.create_glossary(
+            name="env-key-test",
+            source_language="English",
+            target_language="French",
+        )
+
+    def test_use_env_sentinel_resolves_to_env_key(self, client, store):
+        glossary = self._create_glossary(store)
+
+        captured = {}
+
+        def _fake_factory(**kwargs):
+            captured.update(kwargs)
+            return _CapturingProvider(**kwargs)
+
+        async def _fake_suggest(*args, **kwargs):
+            return [], []
+
+        with patch(
+            "src.core.llm.factory.create_llm_provider",
+            side_effect=_fake_factory,
+        ), patch(
+            "src.api.blueprints.glossary_routes.ner_suggest_terms",
+            side_effect=_fake_suggest,
+        ), patch.dict(os.environ, {"GEMINI_API_KEY": "real-env-key"}):
+            response = client.post(
+                f"/api/glossaries/{glossary.id}/suggest-terms",
+                json={
+                    "text": "Some sample source text to analyze.",
+                    "provider": "gemini",
+                    "model": "gemini-3.1-flash-lite",
+                    "api_key": "__USE_ENV__",
+                },
+            )
+
+        assert response.status_code == 200, response.get_json()
+        assert captured.get("api_key") == "real-env-key"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/test_api_keys.py
+++ b/tests/unit/test_api_keys.py
@@ -1,0 +1,73 @@
+"""
+Unit tests for the shared API-key resolver (src/api/api_keys.py).
+
+Locks in the behavior that four blueprints rely on, including the
+'__USE_ENV__' sentinel resolution that regressed in issue #200.
+"""
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from src.api.api_keys import (
+    USE_ENV_SENTINEL,
+    provider_env_var,
+    resolve_api_key,
+)
+
+
+class TestProviderEnvVar:
+    def test_known_providers(self):
+        assert provider_env_var('gemini') == 'GEMINI_API_KEY'
+        assert provider_env_var('openai') == 'OPENAI_API_KEY'
+        assert provider_env_var('nim') == 'NIM_API_KEY'
+
+    def test_case_insensitive(self):
+        assert provider_env_var('Gemini') == 'GEMINI_API_KEY'
+        assert provider_env_var('OPENAI') == 'OPENAI_API_KEY'
+
+    def test_keyless_or_unknown_provider_returns_empty(self):
+        assert provider_env_var('ollama') == ''
+        assert provider_env_var('nonexistent') == ''
+        assert provider_env_var('') == ''
+        assert provider_env_var(None) == ''
+
+
+class TestResolveApiKey:
+    def test_real_key_is_returned_unchanged(self):
+        with patch.dict(os.environ, {'GEMINI_API_KEY': 'env-key'}):
+            assert resolve_api_key('real-key', 'GEMINI_API_KEY') == 'real-key'
+
+    def test_multi_key_string_passes_through(self):
+        # Comma-separated keys must survive intact for rotation.
+        raw = 'key-a,key-b,key-c'
+        assert resolve_api_key(raw, 'GEMINI_API_KEY') == raw
+
+    def test_sentinel_resolves_to_env(self):
+        with patch.dict(os.environ, {'GEMINI_API_KEY': 'env-key'}):
+            assert resolve_api_key(USE_ENV_SENTINEL, 'GEMINI_API_KEY') == 'env-key'
+
+    def test_empty_value_resolves_to_env(self):
+        with patch.dict(os.environ, {'GEMINI_API_KEY': 'env-key'}):
+            assert resolve_api_key('', 'GEMINI_API_KEY') == 'env-key'
+            assert resolve_api_key(None, 'GEMINI_API_KEY') == 'env-key'
+
+    def test_config_default_when_env_unset(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert resolve_api_key(USE_ENV_SENTINEL, 'GEMINI_API_KEY', 'cfg') == 'cfg'
+
+    def test_env_wins_over_config_default(self):
+        with patch.dict(os.environ, {'GEMINI_API_KEY': 'env-key'}):
+            assert resolve_api_key(USE_ENV_SENTINEL, 'GEMINI_API_KEY', 'cfg') == 'env-key'
+
+    def test_no_env_var_name_uses_config_default(self):
+        assert resolve_api_key(USE_ENV_SENTINEL, '', 'cfg') == 'cfg'
+        assert resolve_api_key('', '', '') == ''
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
## Summary

Recovers commit `f06d03c`, which was committed on 2026-06-10 to the already-merged branch `fix/completion-warning-untranslated-heading` (PR #197) and therefore never reached `main`.

The glossary NER extraction endpoint forwarded the frontend's `__USE_ENV__` placeholder verbatim to the provider when keys were configured in `.env`, so Gemini (and any keyed provider) rejected it as 'API key not valid' while translation kept working.

Fixes #200.

## Changes

- Factor the key resolution that was copy-pasted across four blueprints (translation/sample/config/glossary) into a single `src/api/api_keys.py` helper, so the sentinel is resolved consistently and a new endpoint can't reintroduce the divergence.
- Add unit tests for the helper (`tests/unit/test_api_keys.py`) and the NER endpoint (`tests/unit/glossary/test_ner_endpoint.py`).

## Verification

- Cherry-picked onto current `main`; the resulting patch is content-identical to the original commit (only line offsets shifted by the #210 auth changes).
- All existing call sites added since (#204 resume overrides, #213 key stripping) now route through the shared helper; no inline `__USE_ENV__` resolution remains in `src/api`.
- Full unit suite: 734 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)