### PR TITLE
Fix: resume fails with "Could not create LLM client"

### DIFF
--- a/src/api/blueprints/translation_routes.py
+++ b/src/api/blueprints/translation_routes.py
@@ -167,12 +167,15 @@ def _validate_provider_credentials(config):
         # one for the official API, mirroring the factory's heuristic.
         key_required = (provider != 'openai'
                         or 'api.openai.com' in (config.get('llm_api_endpoint') or ''))
-        if key_required and not (config.get(f"{provider}_api_key") or os.getenv(env_var)):
-            return jsonify({
-                "error": "Missing API key for provider",
-                "message": (f"Resuming with '{provider}' requires an API key. "
-                            f"Set {env_var} in .env or include it in the request."),
-            }), 400
+        if key_required:
+            resolved = config.get(f"{provider}_api_key") or os.getenv(env_var)
+            if not resolved:
+                return jsonify({
+                    "error": "Missing API key for provider",
+                    "message": (f"Resuming with '{provider}' requires an API key. "
+                                f"Set {env_var} in .env or include it in the request."),
+                }), 400
+            config[f"{provider}_api_key"] = resolved
 
     if provider in _ENDPOINT_PROVIDERS and not config.get('llm_api_endpoint'):
         return jsonify({


### PR DESCRIPTION
## Bug

Resuming a translation from a checkpoint fails with: `ERROR: Could not create LLM client`

## Root cause

Checkpoints intentionally no longer persist API keys (issue #213) — they're meant to be re-resolved at resume time from `.env` or from the resume request body.

`_validate_provider_credentials()` (in `src/api/blueprints/translation_routes.py`) checks whether a key is available via `os.getenv(env_var)` as a fallback, but only *validates* its presence — it never writes the resolved value back into `config`. So after validation passes, `config[f"{provider}_api_key"]` is still empty.

Downstream, the EPUB pipeline's `create_llm_client()` (`src/core/llm_client.py`) has no `os.getenv` fallback of its own (unlike `src/core/llm/factory.py`), so it receives an empty key and returns `None`, which triggers the "Could not create LLM client" error.

## Fix

`_validate_provider_credentials()` now resolves the key (request override or `.env`) and writes it back into `config` once validation succeeds, instead of only checking that *some* source of the key exists. This keeps the checkpoint DB free of secrets (issue #213 still holds — nothing is persisted) while making sure the in-memory config passed to the translation job actually carries the key it validated.

Paths where a key was already supplied explicitly (new job creation, resume with an explicit override, key-rotation multi-key strings) are untouched.

## How to reproduce (before the fix)

1. Start a translation with a cloud provider (e.g. Gemini) with start.bat.
2. Interrupt the job so a checkpoint is saved.
3. In the web UI, click the "Resume" button on the paused job.
4. Translation fails with "Could not create LLM client" even though `GEMINI_API_KEY` is set in `.env` or was set via the GUI settings.

## Testing

- Manually reproduced the bug and confirmed the fix resolves it.
- `tests/unit/test_checkpoint_secrets.py` still passes (covers the
  related resume-credential-validation behavior from issue #213).