### PR TITLE
fix(epub): strip web-scraping boilerplate before translation (#239)

### DIFF
--- a/src/core/epub/body_serializer.py
+++ b/src/core/epub/body_serializer.py
@@ -9,6 +9,7 @@ from typing import Tuple, Optional
 import re
 
 from src.utils.unified_logger import info, LogType
+from .boilerplate_filter import strip_web_boilerplate
 from .exceptions import XmlParsingError, BodyExtractionError
 
 
@@ -86,7 +87,9 @@ def normalize_whitespace(html: str) -> str:
 
 def extract_body_html(
     doc_root: etree._Element,
-    normalize: bool = True
+    normalize: bool = True,
+    strip_boilerplate: bool = True,
+    log_callback=None,
 ) -> Tuple[str, Optional[etree._Element]]:
     """
     Extract the HTML content of <body> as a string.
@@ -94,10 +97,19 @@ def extract_body_html(
     Args:
         doc_root: Root of the parsed XHTML document
         normalize: If True, normalize excessive whitespace (default: True)
+        strip_boilerplate: If True, remove web-scraping boilerplate (social
+            share bars, related-post widgets, prev/next nav, hidden elements)
+            before serialization so it is never translated (issue #239). The
+            EPUB3 TOC navigation is preserved.
+        log_callback: Optional callback for logging removed-boilerplate counts
 
     Returns:
         Tuple (body_inner_html, body_element)
         Returns ("", None) if no body element found
+
+    Note: when strip_boilerplate is True the body element is mutated in place;
+    both translation paths replace the body content afterwards, so the removed
+    elements simply never appear in the output.
     """
     # Try XHTML namespace first, then fallback to no namespace
     body = doc_root.find('.//{http://www.w3.org/1999/xhtml}body')
@@ -106,6 +118,9 @@ def extract_body_html(
 
     if body is None:
         return "", None
+
+    if strip_boilerplate:
+        strip_web_boilerplate(body, log_callback=log_callback)
 
     # Serialize the inner content of body (without the <body> tag itself)
     inner_html = etree.tostring(body, encoding='unicode', method='html')

--- a/src/core/epub/boilerplate_filter.py
+++ b/src/core/epub/boilerplate_filter.py
@@ -1,0 +1,180 @@
+"""
+Web-scraping boilerplate removal for EPUB content documents.
+
+Many EPUBs are built by scraping web pages (WordPress/Jetpack blogs, web-novel
+sites, ...). Their chapter bodies carry non-content artifacts that the original
+page rendered as chrome but that survive into the XHTML: social share bars
+("Share on X (Opens in new window)"), related-post widgets, prev/next
+navigation, "Loading..." spinners, screen-reader-only labels, etc.
+
+These artifacts are not prose. Left in place they get chunked, sent to the LLM,
+and translated literally (issue #239), polluting the output and wasting tokens.
+
+This module strips them from the body DOM *before* serialization, so they never
+reach the translator and never appear in the output. It is deliberately
+conservative: it targets structural signals (semantic tags, well-known
+class/id tokens, hidden attributes) rather than guessing from visible text,
+and it preserves the EPUB3 navigation document's TOC.
+"""
+import re
+from typing import Callable, Optional
+
+from lxml import etree
+
+# EPUB Open Packaging Structure namespace (carries epub:type).
+_OPS_NS = "http://www.idpf.org/2007/ops"
+
+# Local tag names that are non-content chrome in a chapter body.
+# <nav> is handled specially below so the EPUB3 TOC is preserved.
+_BOILERPLATE_TAGS = {"footer", "nav"}
+
+# epub:type values that mark a *legitimate* navigation document. A <nav> with
+# one of these is the book's real TOC/landmarks/page-list and must survive
+# (its labels are localized separately, see _update_nav_toc_labels_*).
+_PROTECTED_NAV_TYPES = {"toc", "landmarks", "page-list", "lot", "loi", "lov", "lot"}
+
+# class/id tokens that mark scraped widgets. Matched per whitespace-separated
+# token (and against the raw id), case-insensitively. Kept tight to avoid
+# nuking real prose containers.
+_BOILERPLATE_TOKEN_RE = re.compile(
+    r"""^(?:
+        sharedaddy | sd-sharing | sd-social | sd-block | sd-content |
+        share-?buttons? | sharebox | share-?bar | social-?share |
+        social-?links? | social-?media | social-?icons? |
+        addtoany | addthis | sharethis | jp-sharing |
+        jp-relatedposts | related-?posts? | related-?articles? | yarpp(?:-.*)? |
+        post-?navigation | post-?nav | nav-?links? | nav-?previous | nav-?next |
+        pagination | page-?links? | prev-?next | post-?pagination |
+        comment-?respond | comments?-area | comments?-list | jp-post-flair |
+        screen-?reader-?text | sr-only | visually-?hidden | a11y-hidden
+    )$""",
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def _local_name(element: etree._Element) -> str:
+    """Return the namespace-stripped lowercased tag name (or '' for comments)."""
+    tag = element.tag
+    if not isinstance(tag, str):  # comments, PIs
+        return ""
+    return etree.QName(tag).localname.lower()
+
+
+def _is_protected_nav(element: etree._Element) -> bool:
+    """True if this <nav> is the EPUB3 TOC / landmarks / page-list."""
+    epub_type = element.get(f"{{{_OPS_NS}}}type", "") or element.get("epub:type", "")
+    if any(t in _PROTECTED_NAV_TYPES for t in epub_type.lower().split()):
+        return True
+    # ARIA fallback used by some toolchains.
+    return element.get("role", "").lower() == "doc-toc"
+
+
+def _matches_boilerplate_attr(element: etree._Element) -> bool:
+    """True if the element's class tokens or id match a known boilerplate token."""
+    class_attr = element.get("class", "")
+    if class_attr:
+        for token in class_attr.split():
+            if _BOILERPLATE_TOKEN_RE.match(token):
+                return True
+    element_id = element.get("id", "")
+    if element_id and _BOILERPLATE_TOKEN_RE.match(element_id.strip()):
+        return True
+    return False
+
+
+def _is_hidden(element: etree._Element) -> bool:
+    """True if the element is explicitly hidden (so it carries no visible prose)."""
+    if element.get("hidden") is not None:
+        return True
+    if element.get("aria-hidden", "").lower() == "true":
+        return True
+    style = element.get("style", "")
+    if style and re.search(r"(?:display\s*:\s*none|visibility\s*:\s*hidden)", style, re.IGNORECASE):
+        return True
+    return False
+
+
+def _should_strip(element: etree._Element) -> bool:
+    name = _local_name(element)
+    if name == "nav":
+        return not _is_protected_nav(element)
+    if name in _BOILERPLATE_TAGS:
+        return True
+    if _matches_boilerplate_attr(element):
+        return True
+    if _is_hidden(element):
+        return True
+    return False
+
+
+def _remove_preserving_tail(element: etree._Element) -> None:
+    """Detach an element while keeping any text that trailed it in the parent.
+
+    lxml drops an element's ``tail`` when it is removed; for boilerplate that
+    tail is whitespace, but we move it to the nearest text anchor anyway so we
+    never silently drop adjacent prose.
+    """
+    parent = element.getparent()
+    if parent is None:
+        return
+    tail = element.tail
+    if tail:
+        prev = element.getprevious()
+        if prev is not None:
+            prev.tail = (prev.tail or "") + tail
+        else:
+            parent.text = (parent.text or "") + tail
+    parent.remove(element)
+
+
+def strip_web_boilerplate(
+    body: Optional[etree._Element],
+    log_callback: Optional[Callable] = None,
+) -> int:
+    """Remove scraped web boilerplate from a body element, in place.
+
+    Walks the body once, collecting the topmost matching elements (a matched
+    ancestor short-circuits its descendants), then detaches them. Returns the
+    number of elements removed.
+
+    The EPUB3 navigation document's TOC (<nav epub:type="toc">) is preserved.
+    """
+    if body is None:
+        return 0
+
+    to_remove = []
+    # iter() is document order (parents before children); skipping the subtree
+    # of an already-matched element avoids double-counting nested widgets.
+    skip_until_outside = None
+    for element in body.iter():
+        if not isinstance(element.tag, str):
+            continue
+        if skip_until_outside is not None:
+            # Still inside a subtree already marked for removal?
+            ancestor = element.getparent()
+            inside = False
+            while ancestor is not None:
+                if ancestor is skip_until_outside:
+                    inside = True
+                    break
+                ancestor = ancestor.getparent()
+            if inside:
+                continue
+            skip_until_outside = None
+        if element is body:
+            continue
+        if _should_strip(element):
+            to_remove.append(element)
+            skip_until_outside = element
+
+    for element in to_remove:
+        _remove_preserving_tail(element)
+
+    if to_remove and log_callback:
+        log_callback(
+            "boilerplate_stripped",
+            f"🧹 Removed {len(to_remove)} web-scraping boilerplate "
+            f"element(s) (share bars, related posts, nav, hidden) before translation",
+        )
+
+    return len(to_remove)

--- a/src/core/epub/epub_translation_adapter.py
+++ b/src/core/epub/epub_translation_adapter.py
@@ -48,7 +48,7 @@ class EpubTranslationAdapter(TranslationAdapter[etree._Element, bool]):
             - body_html: HTML content from body
             - context: Dict avec body_element et preserver
         """
-        body_html, body_element = extract_body_html(source)
+        body_html, body_element = extract_body_html(source, log_callback=log_callback)
 
         if log_callback:
             log_callback("body_extracted", f"Extracted {len(body_html)} chars from XHTML body")

--- a/src/core/epub/xhtml_translator.py
+++ b/src/core/epub/xhtml_translator.py
@@ -594,7 +594,7 @@ def _setup_translation(
         Tuple of (body_html, body_element, tag_preserver)
     """
     # Extract body
-    body_html, body_element = extract_body_html(doc_root)
+    body_html, body_element = extract_body_html(doc_root, log_callback=log_callback)
 
     # Initialize tag preserver (use container if provided, otherwise create directly)
     if container is not None:

--- a/tests/unit/epub/test_boilerplate_filter.py
+++ b/tests/unit/epub/test_boilerplate_filter.py
@@ -1,0 +1,146 @@
+"""
+Unit tests for web-scraping boilerplate removal (issue #239).
+
+Covers the artifact families seen in scraped EPUBs (social share bars, related
+posts, prev/next navigation, footers, hidden elements) and verifies that the
+EPUB3 TOC navigation document is preserved.
+"""
+import pytest
+from lxml import etree
+
+from src.core.epub.boilerplate_filter import strip_web_boilerplate
+from src.core.epub.body_serializer import extract_body_html
+
+XHTML_NS = "http://www.w3.org/1999/xhtml"
+
+
+def _body(inner_html: str) -> etree._Element:
+    """Parse an XHTML body fragment and return the <body> element."""
+    doc = (
+        f'<html xmlns="{XHTML_NS}" xmlns:epub="http://www.idpf.org/2007/ops">'
+        f"<body>{inner_html}</body></html>"
+    )
+    root = etree.fromstring(doc.encode("utf-8"))
+    return root.find(f".//{{{XHTML_NS}}}body")
+
+
+def _text(body: etree._Element) -> str:
+    return " ".join(t.strip() for t in body.itertext() if t.strip())
+
+
+class TestStripWebBoilerplate:
+    def test_removes_jetpack_share_bar(self):
+        body = _body(
+            "<p>Real prose.</p>"
+            '<div class="sharedaddy sd-sharing-enabled">'
+            "<h3>Share this:</h3>"
+            '<a class="share-twitter">Share on X (Opens in new window)</a>'
+            "</div>"
+        )
+        removed = strip_web_boilerplate(body)
+        assert removed == 1
+        assert "Real prose." in _text(body)
+        assert "Share on X" not in _text(body)
+
+    def test_removes_related_posts(self):
+        body = _body('<p>Keep me.</p><div id="jp-relatedposts">Related</div>')
+        assert strip_web_boilerplate(body) == 1
+        assert "Related" not in _text(body)
+        assert "Keep me." in _text(body)
+
+    def test_removes_prev_next_navigation(self):
+        body = _body(
+            '<div class="post-navigation"><a>PREV</a><a>NEXT</a></div>'
+            "<p>Chapter body.</p>"
+        )
+        assert strip_web_boilerplate(body) == 1
+        assert "PREV" not in _text(body)
+        assert "Chapter body." in _text(body)
+
+    def test_removes_footer_tag(self):
+        body = _body("<p>Story.</p><footer>SukaMemuat... PREV TOC NEXT</footer>")
+        assert strip_web_boilerplate(body) == 1
+        assert "Story." in _text(body)
+        assert "SukaMemuat" not in _text(body)
+
+    def test_removes_hidden_elements(self):
+        body = _body(
+            '<p>Visible.</p>'
+            '<span class="screen-reader-text">Posted in Uncategorized</span>'
+            '<div style="display:none">tracking pixel alt</div>'
+            '<div aria-hidden="true">decorative</div>'
+        )
+        assert strip_web_boilerplate(body) == 3
+        assert _text(body) == "Visible."
+
+    def test_preserves_epub3_toc_nav(self):
+        body = _body(
+            '<nav epub:type="toc"><ol><li><a href="c1.xhtml">Chapter 1</a></li></ol></nav>'
+        )
+        assert strip_web_boilerplate(body) == 0
+        assert "Chapter 1" in _text(body)
+
+    def test_preserves_landmarks_nav(self):
+        body = _body('<nav epub:type="landmarks"><a href="c1.xhtml">Start</a></nav>')
+        assert strip_web_boilerplate(body) == 0
+        assert "Start" in _text(body)
+
+    def test_removes_non_toc_nav(self):
+        body = _body('<p>Text.</p><nav><a>PREV</a><a>NEXT</a></nav>')
+        assert strip_web_boilerplate(body) == 1
+        assert "PREV" not in _text(body)
+
+    def test_nested_widgets_counted_once(self):
+        body = _body(
+            '<div class="sharedaddy">'
+            '<div class="sd-block sd-social"><a>X</a></div>'
+            "</div>"
+        )
+        # Outer match short-circuits the nested one.
+        assert strip_web_boilerplate(body) == 1
+
+    def test_preserves_ordinary_content(self):
+        body = _body(
+            "<h1>Chapter 1</h1>"
+            "<p>A paragraph that merely mentions the word share casually.</p>"
+            '<div class="chapter-text">More prose.</div>'
+        )
+        assert strip_web_boilerplate(body) == 0
+        assert "Chapter 1" in _text(body)
+        assert "More prose." in _text(body)
+
+    def test_preserves_tail_text(self):
+        # Text trailing a stripped element must not be lost.
+        body = _body('<p>Before.</p><footer>junk</footer> After.')
+        strip_web_boilerplate(body)
+        assert "After." in _text(body)
+        assert "junk" not in _text(body)
+
+    def test_none_body_is_safe(self):
+        assert strip_web_boilerplate(None) == 0
+
+    def test_logs_when_removed(self):
+        events = []
+        body = _body('<footer>x</footer>')
+        strip_web_boilerplate(body, log_callback=lambda e, m, *a, **k: events.append(e))
+        assert "boilerplate_stripped" in events
+
+
+class TestExtractBodyHtmlIntegration:
+    def _root(self, inner_html: str) -> etree._Element:
+        doc = (
+            f'<html xmlns="{XHTML_NS}" xmlns:epub="http://www.idpf.org/2007/ops">'
+            f"<body>{inner_html}</body></html>"
+        )
+        return etree.fromstring(doc.encode("utf-8"))
+
+    def test_extract_strips_by_default(self):
+        root = self._root('<p>Prose.</p><div class="sharedaddy"><a>Share on X</a></div>')
+        html, body = extract_body_html(root)
+        assert "Prose." in html
+        assert "Share on X" not in html
+
+    def test_extract_can_opt_out(self):
+        root = self._root('<p>Prose.</p><div class="sharedaddy"><a>Share on X</a></div>')
+        html, body = extract_body_html(root, strip_boilerplate=False)
+        assert "Share on X" in html


### PR DESCRIPTION
## What

Fixes the **web-scraping artifacts** half of #239: scraped EPUBs (WordPress/Jetpack, web-novel sites) carry non-content chrome in chapter bodies — social share bars (`Share on X (Opens in new window)`), related-post widgets, prev/next navigation, `Loading...` spinners, screen-reader-only labels. These were extracted as prose, chunked, and translated literally, polluting the output and wasting tokens.

## How

New `src/core/epub/boilerplate_filter.py` removes these elements from the body DOM **before serialization**, so they never reach the translator and never appear in the output. Design choices:

- Targets **structural signals** (semantic `<footer>`/`<nav>` tags, well-known class/id tokens, hidden attributes), not visible text — text-based stripping would be locale-dependent and risky.
- **Preserves the EPUB3 TOC** (`<nav epub:type="toc|landmarks|page-list">`, `role="doc-toc"`) so the #195 TOC fix is not regressed.
- **Preserves adjacent tail text** to avoid any content loss.
- Nested widgets count once (a matched ancestor short-circuits descendants).

Wired into `extract_body_html` (on by default, opt-out via `strip_boilerplate=False`); both EPUB extraction paths forward the log callback, so the user sees `🧹 Removed N web-scraping boilerplate element(s)`.

## Tests

`tests/unit/epub/test_boilerplate_filter.py` (15 cases) covers every artifact family, the TOC guard, prose preservation and tail-text preservation. Full EPUB suite green (330 tests, no regression).

## Out of scope

- Bare unclassed text artifacts (e.g. `PREVTOCNEXT` in a class-less `<p>`) — would require text heuristics.
- The **language-switching** half of #239 is a separate root cause (empty/refused responses returning `None` → original kept) and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)