### PR TITLE
Fix: refresh auto_pause_on_rate_limit from live setting on resume

### DIFF
--- a/src/api/blueprints/translation_routes.py
+++ b/src/api/blueprints/translation_routes.py
@@ -195,10 +195,31 @@ def _apply_resume_overrides(config, overrides):
     persist API keys (issue #213), so every resume must find its key in .env
     or in the request.
 
+    auto_pause_on_rate_limit isn't a secret, but a job's config is otherwise a
+    snapshot taken at creation time, so it has the same staleness problem as
+    the credentials above: without refreshing it here, flipping "Disable
+    Auto-Pause" in Settings after a job started would never take effect on
+    that job's resumes. Refreshed from the live setting on every resume,
+    unless this specific resume overrides it.
+
+    Note: this reads `_config.DISABLE_AUTO_PAUSE` as already refreshed by
+    `/api/settings` (which calls `reload_config()` itself after writing to
+    .env) rather than calling `reload_config()` here. `reload_config()` does
+    `load_dotenv(..., override=True)`, which would clobber any provider API
+    key set via a real environment variable (docker/shell) rather than via
+    the .env file -- not something a routine resume should ever do.
+
     Returns a Flask (response, status) tuple to abort with on validation failure,
     or None on success.
     """
     raw_key = None
+
+    if isinstance(overrides, dict) and overrides.get('auto_pause_on_rate_limit') is not None:
+        config['auto_pause_on_rate_limit'] = bool(overrides['auto_pause_on_rate_limit'])
+    else:
+        config['auto_pause_on_rate_limit'] = not (
+            str(_config.DISABLE_AUTO_PAUSE).strip().lower() == 'true'
+        )
 
     if isinstance(overrides, dict) and overrides:
         if overrides.get('model'):

--- a/tests/unit/test_resume_overrides.py
+++ b/tests/unit/test_resume_overrides.py
@@ -1,12 +1,14 @@
 """Unit tests for the resume model/provider override logic (issue #183).
 
 Covers `_apply_resume_overrides`: backward compatibility (empty body), field
-merging, generic API-key routing through `_resolve_api_key`, and the
-key/endpoint validation guards.
+merging, generic API-key routing through `_resolve_api_key`, the
+key/endpoint validation guards, and refreshing `auto_pause_on_rate_limit`
+from `src.config.DISABLE_AUTO_PAUSE` on every resume.
 """
 import pytest
 from flask import Flask
 
+import src.api.blueprints.translation_routes as translation_routes
 from src.api.blueprints.translation_routes import _apply_resume_overrides
 
 
@@ -26,16 +28,47 @@ def _base_config():
     }
 
 
-def test_empty_overrides_leaves_config_untouched(app_ctx):
+def test_empty_overrides_leaves_model_provider_endpoint_untouched(app_ctx, monkeypatch):
+    """model/provider/endpoint stay a snapshot; only auto_pause is refreshed."""
+    monkeypatch.setattr(translation_routes._config, 'DISABLE_AUTO_PAUSE', 'false')
     config = _base_config()
-    snapshot = dict(config)
+    snapshot = {k: v for k, v in config.items()}
     assert _apply_resume_overrides(config, {}) is None
-    assert config == snapshot
+    for key, value in snapshot.items():
+        assert config[key] == value
 
 
-def test_none_overrides_is_noop(app_ctx):
+def test_none_overrides_is_noop_for_model_provider_endpoint(app_ctx, monkeypatch):
+    monkeypatch.setattr(translation_routes._config, 'DISABLE_AUTO_PAUSE', 'false')
     config = _base_config()
+    snapshot = {k: v for k, v in config.items()}
     assert _apply_resume_overrides(config, None) is None
+    for key, value in snapshot.items():
+        assert config[key] == value
+
+
+def test_auto_pause_refreshed_from_live_setting_when_not_overridden(app_ctx, monkeypatch):
+    """A job created while DISABLE_AUTO_PAUSE=false must pick up a later flip
+    to true (e.g. saved via /api/settings, which already refreshes this
+    module attribute) on resume, even with an empty request body."""
+    config = _base_config()
+    config['auto_pause_on_rate_limit'] = True  # snapshot taken at job creation
+
+    monkeypatch.setattr(translation_routes._config, 'DISABLE_AUTO_PAUSE', 'true')
+    assert _apply_resume_overrides(config, {}) is None
+    assert config['auto_pause_on_rate_limit'] is False
+
+    monkeypatch.setattr(translation_routes._config, 'DISABLE_AUTO_PAUSE', 'false')
+    assert _apply_resume_overrides(config, None) is None
+    assert config['auto_pause_on_rate_limit'] is True
+
+
+def test_auto_pause_explicit_override_wins_over_live_setting(app_ctx, monkeypatch):
+    monkeypatch.setattr(translation_routes._config, 'DISABLE_AUTO_PAUSE', 'false')  # live setting says auto-pause ON
+    config = _base_config()
+    err = _apply_resume_overrides(config, {'auto_pause_on_rate_limit': False})
+    assert err is None
+    assert config['auto_pause_on_rate_limit'] is False
 
 
 def test_simple_model_provider_override(app_ctx, monkeypatch):


### PR DESCRIPTION
## Bug

Flipping "Disable Auto-Pause" in Settings has no effect on an
already-created job: every resume of that job keeps using whatever
the setting was when the job was first started.

## Root cause

A job's config is a snapshot taken at creation time and replayed as-is
on every resume. `_apply_resume_overrides()` (issue #183) already
refreshes `model`/`llm_provider`/`llm_api_endpoint`/API key on resume,
but `auto_pause_on_rate_limit` wasn't in that list — it stays frozen at
whatever value was baked into the checkpoint.

## Fix

`_apply_resume_overrides()` now refreshes `auto_pause_on_rate_limit`
from `src.config.DISABLE_AUTO_PAUSE` on every resume, unless the resume
request explicitly overrides it. `/api/settings` already keeps that
module attribute live (it calls `reload_config()` itself after writing
to `.env`), so no extra reload is needed here.

**Deliberately not calling `reload_config()` in this function**: an
earlier version of this fix did, but `reload_config()` does
`load_dotenv(..., override=True)`, which clobbers any provider API key
set via a real environment variable (docker/shell) instead of `.env`.
Since `_apply_resume_overrides` also handles API-key resolution, that
would have silently broken env-var-only deployments on every resume.
Caught by `test_simple_model_provider_override` and
`test_api_key_use_env_sentinel_resolves_from_env` regressing when that
version was tested locally.

## How to reproduce (before the fix)

1. Start a translation with "Disable Auto-Pause" off (default: auto-pause on).
2. Interrupt the job so a checkpoint is saved.
3. Toggle "Disable Auto-Pause" on in Settings.
4. Resume the job and hit a rate limit — it still pauses instead of
   auto-resuming, because the checkpoint's `auto_pause_on_rate_limit`
   was captured before the toggle.

With the fix, step 4 respects the current setting.

## Testing

- `pytest tests/unit/test_resume_overrides.py -v` — 11 tests, all
  passing (2 updated for the new refresh behavior, 2 new covering the
  refresh and the explicit-override path).
- `pytest tests/unit/test_checkpoint_secrets.py -v` — 14 tests, all
  passing (confirms no regression to issue #213's credential handling).