### PR TITLE
Sprint 2 — security and data integrity (#215, #211, #206, #228, #216)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -165,6 +165,14 @@ MAX_TRANSLATION_ATTEMPTS=3
 PARALLEL_TRANSLATIONS=1
 MAX_PARALLEL_TRANSLATIONS=16      # Upper bound for the CLI flag and web UI control
 
+# Extra hostnames the LLM endpoint validator accepts, comma-separated.
+# The known provider hosts and every endpoint configured above are already
+# allowed, as are localhost and private/LAN addresses. Add an entry only for a
+# self-hosted gateway on a public hostname. Not editable from the web UI on
+# purpose: widening the allowlist from the browser would reopen the
+# credential-exfiltration path this guard closes.
+# LLM_ENDPOINT_ALLOWLIST=llm.internal.example.com,gateway.example.org
+
 # Web UI default for the "Don't auto-pause on rate limit" checkbox. Mirror of
 # AUTO_PAUSE_ON_RATE_LIMIT (true here ⇔ AUTO_PAUSE_ON_RATE_LIMIT=false for new
 # jobs). Persisted separately so the UI can show the checkbox state across

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,750 @@
+# Working Backlog
+
+Prioritized, verified triage of every open issue, pull request and discussion as of 2026-08-01.
+
+Every item below was checked against the code at `main` (`2827ed5`). Line references were valid at that
+commit; re-check them if you pick up an item much later. Items already fixed in code are listed in
+[Housekeeping](#housekeeping) rather than silently dropped.
+
+**How to use this document.** Work top to bottom. Each item is a self-contained card: symptom, verified
+evidence, fix direction, done-criteria. Tick the checkbox and add the PR number when it lands. Do not
+reorder sprints without a reason written into the item.
+
+**Effort key.** `S` under an hour. `M` a few hours. `L` multi-day.
+
+---
+
+## Table of contents
+
+- [Sprint 1 — correctness and noise reduction](#sprint-1--correctness-and-noise-reduction)
+- [Sprint 2 — security and data integrity](#sprint-2--security-and-data-integrity)
+- [Sprint 3 — provider layer and config plumbing](#sprint-3--provider-layer-and-config-plumbing)
+- [Sprint 4 — i18n and technical debt](#sprint-4--i18n-and-technical-debt)
+- [Feature queue](#feature-queue)
+- [Pull requests](#pull-requests)
+- [Housekeeping](#housekeeping)
+- [Deferred and product decisions](#deferred-and-product-decisions)
+- [Cross-cutting notes](#cross-cutting-notes)
+
+---
+
+## Sprint 1 — correctness and noise reduction
+
+Goal: stop reporting success when the output is incomplete, stop generating support tickets for trivial
+causes, and unblock the UI. Everything here is small or medium effort with directly visible user impact.
+
+### [ ] 1.1 — Issue #239: jobs marked `completed` while chunks stayed in the source language
+
+**Symptom.** A book finishes as "Complete", but scattered paragraphs are still in the source language.
+No partial-completion card is shown and no resume option is offered, because the checkpoint has already
+been deleted.
+
+**Verified cause.** When a chunk exhausts all retries, the EPUB path falls back to the source text and
+increments a *separate* counter at `src/core/epub/xhtml_translator.py:565` (`stats.fallback_used`).
+The completion classifier at `src/api/handlers.py:611` and `:621` only inspects `stats.failed_chunks`,
+which fallback chunks never touch. The job is therefore classified `completed`, and
+`checkpoint_manager.cleanup_completed_job` (`src/api/handlers.py:637`) destroys the resume data.
+
+This is the unfixed half of #239. The other half, web-scraping boilerplate leaking into the
+translation, was fixed by PR #240 (`2827ed5`).
+
+**Fix direction.** Make the completion classifier consider fallback chunks as unfinished work: treat
+`failed_chunks + fallback_used > 0` as `partial`. Keep the two counters distinct in the stats payload so
+the UI can distinguish "failed outright" from "left as source text", and do not delete the checkpoint
+for a `partial` job. The partial-completion card added in `55efe12` already renders correctly once the
+status is right.
+
+**Done when.** A run where at least one chunk exhausts its retries ends as `partial`, keeps its
+checkpoint, offers resume, and the completion card names the number of untranslated chunks. Add a unit
+test that drives the classifier with `fallback_used=1, failed_chunks=0`.
+
+**Effort.** S/M. **Blocks.** Item 1.2, item 5.5.
+
+---
+
+### [ ] 1.2 — Issue #246: UI reports success, download fails, output directory is empty
+
+**Symptom.** Reported in Chinese: the interface shows the translation as finished, downloading raises an
+error, and the output directory turns out to be empty.
+
+**Status.** Unconfirmed, no repro attached, zero maintainer comments so far. Strongly suspected to be a
+second symptom of the same status-classification defect as item 1.1: a job is marked complete and its
+checkpoint cleaned up before the output file was actually assembled on disk.
+
+**Fix direction.** Do item 1.1 first, then ask the reporter to retest. If it still occurs, the remaining
+suspect is an exception thrown between "mark completed" and final file assembly, which would leave the
+DB row consistent and the filesystem empty. Add a post-assembly existence check before a job is allowed
+to reach `completed`: if the output path does not exist or is zero bytes, classify as `error` and keep
+the checkpoint.
+
+**Done when.** Either the reporter confirms it is gone after 1.1, or a repro is obtained and the
+existence guard is in place with a test.
+
+**Effort.** S once 1.1 lands. **Depends on.** Item 1.1.
+
+---
+
+### [ ] 1.3 — Issue #241: Docker version check reports an update that is already installed
+
+**Symptom.** Two users, one on Docker and one on Linux, see the update banner claiming a new version is
+available immediately after updating.
+
+**Verified cause.** `git show v1.4.10:src/__version__.py` returns `__version__ = "1.4.9"`. The tag was
+cut without bumping the version file, so the running app compares its own stale string against the
+GitHub release tag and always finds itself behind. Diagnosed correctly by `aronsky` in the thread.
+
+**Fix direction.** Bump `src/__version__.py`, then prevent recurrence: add a release-workflow step that
+fails if the pushed tag does not match `src.__version__`. This is the actual value of the item, the
+version string itself is a one-line fix that will be forgotten again otherwise.
+
+**Done when.** `src/__version__.py` matches the latest tag, and a CI job rejects a mismatched tag.
+
+**Effort.** S.
+
+---
+
+### [ ] 1.4 — Issue #208: TXT output loses paragraph breaks at every chunk boundary
+
+**Symptom.** In non-bilingual TXT mode, paragraph separations disappear at each chunk seam. The chunker
+splits on `\n\n` (`src/core/chunking/token_chunker.py:59`), but reassembly does not restore it.
+
+**Verified cause.** Two joiners:
+- `src/core/adapters/txt_adapter.py:151` — `joiner = "\n\n" if bilingual else "\n"`
+- `src/core/refine/txt_refiner.py:129` — `final_text = "\n".join(refined_parts)`
+
+**Fix direction.** Join with `"\n\n"` in both paths. Verify no double-blank-line regression when a chunk
+already ends with a newline; strip trailing whitespace per chunk before joining.
+
+**Done when.** A multi-chunk TXT translation reproduces the source paragraph structure at every seam, in
+both the translate and refine paths. Covered by a test with a three-paragraph, two-chunk input.
+
+**Effort.** S.
+
+---
+
+### [ ] 1.5 — Issue #225: a late or foreign `completed` event resets the UI mid-batch
+
+**Symptom.** During a batch, the whole UI resets to idle and the queue display is lost, while
+translation continues server-side.
+
+**Verified cause.** `src/web/static/js/translation/translation-tracker.js:397-406`. When
+`currentJob` is null, the only guard before calling `resetUIToIdle()` is that `data.translation_id`
+exists and the status is terminal. There is no check that the job belongs to this tab.
+`finishCurrentFileTranslation` (`:585`) sets `currentJob` to null *before* advancing the queue
+(`processNextFileInQueue()` at `:588`/`:596`), so any straggler event arriving in that window wipes the
+batch UI.
+
+**Fix direction.** Track the set of translation IDs this tab started and ignore terminal events for
+unknown IDs. Alternatively, do not null `currentJob` until the next file's job is registered.
+
+**Done when.** A synthetic terminal event with an unknown `translation_id` no longer resets the UI, and a
+batch of three files completes without visual reset between files.
+
+**Effort.** S.
+
+---
+
+### [ ] 1.6 — Issue #224: desync recovery dispatches events nobody listens to
+
+**Symptom.** After a WebSocket drop, the UI stays stuck on "in progress" until a manual page reload,
+even though the recovery code believes it resynced.
+
+**Verified cause.** `src/web/static/js/utils/lifecycle-manager.js:228` dispatches a window
+`CustomEvent('translationUpdate')` and `:240` dispatches `CustomEvent('resetUIToIdle')`. A repo-wide grep
+over `src/web/static/js` for `addEventListener('translationUpdate'` and `addEventListener('resetUIToIdle'`
+returns zero matches. The real Socket.IO handler is bound to `translation_update` (underscore). The
+recovery path is a silent no-op.
+
+**Fix direction.** Call the tracker's handlers directly (`TranslationTracker.handleTranslationUpdate`,
+`resetUIToIdle`) instead of dispatching dead events, or register listeners for the two event names. Prefer
+the direct call and delete the dead dispatch, one less indirection.
+
+**Done when.** Killing the WebSocket mid-job and letting it reconnect resyncs the UI without a reload.
+
+**Effort.** S. **Related.** Item 1.5, same file cluster, ship together.
+
+---
+
+### [ ] 1.7 — Close five stale issues
+
+All verified as already resolved in code. Closing them removes a third of the open-issue noise and makes
+future triage cheaper.
+
+- **#183** — switching model/provider when resuming. Shipped v1.4.1. `POST /api/resume/<id>` accepts
+  `model`, `llm_provider`, `llm_api_endpoint`, `api_key`, `context_window` overrides
+  (`src/api/blueprints/translation_routes.py:318-319`).
+- **#167** — notification system. Shipped v1.3.3. `src/utils/notifier.py`, `NOTIFY_WEBHOOK_URL` config,
+  `tests/unit/test_notifier.py` all present.
+- **#155** — EPUB upload failure and stuck LLM indicator. Two causes fixed: init race (`c5ec9b4`) and
+  Windows registry serving `.js` as `text/plain` (`f90532a`, v1.2.2). The `mimetypes.add_type` calls are
+  present at `translation_api.py:12-16`.
+- **#174** — context length question. Answered as an Ollama/LM Studio configuration matter
+  (`MAX_TOKENS_PER_CHUNK`, `OLLAMA_NUM_CTX`). No code gap. Consider linking the answer into
+  `docs/TROUBLESHOOTING.md` before closing.
+- **#229** — stats counters. Fixed by a later refactor:
+  `src/core/adapters/generic_translator.py:280-299` now accumulates `failed_count` via `nonlocal`, and
+  the success path at `:358-373` uses a separate `completed_count` incremented only on genuine save
+  success. No trace of the reported behaviour remains.
+
+**Also.** Consolidate #140 and #234 into a single PDF tracking issue (see item 5.1), and close #196 with
+a pointer to #198, which already tracks its only in-scope part.
+
+**Effort.** S, no code.
+
+---
+
+## Sprint 2 — security and data integrity
+
+Goal: close the two real security primitives and stop the two silent data-corruption paths. PR #233
+(CORS lockdown plus per-session token on every `/api/` route) changed the *reachability* of several of
+these but not the underlying flaws, which is why they remain here.
+
+### [x] 2.1 — Issue #215 (PR #252): zip-slip on EPUB resume reconstruction
+
+**Symptom.** A crafted EPUB containing `../` entry paths can write files outside the intended directory
+when a job is resumed.
+
+**Verified cause.** `src/utils/security.py` `_validate_epub_file` (around `:380-430`) checks mimetype,
+zip-bomb ratios and suspicious extensions, but never validates entry paths.
+`src/persistence/checkpoint_manager.py:678` calls `zip_ref.extractall(temp_path)` unguarded, and `:744`
+joins `job_dir / file_href` with no containment check. Not touched by PR #233, which addressed an
+unrelated code path.
+
+**Fix direction.** Validate every archive entry before extraction: reject absolute paths, drive letters,
+and any entry whose resolved path is not inside the destination. Do the same for the `file_href` join.
+Prefer a shared helper in `src/utils/security.py` used by both call sites, and reject at validation time
+so a malicious EPUB never reaches extraction.
+
+**Done when.** A test fixture EPUB containing `../../evil.txt` is rejected at validation, and a second
+test asserts nothing was written outside the temp directory.
+
+**Effort.** M. **Severity.** Arbitrary file write.
+
+---
+
+### [x] 2.2 — Issue #211 (PR #252): SSRF and API-key exfiltration via `llm_api_endpoint`
+
+**Symptom.** A request can point the translation job at an attacker-controlled endpoint while the server
+supplies its own stored API key, sending that key to the attacker.
+
+**Verified cause.** `src/api/blueprints/translation_routes.py:177` accepts `llm_api_endpoint` verbatim
+from the request body. No allowlist exists anywhere in the repo. `resolve_api_key()` in
+`src/api/api_keys.py` falls back to the server's `.env` key whenever the request sends an empty value or
+the `__USE_ENV__` sentinel, so the override does not have to carry its own credential.
+
+**What PR #233 changed.** It removed wildcard CORS and gated `/api/` behind a per-session token, which
+closes the drive-by cross-site delivery described in the original report. The flaw itself is unpatched:
+it remains reachable by anyone able to present the session token, that is via XSS, a malicious browser
+extension, or a token shared on a LAN.
+
+**Fix direction.** Never pair a request-supplied endpoint with a server-stored key. Two guards, both
+cheap:
+1. Allowlist endpoint hosts (known provider domains plus loopback and private ranges for self-hosted
+   Ollama and LM Studio, ideally configurable via `.env`).
+2. If the request overrides the endpoint, require it to also supply its own key, and refuse the `.env`
+   fallback in that case.
+
+**Done when.** A job pointing at an unlisted external host is rejected, and a job overriding the endpoint
+without a key does not fall back to the stored credential. Both covered by tests.
+
+**Effort.** S. **Severity.** Credential exfiltration.
+
+---
+
+### [x] 2.3 — Issue #206 (PR #252): DOCX rebuild drops blockquotes and duplicates nested content
+
+**Symptom.** Translated DOCX output silently loses blockquote content and repeats nested list items. Mixed
+header/data table rows come out reordered.
+
+**Verified cause.** All in `src/core/docx/converter.py`:
+- `:374-388` `_convert_html_element_to_docx` branches only on `p`, `h1`-`h6`, `ul`/`ol`, `table`, `br`,
+  `img`. The comment at `:388` reads `# Skip other tags`, so `blockquote` falls through and is dropped.
+- `:421` `_convert_list` uses `element.findall('.//li')`, a descendant search, while `_get_text_content`
+  (`:531-533`) uses `itertext()` which already recurses. A nested `<li>` is therefore emitted once inside
+  its parent's text and again on its own.
+- `:432` `_convert_table` has the identical `.//tr` problem for nested tables, and `:449` builds cells as
+  `findall('.//td') + findall('.//th')`, putting all data cells before all header cells regardless of
+  source order.
+
+**Fix direction.** Add a `blockquote` branch mapping to the Word "Quote" style (or an indented paragraph
+if the style is absent). Replace the descendant searches with direct-child iteration for both `li` and
+`tr`, and recurse explicitly for nesting. Build the cell list in document order rather than by tag.
+
+**Done when.** A round-trip test on a DOCX containing a blockquote, a two-level nested list, a nested
+table and a mixed `th`/`td` row reproduces the structure faithfully.
+
+**Effort.** M. **Severity.** Silent content corruption in a shipped format.
+
+---
+
+### [x] 2.4 — Issue #228 (PR #252): a rate-limit pause discards work already paid for
+
+**Symptom.** When a provider rate-limits a run and the app auto-pauses, refine-mode and plain-text-mode
+work already completed in that pass is thrown away. Resuming re-sends and re-pays for the same chunks.
+
+**Verified cause.**
+- `src/core/translator.py` `refine_chunks` (around `:826-835`) fills a local `refined_parts` list with
+  remaining chunks on `RateLimitError`, then re-raises bare, discarding the list without a checkpoint.
+- `src/core/common/plain_text_pipeline.py:268-271` calls `_fill_remaining_with_source()` and then
+  `:328-329` raises `rate_limit_error`, same shape.
+
+The interruption path immediately below (`:333-341`) does the right thing and returns the reassembled
+partial result. Only the rate-limit path loses it.
+
+**Fix direction.** Make the rate-limit path mirror the interruption path: persist the partial result and
+checkpoint before propagating the pause. Rate-limit pauses are routine, not an edge case, so this is
+recurring waste rather than a rare loss.
+
+**Done when.** A run interrupted by a simulated 429 mid-pass resumes without re-translating chunks that
+had already succeeded.
+
+**Effort.** M.
+
+---
+
+### [x] 2.5 — Issue #216 (PR #252): `PRAGMA foreign_keys` is never enabled, so checkpoints never cascade-delete
+
+**Symptom.** The database grows without bound. `checkpoint_chunks` rows, which hold full original and
+translated text, are never removed.
+
+**Verified cause.** `src/persistence/database.py` `_get_connection` (`:53-65`) sets only
+`journal_mode=WAL` (`:62`) and `busy_timeout` (`:63`). The schema at `:106-109` declares
+`ON DELETE CASCADE`, which SQLite enforces per connection only when the `foreign_keys` pragma is on.
+`delete_job` (`:594-618`) and `cleanup_old_jobs` (`:479-521`) delete only from `translation_jobs` and
+rely on a cascade that never fires. The comment at `:509` asserting "chunks deleted via CASCADE" is
+wrong.
+
+**Fix direction.** Add `conn.execute("PRAGMA foreign_keys = ON")` in `_get_connection`. Add an explicit
+`DELETE FROM checkpoint_chunks` in both methods as defence in depth, and ship a one-off cleanup for
+already-orphaned rows.
+
+**Done when.** Deleting a job removes its chunk rows, and a migration reclaims existing orphans.
+
+**Effort.** S.
+
+---
+
+## Sprint 3 — provider layer and config plumbing
+
+Goal: a batch of independent small fixes in the LLM layer. Individually low severity, collectively the
+reason cost reporting, key handling and error messages cannot be trusted.
+
+### [ ] 3.1 — Issue #230: per-job NIM API key is silently dropped for TXT, SRT and DOCX
+
+`nim_api_key` is threaded through the EPUB path only. The TXT and SRT `llm_config` dict and the DOCX
+`create_llm_provider` call in `src/core/adapters/translate_file.py` omit it, so
+`src/core/llm/factory.py:163` falls back to `os.getenv("NIM_API_KEY")`. A user supplying a per-job key in
+the UI silently gets the server's key, or none at all.
+
+**Done when.** All four formats forward the per-job key. Add a test asserting the factory receives it.
+**Effort.** S.
+
+---
+
+### [ ] 3.2 — Issue #218: OpenRouter and Poe cost tracking is shared across jobs and reads a missing field
+
+Two defects:
+- `src/core/llm/providers/openrouter.py:62-64` and `poe.py:76-78` declare `_session_cost`,
+  `_session_tokens` and `_cost_callback` as **class** attributes, mutated via classmethods called from
+  `src/api/handlers.py:225-227` and `:679`. Concurrent jobs, which the app supports, contaminate each
+  other's totals.
+- `openrouter.py:281` checks for a top-level `"cost"` key, but the request payload (`:231-237`) never
+  sets `"usage": {"include": true}`, so the field is never present and the code always falls through to
+  the hardcoded $0.50/$1.50-per-million estimate at `:285`.
+
+**Done when.** Cost state is per-instance, and OpenRouter requests ask for usage so real costs are used
+when available, with the estimate kept as an explicit fallback.
+**Effort.** S.
+
+---
+
+### [ ] 3.3 — Issue #219: an invalid Mistral or DeepSeek key is retried instead of failing fast
+
+In `mistral.py`, `raise ValueError("Invalid Mistral API key")` on `status_code == 401` sits inside the
+same `try` whose trailing `except Exception` (around `:329`) catches it, logs "API Unknown Error", sleeps
+and retries, eventually returning `None`. `deepseek.py` has the identical shape. As a consequence the
+401 branches inside the `HTTPStatusError` handler in both files are dead code, since a 401 never reaches
+`raise_for_status()`. `poe.py` gets this right and returns `None` immediately, use it as the model.
+
+**Done when.** A bad key surfaces a clear credential error on the first attempt, with no retry storm.
+**Effort.** S.
+
+---
+
+### [ ] 3.4 — Issue #220: thinking-model detection is a no-op after the Ollama refactor
+
+`src/core/llm_client.py:139-140` and `:154-158` still probe for `_is_thinking_model` and
+`_detect_thinking_model`, but `src/core/llm/providers/ollama.py` now exposes `_detect_thinking_behavior()`
+(`:100`) and `_thinking_behavior` (`:44`). The `hasattr` checks fail, so the pre-warm call at
+`src/core/translator.py:759-760` does nothing and the repetition-loop mitigation never arms.
+
+Separately, `gemini.py:79` and `deepseek.py:101` define `_is_thinking_model` as a plain method, so
+`get_is_thinking_model()` returns a truthy bound method rather than a boolean, and never reports `False`.
+
+**Done when.** Ollama detection runs again, and the Gemini/DeepSeek accessor returns a real boolean.
+**Effort.** S/M.
+
+---
+
+### [ ] 3.5 — Issue #231: eight independent correctness bugs in the LLM layer
+
+All eight verified as still present. Good candidate for one grouped PR, one commit each.
+
+1. `pricing_data.py` — the substring-match loop is insertion-order dependent, so a shorter model key can
+   shadow a longer one.
+2. `ollama.py` streaming — `raise_for_status()` is called inside `client.stream()` before the body is
+   read, so `e.response.json()` raises `ResponseNotRead` and is swallowed by a bare `except`.
+   Context-overflow detection never fires for streamed 400s.
+3. `gemini.py` around `:232` — only `parts[0]` is read, additional parts are dropped.
+4. `ollama.py:661` — references `self._context_detector`, never assigned in `__init__`. The
+   `AttributeError` is swallowed by a broad `except`.
+5. `thinking/detection.py` — `elif phrase_len >= 40` is unreachable after an earlier `phrase_len >= 20`
+   check.
+6. `litellm.py` — `KeyPool.peek()` is called once before the retry loop, with no `acquire()` or
+   `mark_throttled()`. Key rotation is effectively dead for this provider.
+7. `thinking/cache.py` — `tested_at` uses `loop.time()`, a monotonic clock, persisted as if it were wall
+   clock.
+8. `rate_limit_handler.py` — 408 falls in the 4xx non-retryable range, so a request timeout is never
+   retried.
+
+**Done when.** Each has a regression test or, where untestable, a comment explaining the invariant.
+**Effort.** M for the bundle.
+
+---
+
+### [ ] 3.6 — Issue #226: only the Ollama loader guards against stale provider responses
+
+`src/web/static/js/providers/provider-manager.js` `loadOllamaModels` (`:479-511`) uses a cancellation
+token stored in `StateManager` plus a post-await re-check that the selected provider is still Ollama.
+None of the other seven loaders do: Gemini (`:608`), OpenAI (`:662`), OpenRouter (`:757`), Mistral
+(`:820`), DeepSeek (`:873`), NIM (`:934`), Poe (`:991`). Switching providers while a fetch is in flight
+repopulates the dropdown with the previous provider's models.
+
+**Fix direction.** Extract the Ollama guard into a shared helper and wrap all eight loaders.
+**Done when.** Rapidly toggling providers never leaves a mismatched model list.
+**Effort.** M.
+
+---
+
+## Sprint 4 — i18n and technical debt
+
+Goal: pay down the two i18n violations and delete the dead code, once the correctness work is done.
+
+### [ ] 4.1 — Issue #222: the TTS/audiobook modal is hardcoded English
+
+`showTTSModal` in `src/web/static/js/index.js` (function at `:574`) builds the modal from a template
+literal with raw English throughout: `🎧 Generate Audiobook` (`:609`), `TTS Provider` (`:620`),
+`GPU Status` (`:631`), `Target Language` (`:643`, `:767`), `Voice (optional)` (`:695`), `Speech Rate`
+(`:702`), `Audio Format` (`:714`, `:799`), `Audio Bitrate` (`:723`), `Voice Cloning` (`:737`),
+`Exaggeration` (`:750`), `CFG Weight` (`:757`), `Cancel` (`:811`), `Generate Audio` (`:813`), plus every
+`<option>` label.
+
+The keys already exist in `src/web/static/locales/en/tts.json` and in all seven locales, they are simply
+unwired for the modal body. The adjacent status and progress code (roughly `:100-219`) does use `t()`
+correctly, so this is a partial job to finish rather than a greenfield one.
+
+**Fix direction.** Emit `data-i18n` attributes on the injected markup so `applyToDOM` handles reactivity
+automatically, per the CLAUDE.md guidance. That avoids adding a `languageChanged` listener for this modal.
+
+**Done when.** Toggling the language selector with the modal open retranslates every label without a page
+reload.
+**Effort.** M.
+
+---
+
+### [ ] 4.2 — Issue #223: file-queue status strings are raw English and double as logic keys
+
+The queue status is both the display string and the comparison key, so it cannot be translated without
+breaking control flow.
+
+- `src/web/static/js/files/file-upload.js:858` sets `status: 'Queued'`, `:1002` renders it directly via
+  `statusSpan.textContent = \`(${file.status})\``, and `:934`, `:938`, `:1019`, `:1047`, `:1053` compare
+  against the literal.
+- `src/web/static/js/translation/batch-controller.js:289`, `:298`, `:308`, `:325`, `:347` set
+  `'Preparing...'`, `'Error: Missing API key'`, `'Path Error'`, `'Submitted'`, `'Initiation Error'`.
+- `src/web/static/js/translation/translation-tracker.js:321`, `:363`, `:478`, `:573-576` set
+  `'Processing'`, `'Completed'`, `'Interrupted'`, `'Rate Limited'`, `'Error'`.
+- No `localeChanged` listener exists in `file-upload.js`. Only `files/file-manager.js:36` has one, which
+  is why the queue never re-renders on a language switch.
+
+**Fix direction.** Introduce a status-code enum decoupled from display text, update every comparison
+site across the three files, add the display keys to all seven locales, and wire a `localeChanged`
+re-render for the queue.
+
+**Done when.** The queue shows localized statuses that update live on language switch, and no comparison
+anywhere comments against a display string.
+**Effort.** L. Largest single i18n item, do not start it mid-sprint.
+
+---
+
+### [ ] 4.3 — Issue #227: delete the dead code and the French docstrings
+
+Verified dead, zero callers repo-wide:
+- The error subsystem: `retry_manager.py`, `error_recovery.py`, `error_handler.py`, `error_logger.py`.
+  Exported from `adapters/__init__.py` but instantiated nowhere.
+- `subtitle_translator.py` — `translate_subtitles` and `translate_subtitles_in_blocks`. The former would
+  crash if called: it passes `custom_instructions=` to `generate_translation_request`, which has no such
+  parameter.
+- `xhtml_translator.py` — `attempt_placeholder_correction`, `build_specific_error_details`,
+  `extract_corrected_text`. `src/config.py` defines `MAX_PLACEHOLDER_CORRECTION_ATTEMPTS` twice (around
+  `:337` as `2`, then around `:502` as `0`, and the second wins), confirming the path is dead by design.
+- `xml_helpers.py` — fully orphaned, not even imported by `epub/__init__.py`.
+- `parallel.py` — `iter_ordered_windows` and `gather_window` are used only inside their own module.
+  `iter_ordered_concurrent` is the real scheduler, used by `plain_text_pipeline.py`,
+  `xhtml_translator.py` and `generic_translator.py`.
+- `form-manager.js` — `getTranslationConfig` and `validateConfig` call only each other, while
+  `batch-controller.js` carries an actively used, drifted duplicate. Reconcile before deleting.
+
+**Language-policy violations found while verifying**, which CLAUDE.md forbids:
+`src/core/common/translation_orchestrator.py` and `src/core/docx/docx_translation_adapter.py` have
+French docstrings, and `src/config.py` has French docstrings around `:331` and `:335`.
+
+**Fix direction.** Delete in small reviewable commits, one subsystem each, running the test suite between
+them. Translate the docstrings in the same PR. Resolve the duplicated config constant rather than
+deleting one occurrence blindly, decide whether placeholder correction should exist at all.
+
+**Done when.** The dead modules are gone, the suite is green, and no French text remains in committed
+source.
+**Effort.** S/M, mostly deletions.
+
+---
+
+## Feature queue
+
+Ordered by demand signal against effort. None of these should start before Sprint 2 is done.
+
+### [ ] 5.1 — PDF support (#140, #234, discussion #191)
+
+Highest cumulative demand: three distinct reporters across two duplicate issues plus a discussion. No PDF
+handling exists anywhere in `src/`.
+
+The pragmatic scope you already proposed in both threads, text-only PDF converted to Markdown or plain
+text, was agreed to by the reporters and never built. A third user (`a-bashtannik`) contributed
+implementation notes: PyMuPDF plus marker-pdf plus Pillow, with hyphenation, footnotes and page-boundary
+reassembly flagged as the genuinely hard parts.
+
+**First action.** Merge #140 and #234 into one tracking issue and write the agreed scope into it, so the
+"will you support PDF" question stops being answered three times. Note that discussion #191 currently
+answers it as "pre-convert with pdf-craft", which stays a valid interim answer.
+**Effort.** L.
+
+---
+
+### [ ] 5.2 — Issue #250: gender support in the glossary
+
+When the source language does not mark gender, such as Chinese, the model defaults every character to
+"he", corrupting character identity across a whole book. No gender field exists in `src/core/glossary/`;
+the only gender-related code in the repo is unrelated TTS voice selection.
+
+**Fix direction.** Add an optional gender column to glossary entries and inject it into the per-chunk
+glossary prompt. Requires locale keys in all seven files for the new UI column.
+**Effort.** M. **Impact.** Real translation quality gain for CJK sources.
+
+---
+
+### [ ] 5.3 — Discussion #248: use a different model for the refine pass
+
+The chained refine pass already exists (`src/api/blueprints/translation_routes.py:196-197`,
+`src/api/handlers.py:473-511`) but hardcodes `llm_provider=config.get('llm_provider', 'ollama')` and
+`model_name=config['model']`, reusing the translation model. The ask is "translate cheap, refine strong",
+which the architecture already almost supports.
+
+**Fix direction.** Accept optional `refine_provider` / `refine_model` / `refine_api_key` in the job
+config and thread them into the refine call. Related to #183's resume-override plumbing, which solved the
+same class of problem.
+**Effort.** M. **Action.** Convert the discussion into a tracked issue first.
+
+---
+
+### [ ] 5.4 — Discussion #249: expose chunk size in the CLI and the UI
+
+`MIN_CHUNK_SIZE`, `MAX_CHUNK_SIZE` and `MAX_TOKENS_PER_CHUNK` already exist as `.env`-only settings
+(`src/config.py:317-318`, `:341`, `:655-659`). There is no `translate.py` flag and no UI field, so the
+knob is undiscoverable. Cheap win, and it also answers the recurring class of question behind #174.
+**Effort.** S.
+
+---
+
+### [ ] 5.5 — Issue #232: optional per-file failure log
+
+A power user asked for an optional `.txt` export summarizing which chapters fell back or failed, in a
+`Cap_1.html = ...` form, to review quickly in Calibre. Nothing like it exists.
+
+This pairs naturally with item 1.1: correctly tracking `fallback_used` per chunk produces exactly the
+data this export needs, so build it immediately after.
+**Effort.** S/M. **Depends on.** Item 1.1.
+
+---
+
+### [ ] 5.6 — Issue #242: HTML `<ruby>` elements need dedicated handling
+
+Zero occurrences of "ruby" anywhere in `src/`. Ruby annotations in Japanese and Korean text currently
+reach the model unhandled and confuse it, especially in plain-text mode. The reporter submitted a
+well-formed proposal including a fallback to the `<rp>` parenthesis form.
+**Effort.** M/L.
+
+---
+
+### [ ] 5.7 — Issue #243: Markdown file support
+
+`FileType` in `src/utils/file_detector.py:18` is `Literal["txt","epub","srt","docx"]`. A `.md` file is
+sniffed and silently handled as plain text (`:22`), so headers, lists and code fences are not protected
+from the model.
+**Effort.** M.
+
+---
+
+### [ ] 5.8 — Issue #198: hydrate active jobs from the server on page load
+
+A second browser sees nothing for a job currently running elsewhere.
+`src/web/static/js/translation/translation-tracker.js:159-160` restores active jobs only from
+localStorage, and `src/persistence/database.py:438-459` `get_resumable_jobs()` filters
+`status IN ('paused','interrupted','error','partial')`, deliberately excluding `running`. This is the
+one in-scope piece salvaged from the #196 audit.
+**Effort.** M.
+
+---
+
+### [ ] 5.9 — Discussion #238: dynamically maintained relationship and glossary context
+
+The most substantive unimplemented feature in the backlog. The current glossary is a static user-curated
+term list; this asks for an evolving per-chunk context capturing character genders, forms of address and
+relationships, maintained by an extra LLM call.
+
+A community member (`windfox1243`) has a working prototype fork and answered your design questions in the
+thread. The known costs: one extra LLM call per chunk, and translation becomes sequential because the
+state evolves, which removes parallelism.
+
+**Action.** Convert to a tracked issue capturing the design questions already raised: context storage
+shape, prompt placement, growth control, and the cost/parallelism tradeoff. Overlaps with item 5.2, gender
+is the narrow, cheap version of the same problem, so ship 5.2 first and learn from it.
+**Effort.** L.
+
+---
+
+### [ ] 5.10 — Discussion #146: cross-provider key-pool cascading
+
+Key rotation on 429 shipped (comma-separated `*_API_KEY`, `docs/API_KEY_ROTATION.md`). The unaddressed
+half is the cascade suggested by `virdb`: fall back Gemini to OpenAI to Ollama when a whole provider is
+exhausted. Split it into its own issue so the shipped part stops being confused with the pending part.
+**Effort.** M.
+
+---
+
+## Pull requests
+
+### [ ] PR #245 — Portuguese (Brazil) and Portuguese (Portugal) distinction
+
++101/-18 across 12 files. Adds `src/utils/lang_normalize.py`, updates `lang_support.py` for BCP47,
+`tts_config.py`, `pricing/estimator.py`, `context_optimizer.py`, prompt helpers, six HTML dropdowns and
+browser-locale detection in `form-manager.js`. Ships a test
+(`test_epub_xhtml_lang_attributes.py`). Language dropdown options are plain text with no `data-i18n`
+already on `main`, so this introduces no new i18n violation.
+
+**Verdict.** Merge, optionally with a nit: `src/tts/providers/chatterbox_tts.py` and
+`src/utils/language_detector.py` still map `"pt"` to `"Portuguese"` for source detection. Low impact.
+**Order.** Merge first, smallest risk of the three.
+
+---
+
+### [ ] PR #247 — Atlas Cloud provider
+
++336/-8 across 34 files. Best engineering quality of the three: follows the full provider registration
+pattern (factory, config, api_keys, adapters, refiners, frontend wiring) and adds three test files
+including `test_atlascloud_provider.py`.
+
+**Blocking before merge:**
+- Locale keys added only to `en` (`settings.json`, `errors.json`). The six other locales are missing every
+  `atlascloud_*` and `api_key_required_atlascloud` key, which violates the CLAUDE.md rule.
+- Not wired into `translate.py`: absent from the `--provider` choices and no `--atlascloud_api_key`.
+- Absent from `README.md`: no badge, no row in the API-key table.
+
+**Verdict.** Request changes, then merge. All three gaps are mechanical.
+
+---
+
+### [ ] PR #244 — Requesty provider
+
++214/-14 across 11 files, entirely inside `benchmark/` plus docs and `.env.example`. Zero changes under
+`src/`. Requesty is therefore not selectable in the web UI or in `translate.py`, despite the PR title.
+
+**Verdict.** Ask the author which was intended. If benchmark tooling only, retitle to
+"Add Requesty to the benchmark CLI" and merge, it is low risk and self-contained. If a real provider was
+intended, it needs the full registration pattern that PR #247 demonstrates.
+
+**Note on CI.** None of the three PRs has any recorded review or status check. Worth confirming whether
+fork PRs are meant to run CI at all, since that gap will keep costing review time.
+
+---
+
+## Housekeeping
+
+Already fixed in code, no action beyond closing. Full evidence in item 1.7.
+
+| Issue | Resolution |
+| --- | --- |
+| #183 | Shipped v1.4.1 |
+| #167 | Shipped v1.3.3 |
+| #155 | Shipped v1.2.2 |
+| #174 | Answered, config matter |
+| #229 | Fixed by a later refactor |
+| #196 | Superseded by #198 |
+| #140 / #234 | Merge into one PDF issue |
+
+Discussions already resolved and worth closing or marking answered: #173 (auto-update, shipped v1.3.7),
+#199 (bilingual output, fixed v1.4.9), #182 (LM Studio already works through the generic OpenAI-compatible
+provider, a discoverability issue rather than a code gap, worth a line in `docs/PROVIDERS.md`), #176
+(fixed differently in v1.3.12), #169 (fixed v1.3.13 and v1.3.14), #164 (shipped v1.2.3), #165 (version now
+in the header), #161 (shipped as the glossary), #126 (backoff and auto-resume shipped v1.0.20/v1.0.21).
+
+---
+
+## Deferred and product decisions
+
+### Issue #221 — device fingerprint sent to LLM providers
+
+`src/utils/telemetry.py:54-63` derives a client ID from `uuid.getnode()`, and
+`src/core/llm/base.py:93-98` attaches the resulting headers to the shared client used by every provider.
+There is no opt-out in `src/config.py`.
+
+This is intentional project behaviour, not a regression. Treat it as a disclosure and product decision
+rather than a defect to patch: decide what the documentation should say, and whether an opt-out is
+offered. Do not action it as a bug fix without deciding that first.
+
+### Issue #212 — self-update endpoint hardening
+
+The primary claim, an unauthenticated CSRF-reachable update endpoint, is closed: `/api/version/update` is
+not in the `_EXEMPT_ENDPOINTS` frozenset in `src/api/auth.py`, so PR #233's token gate covers it.
+
+What remains is lower-priority supply-chain hardening: `requirements.txt` is fully unpinned, there is no
+lockfile, and no commit or signature verification runs before `git pull` plus `pip install --upgrade`.
+Keep the issue open but retitle it to reflect the remaining scope, or split it out and close the original.
+
+### Issue #196 — deep repository and UI audit
+
+The multi-user and SaaS framing was rejected by design, the project is intentionally single-user and
+self-hosted. The one in-scope item became #198 (item 5.8). Close with a pointer.
+
+---
+
+## Cross-cutting notes
+
+**Item 1.1 unlocks two other items.** Correctly separating "failed" from "fell back to source" is the
+prerequisite for both the #246 diagnosis (item 1.2) and the failure-log export (item 5.5). Do it first
+and the two that follow get much cheaper.
+
+**PR #233 changed reachability, not correctness.** Items 2.2, and the deferred #212 and #214, all had
+their delivery vector closed by the CORS and session-token work while the underlying flaw stayed. When
+re-reading those issues, do not take the closed vector as a fix.
+
+**Three frontend items share one cluster.** Items 1.5, 1.6 and 3.6 all live in the tracker and lifecycle
+code. Shipping them together is cheaper than three separate reviews, but keep 4.2 out of that batch, it
+is a different order of magnitude.
+
+**Recurring class: state exists but is not exposed.** Items 5.4 (chunk size), 5.3 (refine model) and 5.10
+(key cascade) are all cases where the capability is already in the code and only the surface is missing.
+They are the cheapest user-visible wins in the feature queue.
+
+**Every new user-facing string** must land in all seven locales (`en`, `fr`, `es`, `de`, `zh-CN`, `ja`,
+`ko`) in the same commit, and must re-render on language switch. This applies to items 4.1, 4.2, 5.2 and
+PR #247.

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -260,6 +260,20 @@ Browse models: [build.nvidia.com](https://build.nvidia.com/)
 
 ---
 
+## Endpoint Allowlist
+
+The web API lets a request choose the endpoint the server calls, so the server checks that endpoint against an allowlist before using it. Accepted out of the box: the known provider hosts (`api.openai.com`, `generativelanguage.googleapis.com`, `openrouter.ai`, `api.mistral.ai`, `api.deepseek.com`, `api.poe.com`, `integrate.api.nvidia.com`), every `*_API_ENDPOINT` configured in your `.env`, and any loopback, LAN or `host.docker.internal` address so self-hosted Ollama, LM Studio, llama.cpp and vLLM keep working. Anything else returns HTTP 400.
+
+To allow a self-hosted gateway on a public hostname, add it to `LLM_ENDPOINT_ALLOWLIST` in `.env` (comma-separated; subdomains of a listed host are covered):
+
+```bash
+LLM_ENDPOINT_ALLOWLIST=llm.internal.example.com,gateway.example.org
+```
+
+This variable is read at startup only and is deliberately not editable from the web UI. A second rule pairs with it: when a request supplies an endpoint that differs from the configured default, the server refuses to attach the API key stored in `.env` — that request must send its own key, or it is rejected. Together these guarantee a stored credential is never sent to a host the request chose.
+
+---
+
 ## API Key Rotation
 
 Every cloud provider above accepts a comma-separated list of keys (e.g. `key1,key2,key3`). The system automatically rotates keys on HTTP 429 — useful for chaining free-tier accounts. See [API_KEY_ROTATION.md](API_KEY_ROTATION.md) for details.

--- a/src/api/api_keys.py
+++ b/src/api/api_keys.py
@@ -38,7 +38,7 @@ def provider_env_var(provider):
     return PROVIDER_ENV_VARS.get((provider or '').lower(), '')
 
 
-def resolve_api_key(value, env_var_name, config_default=''):
+def resolve_api_key(value, env_var_name, config_default='', allow_env_fallback=True):
     """Resolve a per-request API-key value to the key to actually use.
 
     A real key (anything truthy that isn't the ``__USE_ENV__`` sentinel) is
@@ -51,12 +51,18 @@ def resolve_api_key(value, env_var_name, config_default=''):
         env_var_name: Env var to fall back to. Empty/None skips the env lookup.
         config_default: Last-resort default (e.g. the value loaded into the
             config module at import time) when the env var is unset.
+        allow_env_fallback: When ``False``, an absent or sentinel value resolves
+            to ``''`` instead of consulting the environment. Callers use this
+            when the request chose the destination host: the server's stored
+            key must never travel to an endpoint the client picked.
 
     Returns:
         The resolved key string (possibly empty if nothing is configured).
     """
     if value and value != USE_ENV_SENTINEL:
         return value
+    if not allow_env_fallback:
+        return ''
     if not env_var_name:
         return config_default
     return os.getenv(env_var_name, config_default)

--- a/src/api/blueprints/config_routes.py
+++ b/src/api/blueprints/config_routes.py
@@ -51,6 +51,7 @@ from src.config import reload_config
 from src import __version__
 from src.core.llm.base import normalize_api_keys
 from src.api.api_keys import resolve_api_key as _resolve_api_key
+from src.api.services.endpoint_validator import EndpointValidator
 
 # Setup logger for this module
 logger = logging.getLogger('config_routes')
@@ -539,7 +540,22 @@ def create_config_blueprint(server_session_id=None):
           would cause HTTP 400 at translation time. Return an explicit error so
           the UI can surface it.
         """
-        api_key = _first_key(_resolve_api_key(provided_api_key, 'OPENAI_API_KEY', _config.OPENAI_API_KEY))
+        ok, err = EndpointValidator.validate(api_endpoint)
+        if not ok:
+            return jsonify({"error": err}), 400
+
+        # When the caller picks a host other than the configured one, the
+        # server's stored key must not follow it (see endpoint_validator).
+        requested = (api_endpoint or '').strip().rstrip('/')
+        is_override = bool(requested) and requested != (
+            _config.OPENAI_API_ENDPOINT or ''
+        ).strip().rstrip('/')
+        api_key = _first_key(_resolve_api_key(
+            provided_api_key,
+            'OPENAI_API_KEY',
+            _config.OPENAI_API_KEY,
+            allow_env_fallback=not is_override,
+        ))
 
         if api_endpoint:
             base_url = api_endpoint.replace('/chat/completions', '').rstrip('/')
@@ -667,6 +683,11 @@ def create_config_blueprint(server_session_id=None):
     def _get_ollama_models():
         """Get available models from Ollama API"""
         ollama_base_from_ui = request.args.get('api_endpoint', _config.API_ENDPOINT)
+
+        # No key is involved here, so only the allowlist applies.
+        ok, err = EndpointValidator.validate(ollama_base_from_ui)
+        if not ok:
+            return jsonify({"error": err}), 400
 
         try:
             parsed = urlparse(ollama_base_from_ui)

--- a/src/api/blueprints/glossary_routes.py
+++ b/src/api/blueprints/glossary_routes.py
@@ -26,6 +26,7 @@ from src.core.glossary import suggest_terms as ner_suggest_terms
 from src.core.glossary.models import GlossaryConfig
 from src.core.llm.exceptions import RateLimitError
 from src.api.api_keys import provider_env_var, resolve_api_key
+from src.api.services.endpoint_validator import EndpointValidator
 
 _NER_UPLOAD_MAX_BYTES = 100 * 1024 * 1024
 _NER_TEXT_EXTS = {'.txt', '.srt'}
@@ -867,14 +868,25 @@ def create_glossary_blueprint(store: Optional[GlossaryStore] = None):
             model = data.get('model') or _config.DEFAULT_MODEL
             api_endpoint = data.get('api_endpoint') or _config.API_ENDPOINT
 
+            ok, endpoint_error = EndpointValidator.validate(api_endpoint)
+            if not ok:
+                return jsonify({"error": endpoint_error}), 400
+
             # The frontend sends the '__USE_ENV__' sentinel (or nothing) when the
             # key field is empty but a key is configured in .env; resolve_api_key
             # turns that back into the real, possibly multi-key, env value.
+            # A caller-chosen endpoint gets no .env key: the stored credential
+            # must never travel to a host the request picked.
+            requested_endpoint = (api_endpoint or '').strip().rstrip('/')
+            is_endpoint_override = bool(requested_endpoint) and requested_endpoint != (
+                _config.API_ENDPOINT or ''
+            ).strip().rstrip('/')
             env_var = provider_env_var(provider_type)
             api_key = resolve_api_key(
                 data.get('api_key'),
                 env_var,
                 getattr(_config, env_var, '') if env_var else '',
+                allow_env_fallback=not is_endpoint_override,
             ) or None
 
             try:

--- a/src/api/blueprints/translation_routes.py
+++ b/src/api/blueprints/translation_routes.py
@@ -7,7 +7,9 @@ import copy
 from pathlib import Path
 from flask import Blueprint, request, jsonify
 
+import src.config as _config
 from src.api.services.path_validator import PathValidator
+from src.api.services.endpoint_validator import EndpointValidator
 from src.config import (
     REQUEST_TIMEOUT,
     OLLAMA_NUM_CTX,
@@ -16,7 +18,11 @@ from src.config import (
     MAX_PARALLEL_TRANSLATIONS,
 )
 from src.tts.tts_config import TTSConfig
-from src.api.api_keys import resolve_api_key as _resolve_api_key
+from src.api.api_keys import (
+    resolve_api_key as _resolve_api_key,
+    provider_env_var as _provider_env_var,
+    USE_ENV_SENTINEL,
+)
 
 
 def _clamp_parallel_workers(value):
@@ -41,6 +47,91 @@ _KEY_PROVIDERS = ('gemini', 'openai', 'openrouter', 'mistral', 'deepseek', 'poe'
 
 # Providers that talk to a user-supplied endpoint; the others use a built-in one.
 _ENDPOINT_PROVIDERS = ('ollama', 'openai')
+
+# Providers whose client actually reads config['llm_api_endpoint'].
+# Source: src/core/llm/factory.py:87 (ollama), :93 (openai), :170 (nim).
+# The others use a constant or a .env endpoint and ignore the request field,
+# so an endpoint sent alongside them is inert and must not be treated as an
+# override — the frontend sends llm_api_endpoint unconditionally.
+_ENDPOINT_CONSUMING_PROVIDERS = ('ollama', 'openai', 'nim')
+
+
+def _server_default_endpoint(provider):
+    """Return the .env-configured endpoint for an endpoint-consuming provider.
+
+    Read from src.config at call time so reload_config() is honoured.
+    """
+    provider = (provider or '').lower()
+    if provider == 'ollama':
+        return _config.API_ENDPOINT
+    if provider == 'openai':
+        return _config.OPENAI_API_ENDPOINT
+    if provider == 'nim':
+        return _config.NIM_API_ENDPOINT
+    return ''
+
+
+def _normalize_endpoint(value):
+    """Normalize an endpoint for comparison (trim whitespace and trailing '/')."""
+    return (value or '').strip().rstrip('/')
+
+
+def _is_endpoint_override(config, requested_endpoint):
+    """True when the request chose an endpoint the selected provider actually
+    reads and that differs from the server default.
+
+    Providers outside _ENDPOINT_CONSUMING_PROVIDERS ignore the request field
+    entirely, so an endpoint sent with them is never an override.
+    """
+    provider = (config.get('llm_provider') or 'ollama').lower()
+    if provider not in _ENDPOINT_CONSUMING_PROVIDERS:
+        return False
+    normalized = _normalize_endpoint(requested_endpoint)
+    return bool(normalized) and normalized != _normalize_endpoint(
+        _server_default_endpoint(provider)
+    )
+
+
+def _validate_endpoint_and_key_pairing(config, requested_endpoint, request_key=None):
+    """Reject a disallowed endpoint, and refuse to pair an overridden endpoint
+    with the server's stored key.
+
+    A request that chooses its own host must also bring its own credential:
+    otherwise the server would forward a .env key to a destination the client
+    picked. Providers that ignore the request's endpoint are exempt, and
+    'ollama' has no key to leak so it needs none.
+
+    Args:
+        config: The job config being built or resumed.
+        requested_endpoint: The endpoint the request supplied, if any.
+        request_key: The raw key the request supplied for the selected provider
+            (may be the '__USE_ENV__' sentinel, empty, or absent).
+
+    Returns a Flask (response, status) tuple to abort with, or None when the
+    request is acceptable.
+    """
+    ok, err = EndpointValidator.validate(requested_endpoint)
+    if not ok:
+        return jsonify({"error": "Endpoint not allowed", "message": err}), 400
+
+    if not _is_endpoint_override(config, requested_endpoint):
+        return None
+
+    provider = (config.get('llm_provider') or 'ollama').lower()
+    if provider in _KEY_PROVIDERS and (not request_key or request_key == USE_ENV_SENTINEL):
+        # Only refuse when a stored key actually exists, i.e. when there is
+        # something to leak. 'openai' also covers keyless local servers
+        # (LM Studio, llama.cpp, vLLM) — same carve-out as
+        # _validate_provider_credentials, and it keeps that path working.
+        if os.getenv(_provider_env_var(provider) or ''):
+            return jsonify({
+                "error": "Endpoint override requires its own API key",
+                "message": (f"A custom '{provider}' endpoint was supplied, so the server's "
+                            "stored key will not be used. Send the key with the request or "
+                            "restore the default endpoint."),
+            }), 400
+
+    return None
 
 
 def _strip_api_keys(config):
@@ -107,6 +198,8 @@ def _apply_resume_overrides(config, overrides):
     Returns a Flask (response, status) tuple to abort with on validation failure,
     or None on success.
     """
+    raw_key = None
+
     if isinstance(overrides, dict) and overrides:
         if overrides.get('model'):
             config['model'] = overrides['model']
@@ -127,6 +220,23 @@ def _apply_resume_overrides(config, overrides):
         if provider in _KEY_PROVIDERS and raw_key not in (None, ''):
             env_var = f"{provider.upper()}_API_KEY"
             config[f"{provider}_api_key"] = _resolve_api_key(raw_key, env_var)
+
+    # A resume can point the job at a different host, either through the
+    # override body or through the endpoint stored in the checkpoint. The same
+    # pairing rule as the start endpoint applies, so the .env key never
+    # follows a non-default endpoint.
+    requested_endpoint = config.get('llm_api_endpoint')
+    pairing_error = _validate_endpoint_and_key_pairing(
+        config, requested_endpoint, request_key=raw_key
+    )
+    if pairing_error is not None:
+        return pairing_error
+
+    provider = (config.get('llm_provider') or 'ollama').lower()
+    if provider in _KEY_PROVIDERS and _is_endpoint_override(config, requested_endpoint):
+        config[f"{provider}_api_key"] = _resolve_api_key(
+            raw_key, _provider_env_var(provider), allow_env_fallback=False
+        )
 
     return _validate_provider_credentials(config)
 
@@ -216,6 +326,26 @@ def create_translation_blueprint(state_manager, start_translation_job, output_di
         else:
             config['text'] = data['text']
             config['file_type'] = data.get('file_type', 'txt')
+
+        # A request-chosen endpoint must be allowlisted, and must carry its own
+        # key: the server's .env key never travels to a host the client picked.
+        requested_endpoint = data.get('llm_api_endpoint')
+        provider = (config.get('llm_provider') or 'ollama').lower()
+        pairing_error = _validate_endpoint_and_key_pairing(
+            config, requested_endpoint, request_key=data.get(f'{provider}_api_key')
+        )
+        if pairing_error is not None:
+            return pairing_error
+
+        if provider in _KEY_PROVIDERS and _is_endpoint_override(config, requested_endpoint):
+            # Belt and braces: re-resolve without the .env fallback so the
+            # invariant "no stored key with an overridden endpoint" is local
+            # and testable. The guard above already ensured a real key is present.
+            config[f'{provider}_api_key'] = _resolve_api_key(
+                data.get(f'{provider}_api_key'),
+                _provider_env_var(provider),
+                allow_env_fallback=False,
+            )
 
         # Create translation in state manager
         state_manager.create_translation(translation_id, config)

--- a/src/api/services/endpoint_validator.py
+++ b/src/api/services/endpoint_validator.py
@@ -1,0 +1,149 @@
+"""
+Allowlist validation for client-supplied LLM endpoints.
+
+Several HTTP entry points let the request choose the host the server will talk
+to (Ollama/LM Studio users legitimately need this). Left unchecked, that turns
+the server into a credential-exfiltration relay: point the endpoint at an
+attacker host and the server happily attaches its ``.env`` API key.
+
+This module is the first of the two guards that close that path. It is a pure
+input validator with no Flask dependency, which is why it lives next to
+``PathValidator``.
+
+Deliberate trade-off — loopback and private ranges are permitted. Self-hosted
+backends (Ollama, LM Studio, llama.cpp, vLLM) run on ``localhost``, on a LAN
+address, or behind ``host.docker.internal``, so rejecting those ranges would
+break the project's primary use case. The consequence is that this validator
+allows SSRF against the operator's own network. That is only acceptable
+because of the second guard, enforced at the call sites: an endpoint that
+differs from the server default is treated as an override and never paired
+with a server-stored API key. No credential travels with a request-chosen
+host, so the worst an attacker gets is an unauthenticated probe of a network
+they must already be able to reach the server from.
+"""
+import ipaddress
+from typing import Optional, Set, Tuple
+from urllib.parse import urlparse
+
+import src.config as _config
+
+
+# Public LLM API hosts the project ships support for. Always accepted, so a
+# default install needs no LLM_ENDPOINT_ALLOWLIST entry at all.
+DEFAULT_ALLOWED_HOSTS = frozenset({
+    'api.openai.com',
+    'generativelanguage.googleapis.com',
+    'openrouter.ai',
+    'api.mistral.ai',
+    'api.deepseek.com',
+    'api.poe.com',
+    'integrate.api.nvidia.com',
+})
+
+# Server defaults read from src.config. A user who points one of these at their
+# own domain must not be locked out by the allowlist.
+_CONFIGURED_ENDPOINT_ATTRS = (
+    'API_ENDPOINT',
+    'OLLAMA_API_ENDPOINT',
+    'OPENAI_API_ENDPOINT',
+    'OPENROUTER_API_ENDPOINT',
+    'MISTRAL_API_ENDPOINT',
+    'DEEPSEEK_API_ENDPOINT',
+    'POE_API_ENDPOINT',
+    'NIM_API_ENDPOINT',
+)
+
+# Non-IP hostnames that always denote the machine the server runs on.
+_LOCAL_HOSTNAMES = frozenset({'localhost', 'host.docker.internal'})
+
+
+class EndpointValidator:
+    """Validates client-supplied LLM endpoint URLs against an allowlist."""
+
+    @staticmethod
+    def allowed_hosts() -> Set[str]:
+        """Return the accepted hostnames, recomputed on every call.
+
+        Never cached: ``reload_config()`` can change the configured endpoints
+        at runtime, and a cached set would silently keep the stale hosts.
+        """
+        hosts = set(DEFAULT_ALLOWED_HOSTS)
+
+        for attr in _CONFIGURED_ENDPOINT_ATTRS:
+            value = getattr(_config, attr, '') or ''
+            if not value.strip():
+                continue
+            try:
+                hostname = urlparse(value.strip()).hostname
+            except ValueError:
+                continue
+            if hostname:
+                hosts.add(hostname.lower())
+
+        hosts.update(getattr(_config, 'LLM_ENDPOINT_ALLOWLIST', ()) or ())
+        return hosts
+
+    @staticmethod
+    def is_local_host(hostname: str) -> bool:
+        """Return True for the operator's own machine or private network.
+
+        Covers 'localhost', '*.localhost', 'host.docker.internal', and any
+        literal address that is loopback, private or link-local — i.e.
+        127.0.0.0/8, ::1, 10/8, 172.16/12, 192.168/16, 169.254/16 and fc00::/7.
+        """
+        if not hostname:
+            return False
+
+        host = hostname.strip().lower()
+        if host in _LOCAL_HOSTNAMES or host.endswith('.localhost'):
+            return True
+
+        try:
+            address = ipaddress.ip_address(host)
+        except ValueError:
+            return False
+        return address.is_loopback or address.is_private or address.is_link_local
+
+    @staticmethod
+    def validate(endpoint: Optional[str]) -> Tuple[bool, Optional[str]]:
+        """Check a request-supplied endpoint URL.
+
+        Returns ``(True, None)`` when the endpoint may be used, or
+        ``(False, message)`` with a message safe to return to the client.
+
+        An absent endpoint is accepted: it means "use the server default",
+        which is not an override and not this function's problem.
+        """
+        if not endpoint or not str(endpoint).strip():
+            return True, None
+
+        try:
+            parsed = urlparse(str(endpoint).strip())
+        except ValueError:
+            return False, "Endpoint is not a valid URL"
+
+        if parsed.scheme not in ('http', 'https'):
+            return False, "Endpoint must use http or https"
+
+        try:
+            if parsed.username or parsed.password:
+                return False, "Endpoint must not embed credentials"
+            # urlparse.hostname is already lowercased, and strips port/userinfo.
+            host = parsed.hostname
+        except ValueError:
+            return False, "Endpoint is not a valid URL"
+
+        if not host:
+            return False, "Endpoint has no host"
+
+        if EndpointValidator.is_local_host(host):
+            return True, None
+
+        allowed = EndpointValidator.allowed_hosts()
+        if host in allowed or any(host.endswith('.' + h) for h in allowed):
+            return True, None
+
+        return False, (
+            f"Endpoint host '{host}' is not allowed. "
+            "Add it to LLM_ENDPOINT_ALLOWLIST in .env to permit it."
+        )

--- a/src/config.py
+++ b/src/config.py
@@ -143,6 +143,13 @@ OLLAMA_NUM_CTX = int(os.getenv('OLLAMA_NUM_CTX', '4096'))
 # high values counter-productive.
 MAX_PARALLEL_TRANSLATIONS = int(os.getenv('MAX_PARALLEL_TRANSLATIONS', '16'))
 
+# Extra hostnames the LLM endpoint validator accepts, comma-separated.
+# Deliberately not exposed through /api/settings: widening the allowlist from
+# the browser would reopen the credential-exfiltration path this guard closes.
+LLM_ENDPOINT_ALLOWLIST = tuple(
+    h.strip().lower() for h in os.getenv('LLM_ENDPOINT_ALLOWLIST', '').split(',') if h.strip()
+)
+
 # Providers that run on the user's own machine and serialize requests through a
 # single model instance. Parallel dispatch gives them no speedup and can
 # saturate the GPU, so the concurrency control is disabled for them.

--- a/src/core/adapters/epub_adapter.py
+++ b/src/core/adapters/epub_adapter.py
@@ -21,6 +21,7 @@ from lxml import etree
 from .format_adapter import FormatAdapter
 from .translation_unit import TranslationUnit
 from src.config import NAMESPACES
+from src.utils.security import safe_extract_zip
 
 
 class EpubAdapter(FormatAdapter):
@@ -73,7 +74,7 @@ class EpubAdapter(FormatAdapter):
 
             # Extract EPUB
             with zipfile.ZipFile(self.input_file_path, 'r') as zip_ref:
-                zip_ref.extractall(self.work_dir)
+                safe_extract_zip(zip_ref, self.work_dir)
 
             # Find OPF file
             self.opf_path = self._find_opf_file()

--- a/src/core/adapters/translate_file.py
+++ b/src/core/adapters/translate_file.py
@@ -22,6 +22,39 @@ from .exceptions import UnsupportedFormatError
 from src.utils.file_detector import detect_file_type, detect_file_type_by_content
 
 
+def _ensure_checkpoint_job(
+    checkpoint_manager: Any,
+    translation_id: Optional[str],
+    file_type: str,
+    config: Dict[str, Any],
+    input_file_path: str
+) -> None:
+    """
+    Guarantee a job row exists before the legacy EPUB/DOCX pipelines run.
+
+    Those pipelines write checkpoint chunks but never create the parent job:
+    the web path relies on the API handler having created it first. The CLI
+    calls translate_file() directly, so nothing created it there and every
+    chunk row was silently orphaned. Foreign-key enforcement now rejects such
+    writes outright, so the row has to exist before the first chunk is saved.
+    """
+    if not (checkpoint_manager and translation_id):
+        return
+
+    try:
+        if checkpoint_manager.db.get_job(translation_id) is not None:
+            return
+        checkpoint_manager.start_job(
+            translation_id=translation_id,
+            file_type=file_type,
+            config=config,
+            input_file_path=input_file_path
+        )
+    except Exception as e:
+        # Checkpointing is best effort; never block a translation over it.
+        print(f"Could not create checkpoint job {translation_id}: {e}")
+
+
 async def translate_file(
     input_filepath: str,
     output_filepath: str,
@@ -160,6 +193,25 @@ async def translate_file(
     # The generic adapter pattern doesn't work well with EPUB's complex XHTML processing
     # that requires HTML chunking, tag preservation, technical content protection, etc.
     # TODO: Refactor EPUB translation to properly work with the adapter pattern
+    # The legacy EPUB/DOCX pipelines below save checkpoint chunks without ever
+    # creating the parent job row, which only worked because the web handler
+    # creates it beforehand. Make the invariant hold on every entry point.
+    if detected_type in ('epub', 'docx'):
+        _ensure_checkpoint_job(
+            checkpoint_manager=checkpoint_manager,
+            translation_id=translation_id,
+            file_type=detected_type,
+            config={
+                'input_file_path': input_filepath,
+                'output_file_path': output_filepath,
+                'source_language': source_language,
+                'target_language': target_language,
+                'model_name': model_name,
+                'llm_provider': llm_provider,
+            },
+            input_file_path=input_filepath
+        )
+
     if detected_type == 'epub':
         from src.core.epub.translator import translate_epub_file
         await translate_epub_file(

--- a/src/core/common/plain_text_checkpoint.py
+++ b/src/core/common/plain_text_checkpoint.py
@@ -1,0 +1,178 @@
+"""Checkpoint plumbing shared by the EPUB and DOCX Plain Text Mode adapters.
+
+Plain Text Mode has no persistence format of its own: it reuses the
+``XHTMLTranslationState`` partial-state machinery that the placeholder pipeline
+already writes through ``CheckpointManager``. The two adapters only differ in
+where the paragraph count and the file identifier come from, so the resume
+guard, the state builder and the completion delete live here rather than being
+duplicated on both sides.
+
+The ``plain_text_mode`` marker written into ``doc_metadata`` is what keeps the
+two persistence users apart: a placeholder-mode state (whose chunks carry
+``local_tag_map`` / ``global_indices`` and real placeholders) must never be
+replayed through the plain pipeline, and vice versa.
+"""
+
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from src.core.epub.xhtml_translation_state import XHTMLTranslationState
+
+
+def _utc_now_iso() -> str:
+    """Timestamp in the exact format used by the XHTML checkpoint writer."""
+    return datetime.now(timezone.utc).replace(tzinfo=None).isoformat() + 'Z'
+
+
+def _as_persistable_chunks(segments: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Add the two inert keys ``XHTMLTranslationState.validate()`` requires.
+
+    Plain segments are ``{'indices', 'text', 'partial'}``; the placeholder
+    pipeline's chunks additionally carry ``local_tag_map`` and
+    ``global_indices``, and ``validate()`` rejects any chunk missing them. A
+    rejected state is silently dropped by ``load_xhtml_partial_state``, which
+    would make the checkpoint unreadable. The two added keys stay empty and are
+    never read back by the plain pipeline.
+    """
+    return [
+        {'local_tag_map': {}, 'global_indices': [], **segment}
+        for segment in segments
+    ]
+
+
+def is_plain_text_state(resume_state: Optional[Any]) -> bool:
+    """True when a partial state was written by Plain Text Mode.
+
+    The single source of truth for telling the two persistence users apart.
+    The plain pipeline uses it to refuse a placeholder state, and the
+    placeholder pipelines use it to refuse a plain one: replaying a plain state
+    there would restore a prefix under an empty placeholder scheme.
+    """
+    metadata = getattr(resume_state, 'doc_metadata', None)
+    return isinstance(metadata, dict) and metadata.get('plain_text_mode') is True
+
+
+def resume_plain_segments(
+    resume_state: Optional[Any],
+    paragraph_count: int,
+    log_callback: Optional[Callable] = None,
+) -> Tuple[Optional[List[Dict[str, Any]]], Optional[List[str]]]:
+    """Validate a partial state for a plain-text resume.
+
+    Returns ``(segments, translated_prefix)`` when the state was written by this
+    pipeline for this exact document, and ``(None, None)`` otherwise so the
+    caller starts fresh. Both rejection paths log and never raise.
+
+    Args:
+        resume_state: XHTMLTranslationState loaded from the checkpoint, or None.
+        paragraph_count: number of source paragraphs extracted for this run.
+        log_callback: optional (key, message) logger.
+    """
+    if resume_state is None:
+        return None, None
+
+    if not is_plain_text_state(resume_state):
+        if log_callback:
+            log_callback(
+                "plain_text_resume_ignored",
+                "⚠️ Checkpoint was not written by Plain Text Mode, restarting this file"
+            )
+        return None, None
+
+    stored_count = resume_state.doc_metadata.get('paragraph_count')
+    if stored_count != paragraph_count:
+        if log_callback:
+            log_callback(
+                "plain_text_resume_ignored",
+                f"⚠️ Checkpoint covers {stored_count} paragraphs but the source has "
+                f"{paragraph_count}, restarting this file"
+            )
+        return None, None
+
+    return list(resume_state.chunks or []), list(resume_state.translated_chunks or [])
+
+
+def build_plain_checkpoint_hook(
+    *,
+    checkpoint_manager: Optional[Any],
+    translation_id: Optional[str],
+    file_href: Optional[str],
+    source_language: str,
+    target_language: str,
+    model_name: str,
+    max_tokens_per_chunk: int,
+    max_retries: Optional[int],
+    paragraph_count: int,
+    prompt_options: Optional[Dict[str, Any]] = None,
+    bilingual: bool = False,
+) -> Optional[Callable[[List[Dict[str, Any]], List[str], int, Dict[str, Any]], None]]:
+    """Build the ``checkpoint_hook`` for ``translate_paragraphs_plain``.
+
+    Returns None when there is nothing to write against (no manager, no job id
+    or no file identifier); the pipeline then skips checkpointing entirely.
+    """
+    if not (checkpoint_manager and translation_id and file_href):
+        return None
+
+    def _save_state(
+        segments: List[Dict[str, Any]],
+        prefix: List[str],
+        next_index: int,
+        stats_dict: Dict[str, Any],
+    ) -> None:
+        """Persist the contiguous translated prefix; resume restarts at next_index."""
+        now = _utc_now_iso()
+        state = XHTMLTranslationState(
+            file_path=file_href or '',
+            translation_id=translation_id,
+            file_href=file_href,
+            source_language=source_language,
+            target_language=target_language,
+            model_name=model_name,
+            max_tokens_per_chunk=max_tokens_per_chunk,
+            max_retries=max_retries or 1,
+            chunks=_as_persistable_chunks(segments),
+            global_tag_map={},
+            placeholder_format=("", ""),
+            translated_chunks=list(prefix),
+            current_chunk_index=next_index,
+            original_body_html="",
+            doc_metadata={
+                'plain_text_mode': True,
+                'paragraph_count': paragraph_count,
+            },
+            stats=stats_dict,
+            created_at=now,
+            updated_at=now,
+            global_stats=None,
+            prompt_options=prompt_options,
+            bilingual=bilingual,
+            original_chunks=None,
+        )
+        checkpoint_manager.save_xhtml_partial_state(translation_id, file_href, state)
+
+    return _save_state
+
+
+def delete_plain_checkpoint(
+    checkpoint_manager: Optional[Any],
+    translation_id: Optional[str],
+    file_href: Optional[str],
+    log_callback: Optional[Callable] = None,
+) -> None:
+    """Drop the plain-text partial state once the output has been rebuilt.
+
+    EPUB gets this for free from ``_save_translated_file``; DOCX has no
+    equivalent seam, so it calls this explicitly. Failing to delete must never
+    fail the translation.
+    """
+    if not (checkpoint_manager and translation_id and file_href):
+        return
+    try:
+        checkpoint_manager.delete_xhtml_partial_state(translation_id, file_href)
+    except Exception as exc:  # noqa: BLE001 - cleanup must not break the result
+        if log_callback:
+            log_callback(
+                "plain_text_checkpoint_delete_failed",
+                f"⚠️ Could not delete the plain-text checkpoint: {exc}"
+            )

--- a/src/core/common/plain_text_pipeline.py
+++ b/src/core/common/plain_text_pipeline.py
@@ -180,6 +180,11 @@ async def translate_paragraphs_plain(
     check_interruption_callback: Optional[Callable] = None,
     prompt_options: Optional[Dict] = None,
     parallel_workers: int = 1,
+    *,
+    resume_segments: Optional[List[Dict[str, Any]]] = None,
+    resume_translated: Optional[List[str]] = None,
+    checkpoint_hook: Optional[Callable[[List[Dict[str, Any]], List[str], int, Dict[str, Any]], None]] = None,
+    checkpoint_every: int = 5,
 ) -> Tuple[List[str], TranslationMetrics, bool]:
     """
     Translate a list of plain-text paragraphs without placeholder preservation.
@@ -200,6 +205,19 @@ async def translate_paragraphs_plain(
             resolved against the provider by the caller). When 1, behavior is
             identical to the legacy sequential loop, including previous-chunk
             context chaining; > 1 drops that chaining.
+        resume_segments: segment list from a previous run's checkpoint, replayed
+            verbatim instead of re-deriving it from `paragraphs`. Storing the
+            segmentation rather than rebuilding it makes resume immune to a
+            token-budget change between the pause and the resume.
+        resume_translated: translations already produced for the first
+            len(resume_translated) segments. Those segments are never retried,
+            including ones that fell back to source text after a failure.
+        checkpoint_hook: called as
+            hook(segments, prefix, next_index, stats_dict) whenever the
+            contiguous translated prefix advances far enough to be worth
+            persisting. `prefix` is always exactly `next_index` items long and
+            contains no None. A hook that raises is logged and ignored.
+        checkpoint_every: how many segments between periodic hook calls.
 
     Returns:
         (translated_paragraphs, stats, was_interrupted)
@@ -212,7 +230,25 @@ async def translate_paragraphs_plain(
             stats_callback(stats.to_dict())
         return source, stats, False
 
-    segments = build_plain_segments(source, max_tokens_per_chunk)
+    # === RESUME ===
+    # build_plain_segments is deterministic for a given (paragraphs, budget),
+    # but the stored segmentation always wins so a budget change between pause
+    # and resume cannot shift the indices the prefix was written against.
+    prefix: List[str] = list(resume_translated or [])
+    segments = (
+        list(resume_segments) if resume_segments is not None
+        else build_plain_segments(source, max_tokens_per_chunk)
+    )
+    if prefix and (resume_segments is None or len(prefix) > len(segments)):
+        # More translated segments than segments to translate means the source
+        # changed under the checkpoint; nothing about the prefix can be trusted.
+        if log_callback:
+            log_callback(
+                "plain_text_resume_discarded",
+                "⚠️ Plain-text checkpoint does not match the source, restarting this file"
+            )
+        prefix = []
+        segments = build_plain_segments(source, max_tokens_per_chunk)
 
     # Chunk dicts mirror split_text_into_chunks() output; context comes from
     # the neighboring segments.
@@ -233,8 +269,6 @@ async def translate_paragraphs_plain(
         })
 
     stats.total_chunks = len(chunks)
-    if stats_callback:
-        stats_callback(stats.to_dict())
 
     workers = max(1, int(parallel_workers))
     sequential = workers == 1
@@ -243,6 +277,14 @@ async def translate_paragraphs_plain(
     # source order.
     translated_parts: List[Optional[str]] = [None] * len(chunks)
     previous_translation_context = ""
+
+    # Restored work counts as processed so the progress bar does not rewind.
+    for k, done in enumerate(prefix):
+        translated_parts[k] = done
+        stats.record_processed()
+
+    if stats_callback:
+        stats_callback(stats.to_dict())
 
     async def _translate_chunk(i):
         """Translate one chunk. Reads previous_translation_context only in
@@ -272,9 +314,29 @@ async def translate_paragraphs_plain(
             if translated_parts[j] is None:
                 translated_parts[j] = chunks[j].get('main_content', '')
 
-    pending = list(range(len(chunks)))
+    def _run_checkpoint_hook(next_index):
+        """Hand the contiguous prefix [0, next_index) to the caller's hook.
+
+        A failing hook degrades persistence, not the translation, so every call
+        is isolated.
+        """
+        if checkpoint_hook is None:
+            return
+        try:
+            checkpoint_hook(
+                segments, list(translated_parts[:next_index]), next_index, stats.to_dict()
+            )
+        except Exception as exc:  # noqa: BLE001 - checkpointing is best-effort
+            if log_callback:
+                log_callback(
+                    "plain_text_checkpoint_failed",
+                    f"⚠️ Plain-text checkpoint failed at segment {next_index}/{len(chunks)}: {exc}"
+                )
+
+    checkpoint_step = max(1, int(checkpoint_every))
+    pending = list(range(len(prefix), len(chunks)))
     rate_limit_error = None
-    processed = 0
+    processed = len(prefix)
 
     # Continuous concurrency with in-order delivery (see iter_ordered_concurrent).
     async for i, result in iter_ordered_concurrent(
@@ -324,10 +386,25 @@ async def translate_paragraphs_plain(
             stats_callback(stats.to_dict())
         processed += 1
 
+        # === CONTIGUITY INVARIANT ===
+        # iter_ordered_concurrent yields indices strictly in ascending order and
+        # every branch above assigns translated_parts[i] (success, empty, None
+        # result, or exception -> source fallback). Therefore, once index i has
+        # been handled, slots 0..i are all non-None and i + 1 is a gap-free
+        # resume point. Every hook call below relies on this: the prefix handed
+        # to the checkpoint is never sparse.
+        next_index = i + 1
+        if next_index % checkpoint_step == 0 or next_index == len(chunks):
+            _run_checkpoint_hook(next_index)
+
     if rate_limit_error is not None:
-        # Keep source text for everything not yet translated, then propagate to
-        # trigger the caller's pause/resume handling.
+        # Persist the contiguous prefix translated before the limit, then keep
+        # source text for everything else and propagate: the caller's auto-pause
+        # depends on the exception reaching it.
+        _run_checkpoint_hook(processed)
         _fill_remaining_with_source()
+        safe_parts = [p if p is not None else "" for p in translated_parts]
+        rate_limit_error.partial_result = _reassemble(segments, safe_parts, source)
         raise rate_limit_error
 
     # Interruption: the scheduler stopped launching new chunks; keep source text
@@ -338,6 +415,7 @@ async def translate_paragraphs_plain(
                 "plain_text_translation_interrupted",
                 f"⏸️ Plain-text translation interrupted at chunk {processed + 1}/{len(chunks)}"
             )
+        _run_checkpoint_hook(processed)
         _fill_remaining_with_source()
         safe_parts = [p if p is not None else "" for p in translated_parts]
         return _reassemble(segments, safe_parts, source), stats, True

--- a/src/core/docx/converter.py
+++ b/src/core/docx/converter.py
@@ -16,7 +16,7 @@ import mammoth
 from docx import Document
 from docx.shared import Pt, RGBColor, Inches
 from docx.enum.text import WD_ALIGN_PARAGRAPH
-from typing import Tuple, Dict, Any, Optional
+from typing import Tuple, Dict, Any, Optional, Set
 from lxml import etree
 
 
@@ -40,6 +40,14 @@ _EQ_MARKER_REGEX = re.compile(
 # text markers before the HTML->DOCX rebuild so _restore_equations can splice
 # the original OMML back in.
 _EQ_TAG_REGEX = re.compile(r'<eq id="(\d+)"\s*/>')
+
+# Tags that start a new paragraph when found inside a <blockquote>.
+_BLOCKQUOTE_BLOCK_TAGS = frozenset(
+    {'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote'}
+)
+# Blockquote children that are rebuilt by the generic dispatch instead of
+# being folded into a quoted paragraph.
+_BLOCKQUOTE_DELEGATED_TAGS = frozenset({'ul', 'ol', 'table'})
 
 _OMML_XPATH = etree.XPath(
     './/m:oMathPara | .//m:oMath[not(ancestor::m:oMathPara)]',
@@ -385,6 +393,8 @@ class DocxHtmlConverter:
             doc.add_paragraph()  # Empty paragraph for line break
         elif tag == 'img':
             self._add_image_run(doc.add_paragraph(), element)
+        elif tag == 'blockquote':
+            self._convert_blockquote(doc, element, metadata)
         # Skip other tags (div, span handled within paragraphs)
 
     def _convert_paragraph(
@@ -409,18 +419,124 @@ class DocxHtmlConverter:
         text = self._get_text_content(element)
         doc.add_heading(text, level=level)
 
-    def _convert_list(
+    def _convert_blockquote(
         self,
         doc: Document,
         element: etree._Element,
         metadata: Dict[str, Any]
+    ) -> None:
+        """
+        Convert HTML <blockquote> to one or more quoted DOCX paragraphs.
+
+        Each block-level child (<p>, <h1>-<h6>) becomes its own paragraph so
+        multi-paragraph quotes are not collapsed; a nested <blockquote>
+        recurses. Lists and tables inside the quote are handed back to the
+        generic dispatch so they are not silently dropped.
+        """
+        style_name = self._quote_style_name(doc)
+        block_children = [
+            child for child in element
+            if child.tag in _BLOCKQUOTE_BLOCK_TAGS
+        ]
+
+        if block_children:
+            for child in block_children:
+                if child.tag == 'blockquote':
+                    self._convert_blockquote(doc, child, metadata)
+                    continue
+                paragraph = doc.add_paragraph()
+                self._add_runs_from_element(paragraph, child, metadata)
+                self._apply_quote_format(paragraph, style_name)
+        elif self._get_block_text(element, exclude=_BLOCKQUOTE_DELEGATED_TAGS).strip():
+            # Bare quote text with no <p> wrapper. The delegated children are
+            # emitted by the loop below, so they are skipped here rather than
+            # flattened into this paragraph a second time.
+            paragraph = doc.add_paragraph()
+            self._add_runs_from_element(
+                paragraph, element, metadata, skip_tags=_BLOCKQUOTE_DELEGATED_TAGS
+            )
+            self._apply_quote_format(paragraph, style_name)
+
+        for child in element:
+            if child.tag in _BLOCKQUOTE_DELEGATED_TAGS:
+                self._convert_html_element_to_docx(doc, child, metadata)
+
+    def _quote_style_name(self, doc: Document) -> Optional[str]:
+        """
+        Return the quote style available in the document, or None.
+
+        python-docx raises KeyError for a style name the template does not
+        define, so each candidate is probed before use.
+        """
+        for name in ('Quote', 'Intense Quote'):
+            try:
+                doc.styles[name]
+            except KeyError:
+                continue
+            return name
+        return None
+
+    def _apply_quote_format(self, paragraph, style_name: Optional[str]) -> None:
+        """Mark a paragraph as quoted, falling back to a left indent."""
+        if style_name:
+            paragraph.style = style_name
+        else:
+            paragraph.paragraph_format.left_indent = Inches(0.5)
+
+    def _convert_list(
+        self,
+        doc: Document,
+        element: etree._Element,
+        metadata: Dict[str, Any],
+        level: int = 1
     ):
-        """Convert HTML list to DOCX list."""
+        """
+        Convert an HTML list to DOCX list paragraphs.
+
+        Only direct <li> children are consumed, in document order; nested
+        <ul>/<ol> recurse with an incremented level. Using `.//li` here would
+        emit every descendant item twice, once for the outer list and once
+        for the nested one.
+        """
         is_ordered = element.tag == 'ol'
 
-        for li in element.findall('.//li'):
-            text = self._get_text_content(li)
-            p = doc.add_paragraph(text, style='List Number' if is_ordered else 'List Bullet')
+        for li in [child for child in element if child.tag == 'li']:
+            text = self._get_block_text(li, exclude={'ul', 'ol'})
+            if text.strip():
+                self._add_list_paragraph(doc, text, is_ordered, level)
+
+            for child in li:
+                if child.tag in ('ul', 'ol'):
+                    self._convert_list(doc, child, metadata, level + 1)
+
+    def _list_style(self, is_ordered: bool, level: int) -> str:
+        """Return the list style name for a nesting level (1-based)."""
+        base = 'List Number' if is_ordered else 'List Bullet'
+        if level >= 2:
+            return f'{base} {min(level, 3)}'
+        return base
+
+    def _add_list_paragraph(
+        self,
+        doc: Document,
+        text: str,
+        is_ordered: bool,
+        level: int
+    ):
+        """
+        Add a list paragraph, falling back to the base style if needed.
+
+        The style is applied after the paragraph is created: add_paragraph()
+        appends the paragraph before applying the style, so catching the
+        KeyError around the whole call would leave an unstyled duplicate
+        behind.
+        """
+        paragraph = doc.add_paragraph(text)
+        try:
+            paragraph.style = self._list_style(is_ordered, level)
+        except KeyError:
+            paragraph.style = self._list_style(is_ordered, 1)
+        return paragraph
 
     def _convert_table(
         self,
@@ -428,40 +544,73 @@ class DocxHtmlConverter:
         element: etree._Element,
         metadata: Dict[str, Any]
     ):
-        """Convert HTML table to DOCX table."""
-        rows = element.findall('.//tr')
+        """
+        Convert HTML <table> to a DOCX table.
+
+        Rows and cells are collected from direct children only, so the rows
+        of a table nested inside a cell never leak into the parent table.
+        A nested table's text is flattened into its parent cell, appearing
+        exactly once; real nested DOCX tables are out of scope.
+        """
+        rows = self._collect_table_rows(element)
         if not rows:
             return
 
-        # Count columns from first row
-        first_row = rows[0]
-        cols = len(first_row.findall('.//td')) + len(first_row.findall('.//th'))
+        # Direct children in document order, so a <th> after a <td> keeps
+        # its position instead of being pushed to the end of the row.
+        row_cells = [
+            [child for child in tr if child.tag in ('td', 'th')]
+            for tr in rows
+        ]
 
+        # The widest row defines the column count; a narrow header row must
+        # not truncate the rows below it.
+        cols = max(len(cells) for cells in row_cells)
         if cols == 0:
             return
 
-        # Create table
         table = doc.add_table(rows=len(rows), cols=cols)
         table.style = 'Table Grid'
 
-        # Fill cells
-        for row_idx, tr in enumerate(rows):
-            cells = tr.findall('.//td') + tr.findall('.//th')
+        for row_idx, cells in enumerate(row_cells):
             for col_idx, cell in enumerate(cells):
                 if col_idx < cols:
                     text = self._get_text_content(cell)
                     table.rows[row_idx].cells[col_idx].text = text
 
+    def _collect_table_rows(self, element: etree._Element) -> list:
+        """
+        Collect the <tr> belonging to this table, in document order.
+
+        Direct-child <tr> keep their position, and <thead>/<tbody>/<tfoot>
+        sections contribute their own direct-child <tr>.
+        """
+        rows = []
+        for child in element:
+            if child.tag == 'tr':
+                rows.append(child)
+            elif child.tag in ('thead', 'tbody', 'tfoot'):
+                rows.extend(
+                    grandchild for grandchild in child
+                    if grandchild.tag == 'tr'
+                )
+        return rows
+
     def _add_runs_from_element(
         self,
         paragraph,
         element: etree._Element,
-        metadata: Dict[str, Any]
+        metadata: Dict[str, Any],
+        skip_tags: Set[str] = frozenset()
     ):
         """
         Add runs to paragraph from HTML element, preserving inline formatting.
 
         Handles <strong>, <em>, <b>, <i>, etc.
+
+        Children whose tag is in ``skip_tags`` contribute no run, but their
+        tail text is kept. Callers use this when the skipped subtree is
+        emitted separately, so its text is not written twice.
         """
         # Handle direct text
         if element.text:
@@ -469,6 +618,12 @@ class DocxHtmlConverter:
 
         # Handle child elements
         for child in element:
+            if child.tag in skip_tags:
+                # Emitted separately by the caller; only the tail belongs here.
+                if child.tail:
+                    paragraph.add_run(child.tail)
+                continue
+
             if child.tag == 'strong' or child.tag == 'b':
                 text = self._get_text_content(child)
                 run = paragraph.add_run(text)
@@ -531,3 +686,23 @@ class DocxHtmlConverter:
     def _get_text_content(self, element: etree._Element) -> str:
         """Extract all text content from an element and its children."""
         return ''.join(element.itertext())
+
+    def _get_block_text(
+        self,
+        element: etree._Element,
+        exclude: Set[str] = frozenset()
+    ) -> str:
+        """
+        Extract text content, skipping the subtrees of excluded children.
+
+        The tail text of an excluded child is kept, so `<li>A<ul>…</ul>B</li>`
+        with exclude={'ul'} yields "AB" rather than dropping the trailing
+        text. Unlike _get_text_content, this is meant for block containers
+        whose nested blocks are rebuilt separately.
+        """
+        parts = [element.text or '']
+        for child in element:
+            if child.tag not in exclude:
+                parts.append(''.join(child.itertext()))
+            parts.append(child.tail or '')
+        return ''.join(parts)

--- a/src/core/docx/docx_translation_adapter.py
+++ b/src/core/docx/docx_translation_adapter.py
@@ -279,7 +279,26 @@ class DocxTranslationAdapter(TranslationAdapter[str, bytes]):
                 stats_callback=stats_callback,
                 check_interruption_callback=check_interruption_callback,
                 parallel_workers=parallel_workers,
+                file_href=file_href,
+                checkpoint_manager=checkpoint_manager,
+                translation_id=translation_id,
+                max_retries=max_retries,
+                resume_state=resume_state,
             )
+
+        # A Plain Text Mode checkpoint carries no tag map and an empty
+        # placeholder format, so replaying it here would restore a prefix under
+        # a placeholder scheme that never produced it. Mirror of the guard the
+        # plain pipeline applies: each mode resumes only its own state.
+        from src.core.common.plain_text_checkpoint import is_plain_text_state
+        if is_plain_text_state(resume_state):
+            if log_callback:
+                log_callback(
+                    "docx_resume_ignored",
+                    "⚠️ Checkpoint was written in Plain Text Mode; restarting "
+                    "this file with placeholder translation"
+                )
+            resume_state = None
 
         # === RESUME FROM PARTIAL STATE ===
         if resume_state:
@@ -410,6 +429,11 @@ class DocxTranslationAdapter(TranslationAdapter[str, bytes]):
         stats_callback: Optional[Callable],
         check_interruption_callback: Optional[Callable],
         parallel_workers: int = 1,
+        file_href: Optional[str] = None,
+        checkpoint_manager: Optional[Any] = None,
+        translation_id: Optional[str] = None,
+        max_retries: int = 1,
+        resume_state: Optional[Any] = None,
     ) -> Tuple[bytes, Any]:
         """
         Plain-text-mode DOCX translation: skip mammoth + placeholders.
@@ -417,12 +441,23 @@ class DocxTranslationAdapter(TranslationAdapter[str, bytes]):
         Read paragraphs via python-docx, translate as plain text, rebuild
         a fresh Document with the same page setup. Images are reattached
         right after their original paragraph (separate image-only paragraph).
+
+        Segment-level checkpointing reuses the XHTML partial-state machinery:
+        a rate limit or an interruption leaves a resumable checkpoint behind,
+        and `resume_state` restarts at the first unattempted segment. Unlike
+        EPUB there is no post-save seam to clean up after us, so the state is
+        deleted here once the document has been rebuilt.
         """
         import os
         import tempfile
 
         from .plain_extractor import extract_plain_paragraphs, build_minimal_docx
         from src.core.common.plain_text_pipeline import translate_paragraphs_plain
+        from src.core.common.plain_text_checkpoint import (
+            build_plain_checkpoint_hook,
+            delete_plain_checkpoint,
+            resume_plain_segments,
+        )
         from ..epub.translation_metrics import TranslationMetrics
 
         bilingual_flag = bool(prompt_options.get('bilingual')) if prompt_options else False
@@ -441,6 +476,24 @@ class DocxTranslationAdapter(TranslationAdapter[str, bytes]):
                 log_callback("plain_text_empty_docx", "⚠️ No paragraphs found in DOCX")
             return b'', TranslationMetrics()
 
+        paragraph_count = len(content.paragraphs_text)
+        resume_segments, resume_translated = resume_plain_segments(
+            resume_state, paragraph_count, log_callback
+        )
+        checkpoint_hook = build_plain_checkpoint_hook(
+            checkpoint_manager=checkpoint_manager,
+            translation_id=translation_id,
+            file_href=file_href,
+            source_language=source_language,
+            target_language=target_language,
+            model_name=model_name,
+            max_tokens_per_chunk=max_tokens_per_chunk,
+            max_retries=max_retries,
+            paragraph_count=paragraph_count,
+            prompt_options=prompt_options,
+            bilingual=bilingual_flag,
+        )
+
         translated, stats, was_interrupted = await translate_paragraphs_plain(
             paragraphs=content.paragraphs_text,
             source_language=source_language,
@@ -454,6 +507,9 @@ class DocxTranslationAdapter(TranslationAdapter[str, bytes]):
             check_interruption_callback=check_interruption_callback,
             prompt_options=prompt_options,
             parallel_workers=parallel_workers,
+            resume_segments=resume_segments,
+            resume_translated=resume_translated,
+            checkpoint_hook=checkpoint_hook,
         )
 
         if was_interrupted:
@@ -482,5 +538,9 @@ class DocxTranslationAdapter(TranslationAdapter[str, bytes]):
 
         if log_callback:
             log_callback("docx_plain_text_rebuilt", f"📄 Plain-text DOCX rebuilt ({len(docx_bytes)} bytes)")
+
+        # The document is complete: drop the segment checkpoint so a later
+        # resume of the same job does not replay a stale state.
+        delete_plain_checkpoint(checkpoint_manager, translation_id, file_href, log_callback)
 
         return docx_bytes, stats

--- a/src/core/epub/epub_translation_adapter.py
+++ b/src/core/epub/epub_translation_adapter.py
@@ -253,6 +253,10 @@ class EpubTranslationAdapter(TranslationAdapter[etree._Element, bool]):
                 bilingual_flag=bilingual_flag,
                 file_href=file_href,
                 parallel_workers=parallel_workers,
+                checkpoint_manager=checkpoint_manager,
+                translation_id=translation_id,
+                max_retries=max_retries,
+                resume_state=resume_state,
             )
 
         success, stats = await translate_xhtml_simplified(
@@ -297,6 +301,10 @@ class EpubTranslationAdapter(TranslationAdapter[etree._Element, bool]):
         bilingual_flag: bool,
         file_href: Optional[str],
         parallel_workers: int = 1,
+        checkpoint_manager: Optional[Any] = None,
+        translation_id: Optional[str] = None,
+        max_retries: int = 1,
+        resume_state: Optional[Any] = None,
     ) -> Tuple[bool, Any]:
         """
         Plain-text-mode translation path: skip placeholders entirely.
@@ -305,10 +313,19 @@ class EpubTranslationAdapter(TranslationAdapter[etree._Element, bool]):
         them via the common plain-text pipeline, then rewrite body with a flat
         structure (block tags preserved, images reattached after their parent
         paragraph, inline formatting dropped).
+
+        Segment-level checkpointing reuses the XHTML partial-state machinery:
+        a rate limit or an interruption leaves a resumable checkpoint behind,
+        and `resume_state` restarts at the first unattempted segment. The state
+        is deleted by the EPUB translator once the file has been saved.
         """
         from .plain_extractor import extract_plain_paragraphs, replace_body_with_paragraphs
         from .translation_metrics import TranslationMetrics
         from src.core.common.plain_text_pipeline import translate_paragraphs_plain
+        from src.core.common.plain_text_checkpoint import (
+            build_plain_checkpoint_hook,
+            resume_plain_segments,
+        )
 
         body = doc_root.find('.//{http://www.w3.org/1999/xhtml}body')
         if body is None:
@@ -328,6 +345,23 @@ class EpubTranslationAdapter(TranslationAdapter[etree._Element, bool]):
                 f"{sum(len(v) for v in images_by_paragraph.values())} images anchored"
             )
 
+        resume_segments, resume_translated = resume_plain_segments(
+            resume_state, len(paragraphs_text), log_callback
+        )
+        checkpoint_hook = build_plain_checkpoint_hook(
+            checkpoint_manager=checkpoint_manager,
+            translation_id=translation_id,
+            file_href=file_href,
+            source_language=source_language,
+            target_language=target_language,
+            model_name=model_name,
+            max_tokens_per_chunk=max_tokens_per_chunk,
+            max_retries=max_retries,
+            paragraph_count=len(paragraphs_text),
+            prompt_options=prompt_options,
+            bilingual=bilingual_flag,
+        )
+
         translated, stats, was_interrupted = await translate_paragraphs_plain(
             paragraphs=paragraphs_text,
             source_language=source_language,
@@ -341,6 +375,9 @@ class EpubTranslationAdapter(TranslationAdapter[etree._Element, bool]):
             check_interruption_callback=check_interruption_callback,
             prompt_options=prompt_options,
             parallel_workers=parallel_workers,
+            resume_segments=resume_segments,
+            resume_translated=resume_translated,
+            checkpoint_hook=checkpoint_hook,
         )
 
         if was_interrupted:

--- a/src/core/epub/translator.py
+++ b/src/core/epub/translator.py
@@ -30,6 +30,7 @@ from ..post_processor import clean_residual_tag_placeholders
 from ..context_optimizer import AdaptiveContextManager, INITIAL_CONTEXT_SIZE, CONTEXT_STEP, MAX_CONTEXT_SIZE
 from .rtl_support import apply_rtl_to_epub_directory, is_rtl_language
 from .lang_support import apply_target_language_to_xhtml_directory, get_language_code
+from src.utils.security import safe_extract_zip
 
 
 async def translate_epub_file(
@@ -329,7 +330,7 @@ def _extract_epub(input_filepath: str, temp_dir: str, log_callback: Optional[Cal
         log_callback("epub_extract_start", "Extracting EPUB...")
 
     with zipfile.ZipFile(input_filepath, 'r') as zip_ref:
-        zip_ref.extractall(temp_dir)
+        safe_extract_zip(zip_ref, temp_dir)
 
 
 def _find_opf_file(temp_dir: str) -> Optional[str]:

--- a/src/core/epub/xhtml_translator.py
+++ b/src/core/epub/xhtml_translator.py
@@ -1628,6 +1628,20 @@ async def translate_xhtml_simplified(
         from src.config import MAX_TOKENS_PER_CHUNK
         max_tokens_per_chunk = MAX_TOKENS_PER_CHUNK
 
+    # A Plain Text Mode checkpoint carries no tag map and an empty placeholder
+    # format, so replaying it here would restore a prefix under a placeholder
+    # scheme that never produced it. This is the mirror of the guard the plain
+    # pipeline applies to placeholder states: each mode resumes only its own.
+    from src.core.common.plain_text_checkpoint import is_plain_text_state
+    if is_plain_text_state(resume_state):
+        if log_callback:
+            log_callback(
+                "xhtml_resume_ignored",
+                "⚠️ Checkpoint was written in Plain Text Mode; restarting this "
+                "file with placeholder translation"
+            )
+        resume_state = None
+
     # === RESUME FROM PARTIAL STATE ===
     if resume_state:
         if log_callback:

--- a/src/core/llm/exceptions.py
+++ b/src/core/llm/exceptions.py
@@ -4,6 +4,8 @@ LLM-specific exceptions.
 This module defines all custom exceptions used in the LLM provider system.
 """
 
+from typing import Any
+
 
 class ContextOverflowError(Exception):
     """
@@ -38,9 +40,16 @@ class RateLimitError(Exception):
         retry_after: Suggested wait time in seconds (from Retry-After header),
                      or None if not provided by the API.
         provider: Name of the LLM provider that was rate-limited.
+        partial_result: Best-effort, already-reassembled payload carrying the
+                        work completed before the rate limit hit, so the caller
+                        can persist it instead of discarding it. Its type is
+                        defined by whoever raises (or re-raises) the error;
+                        None when the raiser has nothing to hand over.
     """
 
-    def __init__(self, message: str, retry_after: int = None, provider: str = None):
+    def __init__(self, message: str, retry_after: int = None, provider: str = None,
+                 partial_result: Any = None):
         super().__init__(message)
         self.retry_after = retry_after
         self.provider = provider
+        self.partial_result = partial_result

--- a/src/core/refine/txt_refiner.py
+++ b/src/core/refine/txt_refiner.py
@@ -10,9 +10,50 @@ import aiofiles
 from typing import Optional, Callable, Dict, Any
 
 from src.core.chunking.reassembly import join_translated_chunks
+from src.core.llm.exceptions import RateLimitError
 from src.core.text_processor import split_text_into_chunks
 from src.core.translator import refine_chunks
 from src.config import DEFAULT_MODEL, API_ENDPOINT
+
+
+async def _write_refined_output(
+    refined_parts,
+    structured_chunks,
+    output_filepath: str,
+    log_callback: Optional[Callable] = None,
+) -> bool:
+    """Reassemble the refined parts and write the final file.
+
+    Shared by the nominal completion path and the rate-limit partial-save path
+    so both produce byte-identical output for the same parts. Returns True when
+    the file was written; logs and returns False otherwise.
+    """
+    from src.config import ATTRIBUTION_ENABLED, GENERATOR_NAME, GENERATOR_SOURCE
+    final_text = join_translated_chunks(refined_parts, structured_chunks)
+    if ATTRIBUTION_ENABLED:
+        footer = f"\n\n{'=' * 60}\n"
+        footer += f"Refined with {GENERATOR_NAME}\n"
+        footer += f"{GENERATOR_SOURCE}\n"
+        footer += f"{'=' * 60}\n"
+        final_text += footer
+
+    try:
+        from src.utils.text_encoding import apply_normalization
+        final_text = apply_normalization(final_text)
+    except Exception:
+        pass
+
+    try:
+        async with aiofiles.open(output_filepath, 'w', encoding='utf-8') as f:
+            await f.write(final_text)
+        return True
+    except Exception as e:
+        err_msg = f"ERROR: Saving output file '{output_filepath}': {e}"
+        if log_callback:
+            log_callback("refine_save_error", err_msg)
+        else:
+            print(err_msg)
+        return False
 
 
 async def refine_txt_file(
@@ -104,53 +145,45 @@ async def refine_txt_file(
     # refine-only mode we pass main_content as both draft and original.
     draft_chunks = [c["main_content"] for c in structured_chunks]
 
-    refined_parts = await refine_chunks(
-        translated_chunks=draft_chunks,
-        original_chunks=structured_chunks,
-        target_language=target_language,
-        model_name=model_name,
-        api_endpoint=cli_api_endpoint,
-        log_callback=log_callback,
-        stats_callback=stats_callback,
-        check_interruption_callback=check_interruption_callback,
-        llm_provider=llm_provider,
-        gemini_api_key=gemini_api_key,
-        openai_api_key=openai_api_key,
-        openrouter_api_key=openrouter_api_key,
-        mistral_api_key=mistral_api_key,
-        deepseek_api_key=deepseek_api_key,
-        poe_api_key=poe_api_key,
-        nim_api_key=nim_api_key,
-        context_window=context_window,
-        auto_adjust_context=auto_adjust_context,
-        prompt_options=prompt_options,
-    )
-
-    from src.config import ATTRIBUTION_ENABLED, GENERATOR_NAME, GENERATOR_SOURCE
-    final_text = join_translated_chunks(refined_parts, structured_chunks)
-    if ATTRIBUTION_ENABLED:
-        footer = f"\n\n{'=' * 60}\n"
-        footer += f"Refined with {GENERATOR_NAME}\n"
-        footer += f"{GENERATOR_SOURCE}\n"
-        footer += f"{'=' * 60}\n"
-        final_text += footer
-
     try:
-        from src.utils.text_encoding import apply_normalization
-        final_text = apply_normalization(final_text)
-    except Exception:
-        pass
+        refined_parts = await refine_chunks(
+            translated_chunks=draft_chunks,
+            original_chunks=structured_chunks,
+            target_language=target_language,
+            model_name=model_name,
+            api_endpoint=cli_api_endpoint,
+            log_callback=log_callback,
+            stats_callback=stats_callback,
+            check_interruption_callback=check_interruption_callback,
+            llm_provider=llm_provider,
+            gemini_api_key=gemini_api_key,
+            openai_api_key=openai_api_key,
+            openrouter_api_key=openrouter_api_key,
+            mistral_api_key=mistral_api_key,
+            deepseek_api_key=deepseek_api_key,
+            poe_api_key=poe_api_key,
+            nim_api_key=nim_api_key,
+            context_window=context_window,
+            auto_adjust_context=auto_adjust_context,
+            prompt_options=prompt_options,
+        )
+    except RateLimitError as e:
+        # Persist whatever the pass managed to refine before pausing, then let
+        # the error propagate: handlers.py drives the pause / auto-resume.
+        parts = e.partial_result
+        if parts is None or len(parts) != len(structured_chunks):
+            raise
+        written = await _write_refined_output(
+            parts, structured_chunks, output_filepath, log_callback)
+        if written and log_callback:
+            log_callback("refine_partial_saved",
+                         f"💾 Partial refined output saved before rate-limit pause: '{output_filepath}'")
+        raise
 
-    try:
-        async with aiofiles.open(output_filepath, 'w', encoding='utf-8') as f:
-            await f.write(final_text)
-        if log_callback:
-            log_callback("refine_save_success", f"Refined output saved: '{output_filepath}'")
-        return True
-    except Exception as e:
-        err_msg = f"ERROR: Saving output file '{output_filepath}': {e}"
-        if log_callback:
-            log_callback("refine_save_error", err_msg)
-        else:
-            print(err_msg)
+    if not await _write_refined_output(
+            refined_parts, structured_chunks, output_filepath, log_callback):
         return False
+
+    if log_callback:
+        log_callback("refine_save_success", f"Refined output saved: '{output_filepath}'")
+    return True

--- a/src/core/translator.py
+++ b/src/core/translator.py
@@ -832,6 +832,10 @@ async def refine_chunks(
                 # Add remaining unrefined chunks as-is
                 for remaining in translated_chunks[i:]:
                     refined_parts.append(remaining)
+                # Invariant: len(refined_parts) == len(translated_chunks) here —
+                # the list is complete, chunks at index >= i are the unrefined
+                # drafts. Hand it to the caller so the partial pass can be saved.
+                e.partial_result = list(refined_parts)
                 raise  # Re-raise to handlers.py
 
             # Record success in context manager

--- a/src/persistence/checkpoint_manager.py
+++ b/src/persistence/checkpoint_manager.py
@@ -7,6 +7,7 @@ import shutil
 from typing import Optional, Dict, List, Any, Tuple
 from pathlib import Path
 from .database import Database
+from src.utils.security import SecurityError, resolve_within, safe_extract_zip
 
 
 class CheckpointManager:
@@ -682,7 +683,7 @@ class CheckpointManager:
 
                     # Extract original EPUB
                     with zipfile.ZipFile(preserved_input_path, 'r') as zip_ref:
-                        zip_ref.extractall(temp_path)
+                        safe_extract_zip(zip_ref, temp_path)
 
                     # Restore translated files from checkpoint
                     restore_success = self.restore_epub_files(translation_id, temp_path)
@@ -747,14 +748,18 @@ class CheckpointManager:
         job_dir = self.uploads_dir / translation_id / "translated_files"
         job_dir.mkdir(parents=True, exist_ok=True)
 
-        # Preserve directory structure
-        file_path = job_dir / file_href
-        file_path.parent.mkdir(parents=True, exist_ok=True)
-
         try:
+            # Preserve directory structure, but never outside the job directory:
+            # file_href comes from the EPUB manifest and is attacker-controlled
+            file_path = resolve_within(job_dir, file_href)
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+
             with open(file_path, 'wb') as f:
                 f.write(file_content)
             return True
+        except SecurityError:
+            print(f"Refusing unsafe EPUB file href: {file_href}")
+            return False
         except Exception as e:
             print(f"Error saving EPUB file {file_href}: {e}")
             return False
@@ -782,7 +787,13 @@ class CheckpointManager:
             for file_path in translated_files_dir.rglob('*'):
                 if file_path.is_file():
                     rel_path = file_path.relative_to(translated_files_dir)
-                    dest_path = work_dir / rel_path
+                    try:
+                        dest_path = resolve_within(
+                            work_dir, str(rel_path).replace('\\', '/')
+                        )
+                    except SecurityError:
+                        print(f"Skipping unsafe restored EPUB path: {rel_path}")
+                        continue
                     dest_path.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy2(file_path, dest_path)
             return True

--- a/src/persistence/database.py
+++ b/src/persistence/database.py
@@ -61,6 +61,11 @@ class Database:
             conn.row_factory = sqlite3.Row
             conn.execute("PRAGMA journal_mode=WAL")
             conn.execute("PRAGMA busy_timeout=30000")
+            # SQLite scopes foreign_keys per connection, not per database, so it
+            # must be enabled here (on every connection we hand out) rather than
+            # once in _initialize_schema. Without it, the ON DELETE CASCADE
+            # declared on checkpoint_chunks is silently ignored.
+            conn.execute("PRAGMA foreign_keys = ON")
             self._local.connection = conn
         return self._local.connection
 
@@ -119,6 +124,17 @@ class Database:
                 CREATE INDEX IF NOT EXISTS idx_chunks_translation
                 ON checkpoint_chunks(translation_id)
             """)
+
+            # Reclaim chunk rows orphaned by deletions performed while foreign
+            # key enforcement was off. Idempotent by construction: on a clean
+            # database it deletes zero rows, so it can run on every startup and
+            # needs no schema-version table.
+            cursor.execute("""
+                DELETE FROM checkpoint_chunks
+                WHERE translation_id NOT IN (SELECT translation_id FROM translation_jobs)
+            """)
+            if cursor.rowcount > 0:
+                print(f"Reclaimed {cursor.rowcount} orphaned checkpoint chunk row(s)")
 
             conn.commit()
 
@@ -506,7 +522,17 @@ class Database:
                 if not job_ids:
                     return 0
 
-                # Delete old jobs (chunks deleted via CASCADE)
+                # Delete the chunks explicitly (defence in depth: the ON DELETE
+                # CASCADE only fires while PRAGMA foreign_keys is on). The
+                # placeholder string is built from len(job_ids); the values
+                # themselves are always bound as parameters.
+                placeholders = ','.join('?' * len(job_ids))
+                cursor.execute(
+                    f"DELETE FROM checkpoint_chunks WHERE translation_id IN ({placeholders})",
+                    job_ids
+                )
+
+                # Delete old jobs (chunks already deleted explicitly above)
                 cursor.execute("""
                     DELETE FROM translation_jobs
                     WHERE status IN ('paused', 'interrupted', 'error', 'partial', 'completed')
@@ -605,6 +631,13 @@ class Database:
             try:
                 conn = self._get_connection()
                 cursor = conn.cursor()
+
+                # Defence in depth: the ON DELETE CASCADE below only fires while
+                # PRAGMA foreign_keys is on for this connection.
+                cursor.execute(
+                    "DELETE FROM checkpoint_chunks WHERE translation_id = ?",
+                    (translation_id,)
+                )
 
                 cursor.execute(
                     "DELETE FROM translation_jobs WHERE translation_id = ?",

--- a/src/utils/security.py
+++ b/src/utils/security.py
@@ -6,8 +6,9 @@ import re
 import secrets
 import mimetypes
 import logging
+import zipfile
 from pathlib import Path
-from typing import Set, Optional, Dict, Any
+from typing import Set, Optional, Dict, Any, Iterable, Union
 from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
@@ -16,6 +17,120 @@ logger = logging.getLogger(__name__)
 class SecurityError(Exception):
     """Custom exception for security-related errors"""
     pass
+
+
+# === Archive path containment ===================================================
+#
+# Archive entry names and EPUB manifest hrefs are attacker-controlled: a crafted
+# entry such as '../../evil.txt' would otherwise let an extraction escape its
+# destination directory (zip slip).
+
+_DRIVE_PREFIX_RE = re.compile(r'^[A-Za-z]:')
+
+
+def is_safe_archive_member(entry_name: str) -> bool:
+    """
+    Return True if an archive entry name is safe to join to a destination.
+
+    Pure and OS-independent: no filesystem access. A trailing '/' (directory
+    entry) and a leading './' are allowed; '..' is only rejected when it is a
+    whole path component.
+    """
+    if not entry_name or not entry_name.strip():
+        return False
+
+    # Control characters (including NUL) never belong in a legitimate entry name
+    if any(ord(char) < 0x20 for char in entry_name):
+        return False
+
+    # The ZIP spec mandates '/' as the separator, so an entry containing '\' is
+    # either malicious or already broken: treating it as a separator is the safe
+    # reading on Windows.
+    normalized = entry_name.replace('\\', '/')
+
+    # POSIX absolute path or UNC path
+    if normalized.startswith('/'):
+        return False
+
+    # Windows drive-relative or drive-absolute path
+    if _DRIVE_PREFIX_RE.match(normalized):
+        return False
+
+    if any(component == '..' for component in normalized.split('/')):
+        return False
+
+    return True
+
+
+def find_unsafe_archive_member(entry_names: Iterable[str]) -> Optional[str]:
+    """Return the first unsafe entry name, or None if every name is safe."""
+    for entry_name in entry_names:
+        if not is_safe_archive_member(entry_name):
+            return entry_name
+    return None
+
+
+def _is_within(base: Union[str, Path], target: Union[str, Path]) -> bool:
+    """
+    Return True only if `target` resolves to a location inside `base`.
+
+    This mirrors PathValidator.is_within_directory (resolve both sides, then
+    compare with Path.relative_to — never str.startswith, which would treat
+    '/uploads-evil' as inside '/uploads'). It is reimplemented here on purpose:
+    src/utils must not import from src/api.
+    """
+    try:
+        base_resolved = Path(base).resolve()
+        target_resolved = Path(target).resolve()
+    except OSError:
+        return False
+    try:
+        target_resolved.relative_to(base_resolved)
+        return True
+    except ValueError:
+        return False
+
+
+def safe_extract_zip(zip_ref: zipfile.ZipFile, destination: Union[str, Path]) -> None:
+    """
+    Extract a ZIP archive into `destination`, refusing any escaping entry.
+
+    Every entry is validated before a single byte is written, so a rejected
+    archive leaves the destination untouched.
+
+    Raises:
+        SecurityError: if any entry name would escape `destination`.
+    """
+    entry_names = zip_ref.namelist()
+
+    bad = find_unsafe_archive_member(entry_names)
+    if bad is not None:
+        raise SecurityError(f"Unsafe archive entry path: {bad!r}")
+
+    # Belt and braces: also verify the resolved join stays inside the destination
+    for entry_name in entry_names:
+        if not _is_within(destination, Path(destination) / entry_name):
+            raise SecurityError(f"Unsafe archive entry path: {entry_name!r}")
+
+    zip_ref.extractall(destination)
+
+
+def resolve_within(base: Union[str, Path], relative: str) -> Path:
+    """
+    Resolve `relative` against `base`, refusing anything that escapes `base`.
+
+    Raises:
+        SecurityError: if `relative` is an unsafe archive member or resolves
+            outside `base`.
+    """
+    if not is_safe_archive_member(relative):
+        raise SecurityError(f"Unsafe relative path: {relative!r}")
+
+    resolved = (Path(base) / relative).resolve()
+    if not _is_within(base, resolved):
+        raise SecurityError(f"Unsafe relative path: {relative!r}")
+
+    return resolved
 
 
 @dataclass
@@ -394,7 +509,15 @@ class SecureFileHandler:
             # Basic EPUB structure validation
             with zipfile.ZipFile(file_path, 'r') as epub_zip:
                 file_list = epub_zip.namelist()
-                
+
+                # Reject archives whose entries would escape the extraction dir
+                bad = find_unsafe_archive_member(file_list)
+                if bad is not None:
+                    return FileValidationResult(
+                        is_valid=False,
+                        error_message=f"EPUB contains an unsafe entry path: {bad}"
+                    )
+
                 # Check for required EPUB files
                 if 'mimetype' not in file_list:
                     warnings.append("Missing mimetype file")
@@ -516,6 +639,14 @@ class SecureFileHandler:
             # Basic DOCX structure validation
             with zipfile.ZipFile(file_path, 'r') as docx_zip:
                 file_list = docx_zip.namelist()
+
+                # Reject archives whose entries would escape the extraction dir
+                bad = find_unsafe_archive_member(file_list)
+                if bad is not None:
+                    return FileValidationResult(
+                        is_valid=False,
+                        error_message=f"DOCX contains an unsafe entry path: {bad}"
+                    )
 
                 # Check for required DOCX files
                 has_content_types = '[Content_Types].xml' in file_list

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -30,7 +30,7 @@ pytest tests/e2e/test_completion_classification.py -m e2e
 | Requirement | Effect when missing |
 | --- | --- |
 | `playwright` + its Chromium | the whole directory skips |
-| `GEMINI_API_KEY` (env or `.env`) | the whole directory skips |
+| the selected provider's key (env or `.env`) | the whole directory skips |
 | a free port (default `5099`) | the whole directory skips |
 
 Nothing here fails for a missing prerequisite — it skips, so a normal
@@ -41,8 +41,19 @@ Nothing here fails for a missing prerequisite — it skips, so a normal
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `E2E_PORT` | `5099` | port the test server binds to |
-| `E2E_MODEL` | `gemini-2.5-flash` | model used for every run |
+| `E2E_PROVIDER` | `gemini` | LLM provider driven by the run |
+| `E2E_MODEL` | follows the provider | model used for every run |
+| `E2E_ENDPOINT` | follows the provider | endpoint sent with each job |
 | `E2E_HEADED` | unset | set to `1` to watch the browser |
+
+`E2E_MODEL` and `E2E_ENDPOINT` default per provider, because a Gemini model
+name means nothing to Poe. The key field in the `/api/translate` payload
+follows `E2E_PROVIDER` too, so the suite never sends one provider's key field
+with another provider's job. To run against Poe:
+
+```bash
+E2E_PROVIDER=poe pytest tests/e2e -m e2e
+```
 
 ## What each file covers
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -6,7 +6,7 @@ browser, one set of input fixtures. Individual tests get a fresh page.
 Requirements, all checked at collection time so a missing one skips instead of
 failing:
   - playwright installed, with its Chromium downloaded (`playwright install chromium`)
-  - a Gemini API key in the environment (E2E runs cost real tokens)
+  - an API key for the selected provider (E2E runs cost real tokens)
 """
 import os
 import socket
@@ -19,9 +19,31 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_PORT = int(os.environ.get("E2E_PORT", "5099"))
-# Overridable so the suite can be pointed at a cheaper or newer model.
-E2E_MODEL = os.environ.get("E2E_MODEL", "gemini-2.5-flash")
-E2E_PROVIDER = "gemini"
+# Overridable so the suite can be pointed at a cheaper or newer backend. The
+# model default follows the provider, because a Gemini model name is
+# meaningless to Poe and vice versa; E2E_MODEL still wins when set explicitly.
+_DEFAULT_MODELS = {
+    "gemini": "gemini-2.5-flash",
+    "poe": "Claude-Sonnet-4",
+    "openai": "gpt-4o-mini",
+}
+E2E_PROVIDER = os.environ.get("E2E_PROVIDER", "gemini").strip().lower()
+E2E_MODEL = os.environ.get("E2E_MODEL") or _DEFAULT_MODELS.get(
+    E2E_PROVIDER, "gemini-2.5-flash"
+)
+
+# The API-key field name the /api/translate payload must carry for this
+# provider, and the endpoint that goes with it. Both follow the provider so a
+# run against Poe does not send a Gemini key field or a Gemini host.
+E2E_KEY_FIELD = f"{E2E_PROVIDER}_api_key"
+_DEFAULT_ENDPOINTS = {
+    "gemini": "https://generativelanguage.googleapis.com",
+    "poe": "https://api.poe.com/v1/chat/completions",
+    "openai": "https://api.openai.com/v1/chat/completions",
+}
+E2E_ENDPOINT = os.environ.get("E2E_ENDPOINT") or _DEFAULT_ENDPOINTS.get(
+    E2E_PROVIDER, ""
+)
 
 pytest.importorskip("requests", reason="e2e tests drive the HTTP API")
 sync_playwright = pytest.importorskip(
@@ -31,16 +53,26 @@ sync_playwright = pytest.importorskip(
 import requests  # noqa: E402  (after importorskip)
 
 
-def _has_gemini_key():
-    """True when a Gemini key is reachable, from the environment or .env."""
-    if (os.environ.get("GEMINI_API_KEY") or "").strip():
+def _provider_key_var():
+    """Env var holding the selected provider's key, via the shared mapping."""
+    from src.api.api_keys import provider_env_var
+
+    return provider_env_var(E2E_PROVIDER)
+
+
+def _has_provider_key():
+    """True when the selected provider's key is reachable, from env or .env."""
+    var = _provider_key_var()
+    if not var:
+        return False
+    if (os.environ.get(var) or "").strip():
         return True
     env_file = REPO_ROOT / ".env"
     if not env_file.exists():
         return False
     for line in env_file.read_text(encoding="utf-8", errors="ignore").splitlines():
         name, _, value = line.partition("=")
-        if name.strip() == "GEMINI_API_KEY" and value.split("#")[0].strip():
+        if name.strip() == var and value.split("#")[0].strip():
             return True
     return False
 
@@ -53,8 +85,11 @@ def _port_is_free(port):
 @pytest.fixture(scope="session")
 def live_server(tmp_path_factory):
     """Start the web server on a private port; yield (base_url, api_token)."""
-    if not _has_gemini_key():
-        pytest.skip("GEMINI_API_KEY is not configured; e2e runs need a real LLM")
+    if not _has_provider_key():
+        pytest.skip(
+            f"{_provider_key_var() or E2E_PROVIDER} is not configured; "
+            "e2e runs need a real LLM"
+        )
     if not _port_is_free(DEFAULT_PORT):
         pytest.skip(f"port {DEFAULT_PORT} is already in use; set E2E_PORT to a free one")
 

--- a/tests/e2e/test_completion_classification.py
+++ b/tests/e2e/test_completion_classification.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import pytest
 
-from .conftest import E2E_MODEL, E2E_PROVIDER
+from .conftest import E2E_ENDPOINT, E2E_KEY_FIELD, E2E_MODEL, E2E_PROVIDER
 
 pytestmark = pytest.mark.e2e
 
@@ -33,8 +33,8 @@ def _start(api, file_path, file_type, output_filename, model=None):
         "target_language": "French",
         "model": model or E2E_MODEL,
         "llm_provider": E2E_PROVIDER,
-        "gemini_api_key": "__USE_ENV__",
-        "llm_api_endpoint": "https://generativelanguage.googleapis.com",
+        E2E_KEY_FIELD: "__USE_ENV__",
+        "llm_api_endpoint": E2E_ENDPOINT,
         "output_filename": output_filename,
         "parallel_workers": 2,
     }

--- a/tests/test_docx/conftest.py
+++ b/tests/test_docx/conftest.py
@@ -95,6 +95,18 @@ def sample_html():
 
 
 @pytest.fixture
+def structured_html():
+    """HTML exercising blockquote, nested list, nested table and mixed cells."""
+    return """<html><body>
+<p>Intro paragraph.</p>
+<blockquote><p>Quoted line one.</p><p>Quoted line two.</p></blockquote>
+<ul><li>Outer A<ul><li>Inner A1</li><li>Inner A2</li></ul></li><li>Outer B</li></ul>
+<table><tr><th>H1</th><td>D1</td><th>H2</th></tr>
+<tr><td>Nested<table><tr><td>N1</td></tr></table></td><td>D2</td><td>D3</td></tr></table>
+</body></html>"""
+
+
+@pytest.fixture
 def sample_metadata():
     """Sample metadata for testing."""
     return {

--- a/tests/test_docx/test_converter.py
+++ b/tests/test_docx/test_converter.py
@@ -7,6 +7,7 @@ Tests DOCX ↔ HTML conversion functionality.
 import os
 import pytest
 from docx import Document
+from docx.shared import Inches
 from lxml import etree
 
 from src.core.docx.converter import DocxHtmlConverter
@@ -278,3 +279,155 @@ class TestDocxHtmlConverter:
 
         # lxml should handle it gracefully
         assert os.path.exists(output_path)
+
+
+def _paragraphs_containing(doc, needle):
+    """Return the paragraphs of a document whose text contains `needle`."""
+    return [p for p in doc.paragraphs if needle in p.text]
+
+
+def _single_paragraph_containing(doc, needle):
+    """Return the one paragraph containing `needle`, failing otherwise."""
+    matches = _paragraphs_containing(doc, needle)
+    assert len(matches) == 1, (
+        f"expected exactly one paragraph containing {needle!r}, "
+        f"got {[p.text for p in matches]}"
+    )
+    return matches[0]
+
+
+def _is_quoted(paragraph):
+    """A paragraph is quoted if it carries a Quote style or a 0.5in indent."""
+    style_name = paragraph.style.name if paragraph.style is not None else None
+    if style_name in ('Quote', 'Intense Quote'):
+        return True
+    return paragraph.paragraph_format.left_indent == Inches(0.5)
+
+
+class TestStructuredRebuild:
+    """
+    Structural fidelity of the HTML -> DOCX rebuild.
+
+    Each test re-opens the produced file so it asserts on the real rebuilt
+    document, not on intermediate converter state.
+    """
+
+    @pytest.fixture
+    def rebuilt_doc(self, temp_dir, structured_html):
+        """Rebuild the structured HTML fixture and re-open the DOCX."""
+        out_path = os.path.join(temp_dir, 'structured.docx')
+        DocxHtmlConverter().from_html(structured_html, {}, out_path)
+        assert os.path.exists(out_path)
+        return Document(out_path)
+
+    def test_blockquote_paragraphs_kept_once(self, rebuilt_doc):
+        """Both quoted lines survive, each in exactly one paragraph."""
+        all_text = '\n'.join(p.text for p in rebuilt_doc.paragraphs)
+
+        assert all_text.count('Quoted line one.') == 1
+        assert all_text.count('Quoted line two.') == 1
+        assert len(_paragraphs_containing(rebuilt_doc, 'Quoted line one.')) == 1
+        assert len(_paragraphs_containing(rebuilt_doc, 'Quoted line two.')) == 1
+
+    def test_blockquote_paragraphs_are_marked_as_quotes(self, rebuilt_doc):
+        """Quoted paragraphs use a Quote style, or fall back to an indent."""
+        for needle in ('Quoted line one.', 'Quoted line two.'):
+            paragraph = _single_paragraph_containing(rebuilt_doc, needle)
+            assert _is_quoted(paragraph), (
+                f"paragraph {needle!r} is neither Quote-styled nor indented "
+                f"(style={paragraph.style.name!r}, "
+                f"indent={paragraph.paragraph_format.left_indent!r})"
+            )
+
+    def test_nested_list_items_are_not_duplicated(self, rebuilt_doc):
+        """A nested <ul> is emitted once and not folded into its parent item."""
+        inner = _paragraphs_containing(rebuilt_doc, 'Inner A1')
+        assert len(inner) == 1
+
+        outer = [
+            p for p in rebuilt_doc.paragraphs if p.text.startswith('Outer A')
+        ]
+        assert len(outer) == 1
+        assert 'Inner A1' not in outer[0].text
+        assert 'Inner A2' not in outer[0].text
+
+    def test_nested_list_uses_a_deeper_style(self, rebuilt_doc):
+        """Level 2 items get their own style, unless the template lacks it."""
+        inner = _single_paragraph_containing(rebuilt_doc, 'Inner A1')
+        outer = _single_paragraph_containing(rebuilt_doc, 'Outer A')
+
+        inner_style = inner.style.name
+        outer_style = outer.style.name
+
+        # Either the level-2 style resolved (styles differ), or it was
+        # unavailable and both fell back to the base bullet style.
+        assert inner_style != outer_style or (
+            inner_style == outer_style == 'List Bullet'
+        )
+
+    def test_nested_table_does_not_add_a_top_level_row(self, rebuilt_doc):
+        """The nested table's row stays inside its cell."""
+        assert len(rebuilt_doc.tables) == 1
+        assert len(rebuilt_doc.tables[0].rows) == 2
+
+    def test_mixed_header_cells_keep_document_order(self, rebuilt_doc):
+        """A <th> after a <td> is not pushed to the end of the row."""
+        row = rebuilt_doc.tables[0].rows[0]
+        assert [cell.text for cell in row.cells] == ['H1', 'D1', 'H2']
+
+    def test_nested_table_text_is_flattened_once(self, rebuilt_doc):
+        """Nested table text appears once, in its parent cell only."""
+        table = rebuilt_doc.tables[0]
+        host_cell = table.rows[1].cells[0]
+
+        assert host_cell.text.count('N1') == 1
+
+        other_cells = [
+            cell
+            for row_idx, row in enumerate(table.rows)
+            for col_idx, cell in enumerate(row.cells)
+            if (row_idx, col_idx) != (1, 0)
+        ]
+        assert all('N1' not in cell.text for cell in other_cells)
+
+    def test_column_count_comes_from_the_widest_row(self, rebuilt_doc):
+        """Column count is the max row width, so no cell is truncated."""
+        assert len(rebuilt_doc.tables[0].columns) == 3
+
+    def test_unwrapped_quote_does_not_duplicate_its_list(self, temp_dir):
+        """
+        A blockquote whose text has no <p> wrapper still emits that text once
+        and its list once: the list is delegated to the list converter, so it
+        must not also be flattened into the quoted paragraph.
+        """
+        html = (
+            '<html><body><blockquote>Bare quote text.'
+            '<ul><li>Quoted item</li></ul></blockquote></body></html>'
+        )
+        out_path = os.path.join(temp_dir, 'bare_quote.docx')
+        DocxHtmlConverter().from_html(html, {}, out_path)
+
+        doc = Document(out_path)
+        all_text = '\n'.join(p.text for p in doc.paragraphs)
+
+        assert all_text.count('Bare quote text.') == 1
+        assert all_text.count('Quoted item') == 1
+
+        quote_paragraph = _single_paragraph_containing(doc, 'Bare quote text.')
+        assert 'Quoted item' not in quote_paragraph.text
+        assert _is_quoted(quote_paragraph)
+
+    def test_quote_containing_only_a_list_emits_no_empty_paragraph(self, temp_dir):
+        """A blockquote with no own text must not add a blank quoted paragraph."""
+        html = (
+            '<html><body><blockquote><ul><li>Only item</li></ul>'
+            '</blockquote></body></html>'
+        )
+        out_path = os.path.join(temp_dir, 'list_only_quote.docx')
+        DocxHtmlConverter().from_html(html, {}, out_path)
+
+        doc = Document(out_path)
+        texts = [p.text for p in doc.paragraphs if p.text.strip()]
+
+        assert texts == ['Only item']
+        assert not any(_is_quoted(p) and not p.text.strip() for p in doc.paragraphs)

--- a/tests/unit/test_database_cascade.py
+++ b/tests/unit/test_database_cascade.py
@@ -1,0 +1,183 @@
+"""Foreign-key enforcement and orphan purge for the jobs database.
+
+SQLite ignores `ON DELETE CASCADE` unless `PRAGMA foreign_keys` is on, and that
+pragma is scoped per connection. These tests pin the pragma, the cascade it
+enables, the explicit defence-in-depth deletes, and the one-off purge that
+reclaims chunk rows orphaned before enforcement existed.
+"""
+
+import sqlite3
+
+import pytest
+
+from src.core.adapters.translate_file import _ensure_checkpoint_job
+from src.persistence.checkpoint_manager import CheckpointManager
+from src.persistence.database import Database
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "jobs.db")
+
+
+@pytest.fixture
+def db(db_path):
+    database = Database(db_path)
+    yield database
+    database.close()
+
+
+def _count_chunks(database, translation_id):
+    conn = database._get_connection()
+    row = conn.execute(
+        "SELECT COUNT(*) FROM checkpoint_chunks WHERE translation_id = ?",
+        (translation_id,),
+    ).fetchone()
+    return row[0]
+
+
+def test_foreign_keys_pragma_is_enabled(db):
+    assert db._get_connection().execute("PRAGMA foreign_keys").fetchone()[0] == 1
+
+
+def test_delete_job_removes_its_chunks(db):
+    assert db.create_job("t1", "txt", {}) is True
+    assert db.save_chunk("t1", 0, "a", "b") is True
+
+    assert db.delete_job("t1") is True
+
+    assert _count_chunks(db, "t1") == 0
+
+
+def test_cleanup_old_jobs_removes_chunks(db):
+    assert db.create_job("old", "txt", {}) is True
+    assert db.save_chunk("old", 0, "a", "b") is True
+    assert db.save_chunk("old", 1, "c", "d") is True
+
+    conn = db._get_connection()
+    conn.execute(
+        """
+        UPDATE translation_jobs
+        SET status = 'paused', created_at = datetime('now', '-60 days')
+        WHERE translation_id = ?
+        """,
+        ("old",),
+    )
+    conn.commit()
+
+    assert db.cleanup_old_jobs(max_age_days=30) == 1
+    assert _count_chunks(db, "old") == 0
+
+
+def test_cleanup_old_jobs_with_nothing_to_delete(db):
+    """The IN (...) delete must not be built with zero placeholders."""
+    assert db.create_job("fresh", "txt", {}) is True
+    assert db.save_chunk("fresh", 0, "a", "b") is True
+
+    assert db.cleanup_old_jobs(max_age_days=30) == 0
+    assert _count_chunks(db, "fresh") == 1
+
+
+def test_orphan_chunks_are_purged_on_init(db_path):
+    Database(db_path).close()
+
+    # Simulate a row orphaned by a delete performed while enforcement was off.
+    raw = sqlite3.connect(db_path)
+    raw.execute("PRAGMA foreign_keys=OFF")
+    raw.execute(
+        """
+        INSERT INTO checkpoint_chunks
+        (translation_id, chunk_index, original_text, translated_text, status)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        ("ghost", 0, "a", "b", "completed"),
+    )
+    raw.commit()
+    raw.close()
+
+    reopened = Database(db_path)
+    try:
+        assert _count_chunks(reopened, "ghost") == 0
+    finally:
+        reopened.close()
+
+
+def test_orphan_purge_is_idempotent_on_a_clean_database(db_path, capsys):
+    Database(db_path).close()
+    capsys.readouterr()
+
+    reopened = Database(db_path)
+    try:
+        assert "Reclaimed" not in capsys.readouterr().out
+    finally:
+        reopened.close()
+
+
+def test_normal_write_order_still_succeeds(db_path):
+    manager = CheckpointManager(db_path=db_path)
+    try:
+        assert manager.start_job("job", "txt", {}, None) is True
+        assert manager.save_checkpoint(
+            translation_id="job",
+            chunk_index=0,
+            original_text="a",
+            translated_text="b",
+            total_chunks=1,
+            completed_chunks=1,
+            failed_chunks=0,
+        ) is True
+        assert _count_chunks(manager.db, "job") == 1
+    finally:
+        manager.db.close()
+
+
+def test_save_chunk_for_unknown_job_fails_cleanly(db):
+    assert db.save_chunk("missing", 0, "a", "b") is False
+    assert _count_chunks(db, "missing") == 0
+
+
+class TestLegacyPipelineWriteOrder:
+    """
+    The legacy EPUB/DOCX pipelines save chunks without creating the job row.
+    Under foreign-key enforcement that write is rejected, so translate_file()
+    creates the row first. These tests pin that guard.
+    """
+
+    def test_missing_job_is_created_before_chunks_are_written(self, db_path):
+        manager = CheckpointManager(db_path=db_path)
+        try:
+            _ensure_checkpoint_job(
+                checkpoint_manager=manager,
+                translation_id="cli-job",
+                file_type="epub",
+                config={"source_language": "English"},
+                input_file_path=None,
+            )
+
+            assert manager.db.get_job("cli-job") is not None
+            assert manager.db.save_chunk("cli-job", 0, "a", "b") is True
+            assert _count_chunks(manager.db, "cli-job") == 1
+        finally:
+            manager.db.close()
+
+    def test_existing_job_is_left_untouched(self, db_path):
+        manager = CheckpointManager(db_path=db_path)
+        try:
+            manager.start_job("web-job", "epub", {"marker": "original"}, None)
+
+            _ensure_checkpoint_job(
+                checkpoint_manager=manager,
+                translation_id="web-job",
+                file_type="epub",
+                config={"marker": "overwritten"},
+                input_file_path=None,
+            )
+
+            job = manager.db.get_job("web-job")
+            assert job["config"]["marker"] == "original"
+        finally:
+            manager.db.close()
+
+    def test_no_checkpoint_manager_is_a_no_op(self):
+        _ensure_checkpoint_job(None, "any", "epub", {}, None)
+        _ensure_checkpoint_job(object(), None, "epub", {}, None)

--- a/tests/unit/test_endpoint_allowlist.py
+++ b/tests/unit/test_endpoint_allowlist.py
@@ -1,0 +1,273 @@
+"""Unit tests for the LLM endpoint allowlist and the endpoint/key pairing rule.
+
+Two guards are covered:
+
+1. `EndpointValidator` — a request-supplied endpoint must be loopback/private
+   or an allowlisted host.
+2. The pairing rule in `translation_routes` — an endpoint that differs from the
+   server default must carry its own API key, so the `.env` key never travels
+   to a host the request chose.
+"""
+import pytest
+from flask import Flask
+
+import src.config as _config
+from src.api.api_keys import resolve_api_key
+from src.api.blueprints.translation_routes import create_translation_blueprint
+from src.api.services.endpoint_validator import EndpointValidator
+
+# Inert placeholder — never a real credential.
+FAKE_KEY = 'sk-xxxxxxxx'
+OPENAI_DEFAULT_ENDPOINT = 'https://api.openai.com/v1/chat/completions'
+# Allowlisted by the subdomain rule, but not the configured default.
+OPENAI_ALT_ENDPOINT = 'https://eu.api.openai.com/v1/chat/completions'
+
+
+# ---------------------------------------------------------------------------
+# EndpointValidator
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('endpoint', [None, '', '   '])
+def test_absent_endpoint_is_accepted(endpoint):
+    """No endpoint means 'use the server default', which is not an override."""
+    assert EndpointValidator.validate(endpoint) == (True, None)
+
+
+@pytest.mark.parametrize('endpoint', [
+    'http://localhost:11434/api/generate',
+    'http://127.0.0.1:1234/v1/chat/completions',
+    'http://192.168.1.50:11434/api/generate',
+    'http://host.docker.internal:11434/api/generate',
+    'http://10.0.0.7:8080/v1/chat/completions',
+    'http://[::1]:11434/api/generate',
+    'http://ollama.localhost/api/generate',
+])
+def test_local_and_private_endpoints_are_allowed(endpoint):
+    assert EndpointValidator.validate(endpoint) == (True, None)
+
+
+@pytest.mark.parametrize('endpoint', [
+    OPENAI_DEFAULT_ENDPOINT,
+    OPENAI_ALT_ENDPOINT,  # subdomain rule
+    'https://openrouter.ai/api/v1/chat/completions',
+    'https://integrate.api.nvidia.com/v1/chat/completions',
+])
+def test_known_provider_hosts_are_allowed(endpoint):
+    assert EndpointValidator.validate(endpoint) == (True, None)
+
+
+def test_unknown_public_host_is_rejected():
+    ok, message = EndpointValidator.validate('https://evil.example.com/v1/chat/completions')
+    assert ok is False
+    assert 'evil.example.com' in message
+    assert 'LLM_ENDPOINT_ALLOWLIST' in message
+
+
+def test_non_http_scheme_is_rejected():
+    ok, message = EndpointValidator.validate('ftp://api.openai.com/x')
+    assert ok is False
+    assert 'http or https' in message
+
+
+def test_embedded_credentials_are_rejected():
+    ok, message = EndpointValidator.validate('https://user:pw@api.openai.com/v1')
+    assert ok is False
+    assert 'credentials' in message
+
+
+def test_env_allowlist_extends_accepted_hosts(monkeypatch):
+    """The allowlist is read at call time so reload_config() is honoured."""
+    rejected, _ = EndpointValidator.validate('https://llm.internal.example/v1')
+    assert rejected is False
+
+    monkeypatch.setattr(_config, 'LLM_ENDPOINT_ALLOWLIST', ('llm.internal.example',))
+    assert EndpointValidator.validate('https://llm.internal.example/v1') == (True, None)
+    # Subdomains of an allowlisted host are covered too.
+    assert EndpointValidator.validate('https://eu.llm.internal.example/v1') == (True, None)
+
+
+def test_configured_server_default_is_always_allowed(monkeypatch):
+    monkeypatch.setattr(_config, 'OPENAI_API_ENDPOINT', 'https://gateway.example.org/v1/chat/completions')
+    assert EndpointValidator.validate('https://gateway.example.org/v1/chat/completions') == (True, None)
+
+
+# ---------------------------------------------------------------------------
+# resolve_api_key(allow_env_fallback=...)
+# ---------------------------------------------------------------------------
+
+def test_env_fallback_can_be_disabled(monkeypatch):
+    monkeypatch.setenv('OPENAI_API_KEY', FAKE_KEY)
+    assert resolve_api_key('__USE_ENV__', 'OPENAI_API_KEY', allow_env_fallback=False) == ''
+    assert resolve_api_key('', 'OPENAI_API_KEY', allow_env_fallback=False) == ''
+
+
+def test_env_fallback_is_on_by_default(monkeypatch):
+    monkeypatch.setenv('OPENAI_API_KEY', FAKE_KEY)
+    assert resolve_api_key('__USE_ENV__', 'OPENAI_API_KEY') == FAKE_KEY
+
+
+def test_explicit_key_survives_disabled_fallback(monkeypatch):
+    monkeypatch.setenv('OPENAI_API_KEY', 'env-key')
+    assert resolve_api_key(FAKE_KEY, 'OPENAI_API_KEY', allow_env_fallback=False) == FAKE_KEY
+
+
+# ---------------------------------------------------------------------------
+# POST /api/translate
+# ---------------------------------------------------------------------------
+
+class _RecordingStateManager:
+    """Minimal stand-in that records the config a job was created with."""
+
+    def __init__(self):
+        self.created = []
+
+    def create_translation(self, translation_id, config):
+        self.created.append((translation_id, dict(config)))
+
+
+@pytest.fixture
+def translate_app(tmp_path):
+    """Flask app exposing only the translation blueprint (no auth gate)."""
+    state_manager = _RecordingStateManager()
+    started = []
+
+    app = Flask(__name__)
+    app.register_blueprint(create_translation_blueprint(
+        state_manager,
+        lambda translation_id, config: started.append(translation_id),
+        str(tmp_path),
+    ))
+
+    with app.test_client() as client:
+        yield client, state_manager, started
+
+
+def _payload(**overrides):
+    body = {
+        'text': 'Hello world.',
+        'source_language': 'English',
+        'target_language': 'French',
+        'model': 'gpt-4o',
+        'llm_api_endpoint': OPENAI_DEFAULT_ENDPOINT,
+        'output_filename': 'out.txt',
+    }
+    body.update(overrides)
+    return body
+
+
+@pytest.fixture(autouse=True)
+def deterministic_openai_endpoint(monkeypatch):
+    """Pin the OpenAI default so 'override' is unambiguous regardless of .env."""
+    monkeypatch.setattr(_config, 'OPENAI_API_ENDPOINT', OPENAI_DEFAULT_ENDPOINT)
+
+
+def test_disallowed_endpoint_is_rejected_before_job_creation(translate_app):
+    client, state_manager, started = translate_app
+    resp = client.post('/api/translate', json=_payload(
+        llm_provider='openai',
+        llm_api_endpoint='https://evil.example.com/v1/chat/completions',
+        openai_api_key=FAKE_KEY,
+    ))
+    assert resp.status_code == 400
+    assert resp.get_json()['error'] == 'Endpoint not allowed'
+    assert state_manager.created == []
+    assert started == []
+
+
+def test_endpoint_override_without_own_key_is_rejected(translate_app, monkeypatch):
+    client, state_manager, _started = translate_app
+    monkeypatch.setenv('OPENAI_API_KEY', 'env-only-key')
+    resp = client.post('/api/translate', json=_payload(
+        llm_provider='openai',
+        llm_api_endpoint=OPENAI_ALT_ENDPOINT,
+        openai_api_key='__USE_ENV__',
+    ))
+    assert resp.status_code == 400
+    # The allowlist accepted the host; it is the pairing rule that refused.
+    assert resp.get_json()['error'] == 'Endpoint override requires its own API key'
+    assert state_manager.created == []
+
+
+def test_endpoint_override_with_own_key_is_accepted(translate_app, monkeypatch):
+    client, state_manager, _started = translate_app
+    monkeypatch.setenv('OPENAI_API_KEY', 'env-only-key')
+    resp = client.post('/api/translate', json=_payload(
+        llm_provider='openai',
+        llm_api_endpoint=OPENAI_ALT_ENDPOINT,
+        openai_api_key=FAKE_KEY,
+    ))
+    assert resp.status_code == 200
+    assert len(state_manager.created) == 1
+    _translation_id, config = state_manager.created[0]
+    assert config['openai_api_key'] == FAKE_KEY
+
+
+def test_gemini_endpoint_field_is_inert(translate_app, monkeypatch):
+    """Gemini ignores llm_api_endpoint, so the pairing guard must not fire."""
+    client, state_manager, _started = translate_app
+    monkeypatch.setenv('GEMINI_API_KEY', 'env-gemini-key')
+    resp = client.post('/api/translate', json=_payload(
+        llm_provider='gemini',
+        model='gemini-2.0-flash',
+        llm_api_endpoint=OPENAI_ALT_ENDPOINT,
+        gemini_api_key='__USE_ENV__',
+    ))
+    assert resp.status_code == 200
+    assert len(state_manager.created) == 1
+
+
+def test_default_ollama_endpoint_needs_no_key(translate_app):
+    """The common local path must not regress."""
+    client, state_manager, _started = translate_app
+    resp = client.post('/api/translate', json=_payload(
+        llm_provider='ollama',
+        model='qwen3:14b',
+        llm_api_endpoint=_config.API_ENDPOINT,
+    ))
+    assert resp.status_code == 200
+    assert len(state_manager.created) == 1
+
+
+def test_keyless_local_openai_server_is_accepted(translate_app, monkeypatch):
+    """LM Studio / llama.cpp / vLLM run as provider 'openai' with no stored key.
+
+    Nothing can leak, so the pairing rule must not fire.
+    """
+    client, state_manager, _started = translate_app
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+    resp = client.post('/api/translate', json=_payload(
+        llm_provider='openai',
+        model='qwen3-14b',
+        llm_api_endpoint='http://localhost:1234/v1/chat/completions',
+        openai_api_key='__USE_ENV__',
+    ))
+    assert resp.status_code == 200
+    _translation_id, config = state_manager.created[0]
+    assert config['openai_api_key'] == ''
+
+
+def test_stored_key_never_reaches_a_local_override(translate_app, monkeypatch):
+    """A private-range host is allowlisted, so the pairing rule is the only
+    thing standing between the .env key and the operator's LAN."""
+    client, state_manager, _started = translate_app
+    monkeypatch.setenv('OPENAI_API_KEY', 'env-only-key')
+    resp = client.post('/api/translate', json=_payload(
+        llm_provider='openai',
+        llm_api_endpoint='http://192.168.1.50:1234/v1/chat/completions',
+        openai_api_key='__USE_ENV__',
+    ))
+    assert resp.status_code == 400
+    assert resp.get_json()['error'] == 'Endpoint override requires its own API key'
+    assert state_manager.created == []
+
+
+def test_custom_ollama_endpoint_needs_no_key(translate_app):
+    """Ollama has no stored credential to leak, so an override is fine."""
+    client, state_manager, _started = translate_app
+    resp = client.post('/api/translate', json=_payload(
+        llm_provider='ollama',
+        model='qwen3:14b',
+        llm_api_endpoint='http://192.168.1.50:11434/api/generate',
+    ))
+    assert resp.status_code == 200
+    assert len(state_manager.created) == 1

--- a/tests/unit/test_plain_text_checkpoint.py
+++ b/tests/unit/test_plain_text_checkpoint.py
@@ -1,0 +1,622 @@
+"""
+Segment-level checkpoint and resume for Plain Text Mode (backlog item 2.4).
+
+Before this, a rate-limit pause or an interruption during Plain Text Mode threw
+away every segment already translated: the pipeline reassembled a partial result
+and the adapters dropped it on the floor. These tests pin the replacement
+behaviour:
+
+- the pipeline hands a contiguous, gap-free prefix to a checkpoint hook;
+- rate limit and interruption both persist that prefix before giving up;
+- a resume replays the stored segmentation and never retries a stored segment;
+- a checkpoint that does not match the source is discarded, not trusted;
+- a failing checkpoint backend degrades persistence, never the translation;
+- the EPUB adapter round-trips the whole thing through a real CheckpointManager.
+"""
+import asyncio
+
+import pytest
+from lxml import etree
+
+import src.core.common.plain_text_pipeline as plain_pipeline
+from src.core.llm.exceptions import RateLimitError
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+MAX_TOKENS = 20
+
+# Each paragraph is big enough that the token chunker gives it its own segment,
+# so segment index == paragraph index and the assertions stay readable.
+PARAGRAPHS = [
+    f"Paragraph number {i} with enough words to be its own chunk."
+    for i in range(12)
+]
+
+
+def _fake_llm(seen, fail_at=None):
+    """Fake generate_translation_request recording every main_content it gets.
+
+    `fail_at` is a 0-based call ordinal that raises RateLimitError instead of
+    translating (sequential mode only, where call order == segment order).
+    """
+    async def fake_request(*, main_content, **kwargs):
+        await asyncio.sleep(0)
+        ordinal = len(seen)
+        seen.append(main_content)
+        if fail_at is not None and ordinal == fail_at:
+            raise RateLimitError("429 Too Many Requests", retry_after=1, provider="test")
+        return f"T::{main_content}"
+    return fake_request
+
+
+class _HookRecorder:
+    """Records every checkpoint_hook invocation; optionally always fails."""
+
+    def __init__(self, fail=False):
+        self.calls = []
+        self.fail = fail
+
+    def __call__(self, segments, prefix, next_index, stats_dict):
+        self.calls.append({
+            'segments': segments,
+            'prefix': list(prefix),
+            'next_index': next_index,
+            'stats': stats_dict,
+        })
+        if self.fail:
+            raise RuntimeError("checkpoint backend unavailable")
+
+    @property
+    def indices(self):
+        return [c['next_index'] for c in self.calls]
+
+    @property
+    def last(self):
+        return self.calls[-1]
+
+
+@pytest.fixture
+def patched_llm(monkeypatch):
+    """Install the fake LLM + identity post-processing, return the seen list."""
+    seen = []
+
+    def install(fail_at=None):
+        monkeypatch.setattr(
+            plain_pipeline, "generate_translation_request", _fake_llm(seen, fail_at)
+        )
+        monkeypatch.setattr(plain_pipeline, "clean_translated_text", lambda s: s)
+        return seen
+
+    return install
+
+
+async def _translate(**overrides):
+    kwargs = dict(
+        paragraphs=PARAGRAPHS,
+        source_language="English",
+        target_language="French",
+        model_name="m",
+        llm_client=object(),
+        max_tokens_per_chunk=MAX_TOKENS,
+        parallel_workers=1,
+    )
+    kwargs.update(overrides)
+    return await plain_pipeline.translate_paragraphs_plain(**kwargs)
+
+
+def _segment_count():
+    return len(plain_pipeline.build_plain_segments(PARAGRAPHS, MAX_TOKENS))
+
+
+# ---------------------------------------------------------------------------
+# 1. Hook contract, happy path
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_hook_receives_contiguous_increasing_prefixes(patched_llm):
+    patched_llm()
+    hook = _HookRecorder()
+    total = _segment_count()
+    assert total >= 6, "the fixture must produce enough segments to be interesting"
+
+    out, stats, interrupted = await _translate(checkpoint_hook=hook, checkpoint_every=2)
+
+    assert not interrupted
+    assert out == [f"T::{p}" for p in PARAGRAPHS]
+    assert hook.calls, "the hook was never called"
+    # Strictly increasing resume points.
+    assert hook.indices == sorted(set(hook.indices))
+    for call in hook.calls:
+        assert len(call['prefix']) == call['next_index']
+        assert all(part is not None for part in call['prefix'])
+    assert hook.last['next_index'] == total
+
+
+# ---------------------------------------------------------------------------
+# 2. Rate limit persists the prefix
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_rate_limit_persists_prefix_and_propagates(patched_llm):
+    seen = patched_llm(fail_at=3)
+    hook = _HookRecorder()
+
+    with pytest.raises(RateLimitError) as excinfo:
+        await _translate(checkpoint_hook=hook)
+
+    assert hook.last['next_index'] == 3
+    assert hook.last['prefix'] == [f"T::{p}" for p in PARAGRAPHS[:3]]
+    # The reassembled partial travels with the exception (P4a attribute).
+    assert excinfo.value.partial_result is not None
+    assert excinfo.value.partial_result[:3] == [f"T::{p}" for p in PARAGRAPHS[:3]]
+    # Segment 3 was attempted (and failed); nothing past it was translated.
+    assert seen == PARAGRAPHS[:4]
+
+
+# ---------------------------------------------------------------------------
+# 3. Interruption persists the prefix
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_interruption_persists_prefix(patched_llm):
+    seen = patched_llm()
+    hook = _HookRecorder()
+
+    out, stats, interrupted = await _translate(
+        checkpoint_hook=hook,
+        check_interruption_callback=lambda: len(seen) >= 2,
+    )
+
+    assert interrupted is True
+    assert hook.last['next_index'] == 2
+    assert hook.last['prefix'] == [f"T::{p}" for p in PARAGRAPHS[:2]]
+    # The untranslated tail keeps its source text.
+    assert out[2] == PARAGRAPHS[2]
+
+
+# ---------------------------------------------------------------------------
+# 4. Resume skips completed segments
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_resume_skips_completed_segments(patched_llm):
+    # Run 1: rate-limited after three segments.
+    patched_llm(fail_at=3)
+    hook = _HookRecorder()
+    with pytest.raises(RateLimitError):
+        await _translate(checkpoint_hook=hook)
+
+    segments = hook.last['segments']
+    prefix = hook.last['prefix']
+    assert len(prefix) == 3
+
+    # Run 2: resume from the checkpoint with a fresh, always-succeeding LLM.
+    seen = patched_llm()
+    seen.clear()
+
+    out, stats, interrupted = await _translate(
+        resume_segments=segments,
+        resume_translated=prefix,
+    )
+
+    assert not interrupted
+    assert len(seen) == len(segments) - 3
+    # None of the restored segments was sent to the LLM again.
+    for done in segments[:3]:
+        assert done['text'] not in seen
+    # The restored translations are present in the final output...
+    assert out[:3] == prefix
+    # ...and the remainder was translated in this run.
+    assert out[3:] == [f"T::{p}" for p in PARAGRAPHS[3:]]
+    # Progress accounts for the restored work, not just this run's segments.
+    assert stats.processed_chunks == len(segments)
+
+
+# ---------------------------------------------------------------------------
+# 5. Mismatched resume is discarded
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_mismatched_resume_is_discarded(patched_llm):
+    seen = patched_llm()
+    logs = []
+    total = _segment_count()
+
+    segments = plain_pipeline.build_plain_segments(PARAGRAPHS, MAX_TOKENS)
+    out, stats, interrupted = await _translate(
+        resume_segments=segments[:2],
+        resume_translated=["stale a", "stale b", "stale c"],
+        log_callback=lambda key, msg: logs.append((key, msg)),
+    )
+
+    assert not interrupted
+    assert len(seen) == total
+    assert out == [f"T::{p}" for p in PARAGRAPHS]
+    assert any(key == "plain_text_resume_discarded" for key, _ in logs)
+
+
+@pytest.mark.asyncio
+async def test_no_resume_does_not_log_a_discard(patched_llm):
+    """A plain run without a checkpoint must not warn about a mismatch."""
+    patched_llm()
+    logs = []
+    await _translate(log_callback=lambda key, msg: logs.append((key, msg)))
+    assert not any(key == "plain_text_resume_discarded" for key, _ in logs)
+
+
+# ---------------------------------------------------------------------------
+# 6. Hook failure is non-fatal
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_failing_hook_does_not_abort_translation(patched_llm):
+    patched_llm()
+    hook = _HookRecorder(fail=True)
+    logs = []
+
+    out, stats, interrupted = await _translate(
+        checkpoint_hook=hook,
+        checkpoint_every=2,
+        log_callback=lambda key, msg: logs.append((key, msg)),
+    )
+
+    assert not interrupted
+    assert out == [f"T::{p}" for p in PARAGRAPHS]
+    assert len(hook.calls) >= 2, "the hook kept being called after it failed"
+    assert any(key == "plain_text_checkpoint_failed" for key, _ in logs)
+
+
+# ---------------------------------------------------------------------------
+# EPUB adapter round-trip (7) and resume rejection (8, 9)
+# ---------------------------------------------------------------------------
+def _epub_doc():
+    body = "".join(f"<p>{p}</p>" for p in PARAGRAPHS)
+    return etree.fromstring(f"<html><body>{body}</body></html>")
+
+
+def _checkpoint_manager(tmp_path):
+    from src.persistence.checkpoint_manager import CheckpointManager
+
+    manager = CheckpointManager(db_path=str(tmp_path / "jobs.db"))
+    manager.uploads_dir = tmp_path / "uploads"
+    manager.uploads_dir.mkdir(parents=True, exist_ok=True)
+    return manager
+
+
+async def _epub_plain_run(**overrides):
+    from src.core.epub.epub_translation_adapter import EpubTranslationAdapter
+
+    kwargs = dict(
+        doc_root=_epub_doc(),
+        source_language="English",
+        target_language="French",
+        model_name="m",
+        llm_client=object(),
+        max_tokens_per_chunk=MAX_TOKENS,
+        log_callback=None,
+        context_manager=None,
+        prompt_options={'plain_text_mode': True},
+        stats_callback=None,
+        check_interruption_callback=None,
+        bilingual_flag=False,
+        file_href="OEBPS/chapter1.xhtml",
+        parallel_workers=1,
+    )
+    kwargs.update(overrides)
+    return await EpubTranslationAdapter()._translate_plain_text(**kwargs)
+
+
+def _spy_on_pipeline(monkeypatch):
+    """Record the kwargs the adapter passes to translate_paragraphs_plain."""
+    recorded = []
+    real = plain_pipeline.translate_paragraphs_plain
+
+    async def spy(**kwargs):
+        recorded.append(kwargs)
+        return await real(**kwargs)
+
+    monkeypatch.setattr(plain_pipeline, "translate_paragraphs_plain", spy)
+    return recorded
+
+
+@pytest.mark.asyncio
+async def test_epub_adapter_checkpoint_roundtrip(patched_llm, tmp_path):
+    """7. Rate limit -> real checkpoint on disk -> resume translates the rest."""
+    manager = _checkpoint_manager(tmp_path)
+    tid, href = "job-plain", "OEBPS/chapter1.xhtml"
+    total = _segment_count()
+
+    seen = patched_llm(fail_at=3)
+    with pytest.raises(RateLimitError):
+        await _epub_plain_run(
+            checkpoint_manager=manager,
+            translation_id=tid,
+            file_href=href,
+        )
+
+    state = manager.load_xhtml_partial_state(tid, href)
+    assert state is not None, "the persisted state failed validate() and was dropped"
+    assert state.doc_metadata['plain_text_mode'] is True
+    assert state.doc_metadata['paragraph_count'] == len(PARAGRAPHS)
+    assert state.current_chunk_index == 3
+    assert len(state.chunks) == total
+    assert len(state.translated_chunks) == 3
+
+    # Resume: only the remainder must reach the LLM.
+    seen = patched_llm()
+    seen.clear()
+    success, stats = await _epub_plain_run(
+        checkpoint_manager=manager,
+        translation_id=tid,
+        file_href=href,
+        resume_state=state,
+    )
+
+    assert success is True
+    assert len(seen) == total - 3
+    reloaded = manager.load_xhtml_partial_state(tid, href)
+    assert reloaded is not None and reloaded.current_chunk_index == total
+
+
+@pytest.mark.asyncio
+async def test_epub_adapter_rejects_placeholder_mode_state(patched_llm, monkeypatch, tmp_path):
+    """8. A state without the plain_text_mode marker must not be replayed."""
+    from src.core.epub.xhtml_translation_state import XHTMLTranslationState
+
+    seen = patched_llm()
+    recorded = _spy_on_pipeline(monkeypatch)
+    logs = []
+
+    placeholder_state = XHTMLTranslationState(
+        file_path="OEBPS/chapter1.xhtml",
+        translation_id="job-plain",
+        file_href="OEBPS/chapter1.xhtml",
+        source_language="English",
+        target_language="French",
+        model_name="m",
+        max_tokens_per_chunk=MAX_TOKENS,
+        max_retries=1,
+        chunks=[{'text': "[id0]x[id1]", 'local_tag_map': {}, 'global_indices': []}],
+        global_tag_map={},
+        placeholder_format=("[id", "]"),
+        translated_chunks=["already"],
+        current_chunk_index=1,
+        original_body_html="",
+        doc_metadata={'namespaces': {}},
+        stats={},
+        created_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:00:00Z",
+    )
+
+    success, stats = await _epub_plain_run(
+        resume_state=placeholder_state,
+        log_callback=lambda key, msg: logs.append((key, msg)),
+    )
+
+    assert success is True
+    assert recorded[0]['resume_segments'] is None
+    assert recorded[0]['resume_translated'] is None
+    assert len(seen) == _segment_count()
+    assert any(key == "plain_text_resume_ignored" for key, _ in logs)
+
+
+@pytest.mark.asyncio
+async def test_epub_adapter_rejects_paragraph_count_mismatch(patched_llm, monkeypatch, tmp_path):
+    """9. A plain-text state built for a different source must be ignored."""
+    from src.core.epub.xhtml_translation_state import XHTMLTranslationState
+
+    seen = patched_llm()
+    recorded = _spy_on_pipeline(monkeypatch)
+    logs = []
+
+    segments = plain_pipeline.build_plain_segments(PARAGRAPHS, MAX_TOKENS)
+    stale_state = XHTMLTranslationState(
+        file_path="OEBPS/chapter1.xhtml",
+        translation_id="job-plain",
+        file_href="OEBPS/chapter1.xhtml",
+        source_language="English",
+        target_language="French",
+        model_name="m",
+        max_tokens_per_chunk=MAX_TOKENS,
+        max_retries=1,
+        chunks=segments,
+        global_tag_map={},
+        placeholder_format=("", ""),
+        translated_chunks=["restored 0", "restored 1"],
+        current_chunk_index=2,
+        original_body_html="",
+        doc_metadata={
+            'plain_text_mode': True,
+            'paragraph_count': len(PARAGRAPHS) + 1,  # source changed under us
+        },
+        stats={},
+        created_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:00:00Z",
+    )
+
+    success, stats = await _epub_plain_run(
+        resume_state=stale_state,
+        log_callback=lambda key, msg: logs.append((key, msg)),
+    )
+
+    assert success is True
+    assert recorded[0]['resume_segments'] is None
+    assert len(seen) == _segment_count()
+    assert any(key == "plain_text_resume_ignored" for key, _ in logs)
+
+
+# ---------------------------------------------------------------------------
+# DOCX adapter: same checkpoint, plus the explicit completion delete
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_docx_adapter_checkpoints_then_deletes_on_success(patched_llm, tmp_path):
+    """DOCX has no post-save seam like EPUB, so it must clean up itself."""
+    from docx import Document
+
+    from src.core.docx.docx_translation_adapter import DocxTranslationAdapter
+
+    doc = Document()
+    for paragraph in PARAGRAPHS:
+        doc.add_paragraph(paragraph)
+    source_path = str(tmp_path / "sample.docx")
+    doc.save(source_path)
+
+    manager = _checkpoint_manager(tmp_path)
+    tid, href = "job-docx-plain", "sample.docx"
+
+    async def run(**overrides):
+        kwargs = dict(
+            source_path=source_path,
+            source_language="English",
+            target_language="French",
+            model_name="m",
+            llm_client=object(),
+            max_tokens_per_chunk=MAX_TOKENS,
+            log_callback=None,
+            context_manager=None,
+            prompt_options={'plain_text_mode': True},
+            stats_callback=None,
+            check_interruption_callback=None,
+            parallel_workers=1,
+            file_href=href,
+            checkpoint_manager=manager,
+            translation_id=tid,
+        )
+        kwargs.update(overrides)
+        return await DocxTranslationAdapter()._translate_plain_text(**kwargs)
+
+    # A rate limit leaves a resumable checkpoint behind.
+    patched_llm(fail_at=3)
+    with pytest.raises(RateLimitError):
+        await run()
+
+    state = manager.load_xhtml_partial_state(tid, href)
+    assert state is not None
+    assert state.doc_metadata['plain_text_mode'] is True
+    assert state.current_chunk_index == 3
+
+    # Resuming to completion translates only the tail and clears the state.
+    seen = patched_llm()
+    seen.clear()
+    docx_bytes, stats = await run(resume_state=state)
+
+    assert docx_bytes
+    assert len(seen) == len(state.chunks) - 3
+    assert manager.load_xhtml_partial_state(tid, href) is None
+
+
+# ---------------------------------------------------------------------------
+# The mirror guard: a plain-text state must never reach a placeholder pipeline
+# ---------------------------------------------------------------------------
+def _plain_state(**overrides):
+    """Build a Plain Text Mode partial state, as the hook would persist it."""
+    from src.core.epub.xhtml_translation_state import XHTMLTranslationState
+
+    segments = plain_pipeline.build_plain_segments(PARAGRAPHS, MAX_TOKENS)
+    fields = dict(
+        file_path="OEBPS/chapter1.xhtml",
+        translation_id="job-plain",
+        file_href="OEBPS/chapter1.xhtml",
+        source_language="English",
+        target_language="French",
+        model_name="m",
+        max_tokens_per_chunk=MAX_TOKENS,
+        max_retries=1,
+        chunks=segments,
+        global_tag_map={},
+        placeholder_format=("", ""),
+        translated_chunks=["restored 0", "restored 1"],
+        current_chunk_index=2,
+        original_body_html="",
+        doc_metadata={'plain_text_mode': True, 'paragraph_count': len(PARAGRAPHS)},
+        stats={},
+        created_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:00:00Z",
+    )
+    fields.update(overrides)
+    return XHTMLTranslationState(**fields)
+
+
+class TestPlainStateIsRejectedByPlaceholderPipelines:
+    """
+    Plain Text Mode now writes an XHTMLTranslationState where it previously
+    wrote none. Pausing a plain-text job and resuming it with Plain Text Mode
+    switched off would otherwise hand that state to the placeholder pipeline,
+    which would replay the prefix under an empty placeholder scheme.
+    """
+
+    def test_predicate_identifies_each_state_kind(self):
+        from src.core.common.plain_text_checkpoint import is_plain_text_state
+
+        assert is_plain_text_state(_plain_state()) is True
+        assert is_plain_text_state(None) is False
+        assert is_plain_text_state(object()) is False
+        assert is_plain_text_state(_plain_state(doc_metadata={})) is False
+        assert is_plain_text_state(
+            _plain_state(doc_metadata={'plain_text_mode': False})
+        ) is False
+
+    @pytest.mark.asyncio
+    async def test_xhtml_translator_ignores_a_plain_state(self, monkeypatch):
+        """The EPUB placeholder path restarts the file instead of replaying it."""
+        import src.core.epub.xhtml_translator as xhtml_translator
+
+        captured = {}
+
+        async def _fake_chunk_loop(*args, **kwargs):
+            captured['start_index'] = kwargs.get('start_chunk_index')
+            raise _StopTranslation()
+
+        monkeypatch.setattr(
+            xhtml_translator,
+            "_translate_all_chunks_with_checkpoint",
+            _fake_chunk_loop,
+        )
+
+        logs = []
+        with pytest.raises(_StopTranslation):
+            await xhtml_translator.translate_xhtml_simplified(
+                doc_root=_epub_doc(),
+                source_language="English",
+                target_language="French",
+                model_name="m",
+                llm_client=object(),
+                max_tokens_per_chunk=MAX_TOKENS,
+                log_callback=lambda key, msg: logs.append((key, msg)),
+                resume_state=_plain_state(),
+            )
+
+        assert any(key == "xhtml_resume_ignored" for key, _ in logs)
+        assert not any(key == "xhtml_resume_partial" for key, _ in logs)
+        # Restarted from the top rather than from the plain state's index 2.
+        assert captured['start_index'] == 0
+
+
+class _StopTranslation(Exception):
+    """Sentinel used to stop a pipeline once the assertion point is reached."""
+
+
+    @pytest.mark.asyncio
+    async def test_docx_adapter_ignores_a_plain_state(self, monkeypatch):
+        """The DOCX placeholder path re-extracts instead of replaying."""
+        from src.core.docx.docx_translation_adapter import DocxTranslationAdapter
+
+        def _fake_extract(self, source_path, log_callback=None):
+            raise _StopTranslation()
+
+        monkeypatch.setattr(
+            DocxTranslationAdapter, "extract_content", _fake_extract
+        )
+
+        logs = []
+        with pytest.raises(_StopTranslation):
+            await DocxTranslationAdapter().translate_content(
+                raw_content="unused.docx",
+                source_language="English",
+                target_language="French",
+                model_name="m",
+                llm_client=object(),
+                max_tokens_per_chunk=MAX_TOKENS,
+                log_callback=lambda key, msg: logs.append((key, msg)),
+                prompt_options={},
+                resume_state=_plain_state(),
+            )
+
+        assert any(key == "docx_resume_ignored" for key, _ in logs)
+        assert not any(key == "docx_resume_partial" for key, _ in logs)

--- a/tests/unit/test_rate_limit_partial_refine.py
+++ b/tests/unit/test_rate_limit_partial_refine.py
@@ -1,0 +1,295 @@
+"""A rate limit during a refine pass must keep the work already done.
+
+Before this change, `refine_chunks` re-raised `RateLimitError` bare and the
+list of chunks it had already refined was dropped on the floor: resuming after
+the pause re-refined everything from scratch. The refined parts now ride on
+`RateLimitError.partial_result`, and `refine_txt_file` writes them to disk
+before letting the error propagate to the pause / auto-resume logic.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from src.core.chunking.reassembly import join_translated_chunks
+from src.core.llm.exceptions import RateLimitError
+from src.core.text_processor import split_text_into_chunks
+
+
+# Three ~11-token paragraphs; max_tokens=25 splits them into exactly two chunks.
+PARAGRAPHS = [
+    "First paragraph with a reasonable amount of content in it.",
+    "Second paragraph with a reasonable amount of content in it.",
+    "Third paragraph with a reasonable amount of content in it.",
+]
+MULTI_PARAGRAPH_TEXT = "\n\n".join(PARAGRAPHS)
+CHUNK_CONFIG = {"max_tokens_per_chunk": 25, "soft_limit_ratio": 0.5}
+
+
+_ZERO_WIDTH = re.compile('[\u200b\u200c\u200d\u2060\ufeff]')
+
+
+def _refined(draft: str) -> str:
+    """The refinement the fake LLM applies to a draft chunk."""
+    return draft.upper()
+
+
+def _visible(text: str) -> str:
+    """Drop the invisible characters normalization adds to the written file."""
+    return _ZERO_WIDTH.sub("", text)
+
+
+class _StubLLMClient:
+    """Stands in for a provider client: refine_chunks only opens and closes it."""
+
+    async def detect_thinking_model(self):
+        return False
+
+    async def close(self):
+        return None
+
+
+class _FakeResponse:
+    prompt_tokens = 10
+    completion_tokens = 10
+    context_limit = 4096
+
+
+def _install_fakes(monkeypatch, fail_at_index: int):
+    """Patch the translator seams so chunk `fail_at_index` hits a 429.
+
+    Returns the list of drafts handed to the refinement request, in order.
+    """
+    import src.core.translator as translator
+
+    seen = []
+
+    async def fake_request(*args, **kwargs):
+        draft = kwargs["draft_translation"]
+        index = len(seen)
+        seen.append(draft)
+        if index == fail_at_index:
+            raise RateLimitError("429 Too Many Requests", provider="test")
+        return _refined(draft), _FakeResponse()
+
+    monkeypatch.setattr(translator, "_make_refinement_request", fake_request)
+    monkeypatch.setattr(
+        translator, "create_llm_client", lambda *a, **kw: _StubLLMClient()
+    )
+    return seen
+
+
+def _reference_finalization(parts, structured_chunks) -> str:
+    """The finalization sequence exactly as it was before the extraction.
+
+    Frozen oracle for the `_write_refined_output` refactor: join, attribution
+    footer, normalization. Any drift in the helper shows up as a diff here.
+    """
+    from src.config import ATTRIBUTION_ENABLED, GENERATOR_NAME, GENERATOR_SOURCE
+
+    final_text = join_translated_chunks(parts, structured_chunks)
+    if ATTRIBUTION_ENABLED:
+        footer = f"\n\n{'=' * 60}\n"
+        footer += f"Refined with {GENERATOR_NAME}\n"
+        footer += f"{GENERATOR_SOURCE}\n"
+        footer += f"{'=' * 60}\n"
+        final_text += footer
+
+    try:
+        from src.utils.text_encoding import apply_normalization
+        final_text = apply_normalization(final_text)
+    except Exception:
+        pass
+
+    return final_text
+
+
+async def _run_refine_txt_file(tmp_path, log_events=None):
+    from src.core.refine.txt_refiner import refine_txt_file
+
+    input_file = tmp_path / "input.txt"
+    output_file = tmp_path / "output.txt"
+    input_file.write_text(MULTI_PARAGRAPH_TEXT, encoding="utf-8")
+
+    log_callback = None
+    if log_events is not None:
+        log_callback = lambda event, message: log_events.append((event, message))
+
+    result = await refine_txt_file(
+        input_filepath=str(input_file),
+        output_filepath=str(output_file),
+        target_language="English",
+        log_callback=log_callback,
+        **CHUNK_CONFIG,
+    )
+    return result, output_file
+
+
+class TestRateLimitErrorPartialResult:
+    """Criterion 1 — the new attribute is additive and backward compatible."""
+
+    def test_partial_result_defaults_to_none(self):
+        assert RateLimitError("x").partial_result is None
+
+    def test_partial_result_is_carried(self):
+        assert RateLimitError("x", partial_result=[1]).partial_result == [1]
+
+    def test_retry_after_and_provider_stay_positional(self):
+        err = RateLimitError("x", 30, "gemini")
+        assert err.retry_after == 30
+        assert err.provider == "gemini"
+        assert err.partial_result is None
+        assert str(err) == "x"
+
+    def test_all_four_arguments_positional(self):
+        err = RateLimitError("x", 30, "gemini", ["a"])
+        assert (err.retry_after, err.provider, err.partial_result) == (
+            30, "gemini", ["a"]
+        )
+
+
+class TestRefineChunksAttachesPartial:
+    """Criterion 2 — refine_chunks hands the whole list over on a 429."""
+
+    @pytest.mark.asyncio
+    async def test_partial_result_is_complete_and_ordered(self, monkeypatch):
+        from src.core.translator import refine_chunks
+
+        drafts = [f"Draft chunk number {i} with enough words to refine." for i in range(5)]
+        _install_fakes(monkeypatch, fail_at_index=2)
+
+        with pytest.raises(RateLimitError) as excinfo:
+            await refine_chunks(
+                translated_chunks=drafts,
+                original_chunks=[{} for _ in drafts],
+                target_language="English",
+                model_name="test-model",
+                api_endpoint="http://localhost:11434/api/generate",
+            )
+
+        parts = excinfo.value.partial_result
+        assert parts is not None
+        assert len(parts) == len(drafts)
+        assert parts[0] == _refined(drafts[0])
+        assert parts[1] == _refined(drafts[1])
+        # Index 2 is the chunk that hit the limit; 3-4 were never attempted.
+        assert parts[2:] == drafts[2:]
+
+    @pytest.mark.asyncio
+    async def test_partial_result_is_a_copy(self, monkeypatch):
+        """Mutating the returned list must not reach refine_chunks' internals."""
+        from src.core.translator import refine_chunks
+
+        drafts = [f"Draft chunk number {i} with enough words to refine." for i in range(3)]
+        _install_fakes(monkeypatch, fail_at_index=0)
+
+        with pytest.raises(RateLimitError) as excinfo:
+            await refine_chunks(
+                translated_chunks=drafts,
+                original_chunks=[{} for _ in drafts],
+                target_language="English",
+                model_name="test-model",
+                api_endpoint="http://localhost:11434/api/generate",
+            )
+
+        parts = excinfo.value.partial_result
+        assert parts == drafts
+        assert parts is not drafts
+
+
+class TestRefineTxtFilePartialSave:
+    """Criterion 3 — the partial reaches disk and the error still propagates."""
+
+    @pytest.mark.asyncio
+    async def test_partial_output_is_written_and_error_propagates(
+        self, tmp_path, monkeypatch
+    ):
+        structured_chunks = split_text_into_chunks(
+            MULTI_PARAGRAPH_TEXT, **CHUNK_CONFIG
+        )
+        assert len(structured_chunks) == 2, "fixture must produce two chunks"
+        drafts = [c["main_content"] for c in structured_chunks]
+
+        _install_fakes(monkeypatch, fail_at_index=1)
+        log_events = []
+
+        with pytest.raises(RateLimitError):
+            await _run_refine_txt_file(tmp_path, log_events)
+
+        output_file = tmp_path / "output.txt"
+        assert output_file.exists()
+        content = output_file.read_text(encoding="utf-8")
+        assert content.strip()
+        visible = _visible(content)
+        assert _refined(drafts[0]) in visible
+        # The chunk that hit the limit is kept as its unrefined draft.
+        assert drafts[1] in visible
+        assert content == _reference_finalization(
+            [_refined(drafts[0]), drafts[1]], structured_chunks
+        )
+
+        assert any(event == "refine_partial_saved" for event, _ in log_events)
+
+    @pytest.mark.asyncio
+    async def test_no_partial_result_leaves_no_output(self, tmp_path, monkeypatch):
+        """An unusable partial re-raises untouched and writes nothing."""
+        import src.core.refine.txt_refiner as txt_refiner
+
+        async def raise_bare(*args, **kwargs):
+            raise RateLimitError("429", provider="test")
+
+        monkeypatch.setattr(txt_refiner, "refine_chunks", raise_bare)
+
+        with pytest.raises(RateLimitError):
+            await _run_refine_txt_file(tmp_path)
+
+        assert not (tmp_path / "output.txt").exists()
+
+    @pytest.mark.asyncio
+    async def test_mismatched_partial_length_re_raises(self, tmp_path, monkeypatch):
+        """A partial that does not line up with the chunks is not written."""
+        import src.core.refine.txt_refiner as txt_refiner
+
+        async def raise_with_short_partial(*args, **kwargs):
+            raise RateLimitError("429", provider="test", partial_result=["only one"])
+
+        monkeypatch.setattr(txt_refiner, "refine_chunks", raise_with_short_partial)
+
+        with pytest.raises(RateLimitError):
+            await _run_refine_txt_file(tmp_path)
+
+        assert not (tmp_path / "output.txt").exists()
+
+
+class TestRefineTxtFileHappyPathUnchanged:
+    """Criterion 4 — the _write_refined_output extraction is behaviour-neutral."""
+
+    @pytest.mark.asyncio
+    async def test_output_matches_the_pre_change_finalization(
+        self, tmp_path, monkeypatch
+    ):
+        structured_chunks = split_text_into_chunks(
+            MULTI_PARAGRAPH_TEXT, **CHUNK_CONFIG
+        )
+        drafts = [c["main_content"] for c in structured_chunks]
+
+        _install_fakes(monkeypatch, fail_at_index=-1)  # never fails
+        log_events = []
+
+        result, output_file = await _run_refine_txt_file(tmp_path, log_events)
+
+        assert result is True
+        content = output_file.read_text(encoding="utf-8")
+        assert content == _reference_finalization(
+            [_refined(d) for d in drafts], structured_chunks
+        )
+        assert any(event == "refine_save_success" for event, _ in log_events)
+        assert not any(event == "refine_partial_saved" for event, _ in log_events)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_zip_slip.py
+++ b/tests/unit/test_zip_slip.py
@@ -1,0 +1,213 @@
+"""Unit tests for item 2.1: archive path containment (zip slip).
+
+Covers the shared helpers in `src.utils.security`, the EPUB upload validator,
+and the two checkpoint-manager seams that join an attacker-controlled
+`file_href` to a directory on disk.
+"""
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from src.utils.security import (
+    SecureFileHandler,
+    SecurityError,
+    find_unsafe_archive_member,
+    is_safe_archive_member,
+    resolve_within,
+    safe_extract_zip,
+)
+from src.persistence.checkpoint_manager import CheckpointManager
+
+
+CONTAINER_XML = (
+    '<?xml version="1.0"?>'
+    '<container version="1.0" '
+    'xmlns="urn:oasis:names:tc:opendocument:xmlns:container">'
+    '<rootfiles><rootfile full-path="OEBPS/content.opf" '
+    'media-type="application/oebps-package+xml"/></rootfiles>'
+    '</container>'
+)
+
+CLEAN_ENTRIES = {
+    'mimetype': 'application/epub+zip',
+    'META-INF/container.xml': CONTAINER_XML,
+    'OEBPS/chapter1.xhtml': '<html><body><p>Hello</p></body></html>',
+}
+
+
+def _write_epub(path: Path, extra_entries=None) -> Path:
+    """Build a minimal EPUB-shaped zip, optionally with extra entries."""
+    entries = dict(CLEAN_ENTRIES)
+    if extra_entries:
+        entries.update(extra_entries)
+    with zipfile.ZipFile(path, 'w') as zf:
+        for name, content in entries.items():
+            zf.writestr(name, content)
+    return path
+
+
+# === 1. is_safe_archive_member truth table ===================================
+
+UNSAFE_NAMES = [
+    '../../evil.txt',
+    '..\\..\\evil.txt',
+    '/etc/passwd',
+    'C:/evil.txt',
+    'C:\\evil.txt',
+    '//server/share/x',
+    'OEBPS/../../evil.txt',
+    '',
+    'a\x00b',
+]
+
+SAFE_NAMES = [
+    'mimetype',
+    'META-INF/container.xml',
+    'OEBPS/chapter1.xhtml',
+    'OEBPS/',
+    './OEBPS/ch1.xhtml',
+    'OEBPS/im..ages/a.png',
+]
+
+
+@pytest.mark.parametrize('name', UNSAFE_NAMES)
+def test_is_safe_archive_member_rejects(name):
+    assert is_safe_archive_member(name) is False
+
+
+@pytest.mark.parametrize('name', SAFE_NAMES)
+def test_is_safe_archive_member_accepts(name):
+    assert is_safe_archive_member(name) is True
+
+
+def test_find_unsafe_archive_member_returns_first_offender():
+    names = ['mimetype', '../../evil.txt', 'C:/other.txt']
+    assert find_unsafe_archive_member(names) == '../../evil.txt'
+
+
+def test_find_unsafe_archive_member_returns_none_when_clean():
+    assert find_unsafe_archive_member(SAFE_NAMES) is None
+
+
+# === 2. The EPUB upload validator rejects a traversal entry ==================
+
+def test_validate_epub_file_rejects_traversal_entry(tmp_path):
+    epub_path = _write_epub(
+        tmp_path / 'evil.epub',
+        {'../../evil.txt': 'pwned'},
+    )
+    handler = SecureFileHandler(tmp_path / 'uploads')
+
+    result = handler._validate_epub_file(epub_path)
+
+    assert result.is_valid is False
+    assert 'evil.txt' in result.error_message
+
+
+def test_validate_epub_file_accepts_clean_archive(tmp_path):
+    epub_path = _write_epub(tmp_path / 'clean.epub')
+    handler = SecureFileHandler(tmp_path / 'uploads')
+
+    assert handler._validate_epub_file(epub_path).is_valid is True
+
+
+# === 3. safe_extract_zip writes nothing when it rejects ======================
+
+def test_safe_extract_zip_rejects_and_writes_nothing(tmp_path):
+    epub_path = _write_epub(
+        tmp_path / 'evil.epub',
+        {'../../evil.txt': 'pwned'},
+    )
+    dest = tmp_path / 'extract_root' / 'dest'
+    dest.mkdir(parents=True)
+
+    with zipfile.ZipFile(epub_path, 'r') as zf:
+        with pytest.raises(SecurityError):
+            safe_extract_zip(zf, dest)
+
+    assert list(dest.iterdir()) == []
+    assert not (dest.parent / 'evil.txt').exists()
+    assert not any(p.name == 'evil.txt' for p in tmp_path.rglob('*') if p.is_file())
+
+
+# === 4. A clean archive extracts normally ====================================
+
+def test_safe_extract_zip_extracts_clean_archive(tmp_path):
+    epub_path = _write_epub(tmp_path / 'clean.epub')
+    dest = tmp_path / 'dest'
+    dest.mkdir()
+
+    with zipfile.ZipFile(epub_path, 'r') as zf:
+        safe_extract_zip(zf, dest)
+
+    assert (dest / 'mimetype').is_file()
+    assert (dest / 'META-INF' / 'container.xml').is_file()
+    assert (dest / 'OEBPS' / 'chapter1.xhtml').is_file()
+
+
+def test_resolve_within_rejects_escape(tmp_path):
+    with pytest.raises(SecurityError):
+        resolve_within(tmp_path, '../evil.txt')
+
+
+def test_resolve_within_accepts_nested_path(tmp_path):
+    resolved = resolve_within(tmp_path, 'OEBPS/ch1.xhtml')
+    assert resolved == (tmp_path / 'OEBPS' / 'ch1.xhtml').resolve()
+
+
+# === 5 & 6. save_epub_file containment =======================================
+
+@pytest.fixture
+def checkpoint_manager(tmp_path, monkeypatch):
+    """A CheckpointManager rooted entirely inside tmp_path."""
+    monkeypatch.chdir(tmp_path)
+    return CheckpointManager(db_path=str(tmp_path / 'jobs.db'))
+
+
+def test_save_epub_file_refuses_traversal_href(checkpoint_manager, tmp_path):
+    translation_id = 'job-zip-slip'
+
+    assert checkpoint_manager.save_epub_file(
+        translation_id, '../../evil.txt', b'x'
+    ) is False
+
+    uploads_root = checkpoint_manager.uploads_dir
+    assert not any(
+        p.name == 'evil.txt' for p in uploads_root.rglob('*')
+    )
+    assert not any(
+        p.name == 'evil.txt' for p in uploads_root.parent.rglob('*')
+    )
+    assert not any(p.name == 'evil.txt' for p in tmp_path.rglob('*'))
+
+
+def test_save_epub_file_writes_nested_path(checkpoint_manager):
+    translation_id = 'job-nested'
+
+    assert checkpoint_manager.save_epub_file(
+        translation_id, 'OEBPS/ch1.xhtml', b'x'
+    ) is True
+
+    written = (
+        checkpoint_manager.uploads_dir
+        / translation_id
+        / 'translated_files'
+        / 'OEBPS'
+        / 'ch1.xhtml'
+    )
+    assert written.is_file()
+    assert written.read_bytes() == b'x'
+
+
+def test_restore_epub_files_copies_nested_path(checkpoint_manager, tmp_path):
+    translation_id = 'job-restore'
+    assert checkpoint_manager.save_epub_file(
+        translation_id, 'OEBPS/ch1.xhtml', b'x'
+    ) is True
+
+    work_dir = tmp_path / 'work'
+    work_dir.mkdir()
+
+    assert checkpoint_manager.restore_epub_files(translation_id, work_dir) is True
+    assert (work_dir / 'OEBPS' / 'ch1.xhtml').read_bytes() == b'x'


### PR DESCRIPTION
Implements Sprint 2 of `docs/BACKLOG.md`: two exploitable primitives closed, three silent data-loss paths stopped.

One commit per item, in dependency order. `Closes` is on four of the five issues; #228 is referenced rather than closed because half of it is a product question left open below.

| Commit | Item | Issue |
|---|---|---|
| `bf9d843` | Archive path containment | Closes #215 |
| `5d9e4ea` | Endpoint allowlist + key pairing | Closes #211 |
| `7754d1f` | DOCX rebuild fidelity | Closes #206 |
| `ae3a81b` | Refine keeps its partial output | Refs #228 |
| `a5370e1` | Foreign keys + orphan purge | Closes #216 |
| `98d48e2` | Plain Text Mode checkpoint/resume | Refs #228 |
| `8b0acb8` | e2e provider made configurable | — |

## Scope decisions worth knowing

**#215 covers four extraction sites, not one.** The report names the resume path. The identical unguarded `extractall` is also on the *normal* translation path, reached by every EPUB job. Fixing only the resume site would have left the vulnerability open.

**#211 covers three request seams, not one.** `start_translation_request` is the one reported; the OpenAI/Ollama model listings and the glossary NER endpoint have the same shape — client-chosen endpoint, server-stored key.

**Private ranges stay allowed.** Self-hosted Ollama and LM Studio are the primary use case, so loopback and LAN addresses are accepted and this validator permits SSRF against the operator's own network. That is only acceptable because of the second guard: no server-stored credential ever travels with a request-chosen host.

**The key-pairing rule fires only when a stored key exists.** The literal rule would have rejected every keyless local OpenAI-compatible server (LM Studio, llama.cpp, vLLM), which are documented in `docs/PROVIDERS.md`. If there is no stored key, there is nothing to leak.

**#228 was split.** The refine half is small. The plain-text half turned out to be large: Plain Text Mode had *no* segment-level persistence at all, so the report's "mirror the interruption path" was not implementable — the interruption path loses the same work. The persistence had to be built, which fixes both.

## Two bugs found while implementing, fixed here

**CLI EPUB/DOCX never created its job row.** Enabling `PRAGMA foreign_keys` surfaced it: the legacy pipelines save chunks but never call `start_job`. The web path was safe because the API handler creates the row first. Every CLI EPUB translation had been writing orphaned chunk rows — exactly what the new purge reclaims — and CLI resume was consequently already non-functional. Fixed in `translate_file` rather than by disabling the pragma.

**A plain-text checkpoint could reach the placeholder pipeline.** Plain Text Mode now writes an `XHTMLTranslationState` where it previously wrote none, so pausing a plain-text job and resuming it with Plain Text Mode switched off would replay the prefix under an empty placeholder scheme. `is_plain_text_state` is now the single predicate enforcing separation in both directions.

## Testing

| Level | Result |
|---|---|
| `pytest` (default selection) | **1422 passed**, 1 skipped, 3 failed |
| `pytest tests/e2e -m e2e` (Gemini) | **13 passed** — real server, real Chromium, real translations |
| `pytest -m integration` | **not run** — requires a live Ollama, unavailable on the dev machine |

The 3 failures are `characterization/test_progress_baseline.py::*[docx]` and are **pre-existing**: stashing every tracked change on this branch and re-running against `main`'s code reproduces exactly the same three. See the caveat below.

The e2e suite was also run against Poe (`Claude-Sonnet-4`), where 9 of 13 fail. That is a model limitation, not a regression: the server log reports 51 × `Placeholder validation failed — using fallback` and its own `HIGH PLACEHOLDER FAILURE RATE` warning. Jobs are then correctly classified `partial`, and tests asserting `completed` fail. Worth knowing before recommending Poe for EPUB/DOCX.

Incidentally, that run exercised #211 end to end: `POST /api/translate` with `llm_api_endpoint: https://api.poe.com/v1/chat/completions` and `poe_api_key: __USE_ENV__` passed the new guards with no 400, confirming the allowlist does not reject legitimate traffic from a provider that ignores the request endpoint.

## Open question for review

**Should Plain Text Mode report restored segments in cross-file progress?** The checkpoint hook writes `stats` but leaves `global_stats` as `None`, so a resumed plain-text EPUB under-reports cross-file progress exactly as it does today. Within-file progress is correct. Setting `global_stats` would also start pushing plain-text progress into `db.update_job_progress` via `save_xhtml_partial_state` — a behaviour change worth deciding deliberately rather than acquiring as a side effect. Left unchanged here.

## Follow-ups, not in this PR

- `docs/TROUBLESHOOTING.md` should gain a short section on the new 400s from #211. A user who typed a custom endpoint and left the key field empty will now be rejected — intended, but a visible behaviour change worth a release note.
- Surfacing that rejection clearly in the frontend rather than as a generic 400 toast. Any new user-facing string must land in all seven locales.
- `characterization` goldens depend on the local `.env`: with `MAX_TOKENS_PER_CHUNK=200` the chunk counts diverge from the recorded values and the failing set shifts with configuration. They should pin their chunking config.
- `tests/integration` is hardwired to Ollama and fails rather than skipping when it is absent; the e2e suite skips cleanly and is the better model.
- `srt_refiner.py` has no `RateLimitError` handling, so an SRT refine pass still discards its work on a 429 — the same loss `ae3a81b` just fixed for TXT.
- `EpubAdapter.prepare_for_translation` wraps everything in `except Exception: return False`, which turns the new `SecurityError` into a silent preparation failure. Containment holds; only the error message is lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
