### PR TITLE
feat(gemini): add configurable thinking level/budget via env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,21 @@ GEMINI_MODEL=gemini-2.0-flash
 # BLOCK_MEDIUM_AND_ABOVE, BLOCK_LOW_AND_ABOVE.
 GEMINI_SAFETY_THRESHOLD=BLOCK_NONE
 
+# Gemini "thinking" (reasoning) controls. Thinking tokens are billed at the
+# output token rate, so for a mechanical task like translation, turning
+# thinking down (or off) can meaningfully cut cost with little to no quality
+# impact. Leave both unset to keep the tool's previous default behavior
+# (thinking off on 2.5 models, model default on 3.x models).
+#
+# For Gemini 3.x models (gemini-3.6-flash, gemini-3.5-flash, gemini-3.5-flash-lite, etc.)
+# Valid values: minimal, low, medium, high. Not every level is supported by
+# every model (e.g. Pro models reject "minimal").
+# GEMINI_THINKING_LEVEL=minimal
+#
+# For Gemini 2.5.x models (gemini-2.5-flash, etc.) — an explicit token budget.
+# 0 disables thinking, -1 enables dynamic thinking, or set a specific count.
+# GEMINI_THINKING_BUDGET=0
+
 # Your OpenAI API key (required if using openai provider)
 OPENAI_API_KEY=
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -155,6 +155,28 @@ python translate.py -i book.txt -o book_fr.txt \
     -m gemini-2.0-flash
 ```
 
+### Thinking / Reasoning Control
+
+Some Gemini models ("thinking" models — Gemini 2.5.x and 3.x) reason before
+answering, and those reasoning tokens are billed at the (higher) *output*
+token rate. For a mechanical task like translation, reasoning rarely
+improves quality but can noticeably inflate the bill. Set one of these in
+your `.env` file:
+
+```bash
+# Gemini 3.x models (gemini-3.6-flash, gemini-3.5-flash, gemini-3.5-flash-lite, ...)
+# Valid values: minimal, low, medium, high
+GEMINI_THINKING_LEVEL=minimal
+
+# Gemini 2.5.x models (gemini-2.5-flash, ...) — explicit token budget
+# 0 disables thinking, -1 enables dynamic thinking
+GEMINI_THINKING_BUDGET=0
+```
+
+Leave both unset to keep the previous default (thinking off on 2.5 models,
+model default on 3.x models). Not every level is supported by every model —
+Pro-tier models, for example, reject `minimal`.
+
 ---
 
 ## Mistral (Cloud)

--- a/src/config.py
+++ b/src/config.py
@@ -300,6 +300,31 @@ TEMPERATURE = float(os.getenv('TEMPERATURE', '0.3'))
 # BLOCK_LOW_AND_ABOVE, HARM_BLOCK_THRESHOLD_UNSPECIFIED.
 GEMINI_SAFETY_THRESHOLD = os.getenv('GEMINI_SAFETY_THRESHOLD', 'BLOCK_NONE')
 
+# Gemini "thinking" (reasoning) controls. Thinking tokens are billed at the
+# (higher) output token rate, so for a mechanical task like translation they
+# mostly just inflate the bill without improving quality.
+#
+# GEMINI_THINKING_LEVEL applies to Gemini 3.x models via the `thinkingLevel`
+# field. Valid values: minimal, low, medium, high. Leave unset to use the
+# model's own default (medium for Flash, minimal for Flash-Lite, high for Pro).
+# Not every level is supported by every model; Pro models reject "minimal".
+GEMINI_THINKING_LEVEL = os.getenv('GEMINI_THINKING_LEVEL', '').strip().lower() or None
+_VALID_GEMINI_THINKING_LEVELS = {"minimal", "low", "medium", "high"}
+if GEMINI_THINKING_LEVEL and GEMINI_THINKING_LEVEL not in _VALID_GEMINI_THINKING_LEVELS:
+    print(
+        f"⚠️  GEMINI_THINKING_LEVEL='{GEMINI_THINKING_LEVEL}' is not recognized. "
+        f"Valid values: {', '.join(sorted(_VALID_GEMINI_THINKING_LEVELS))}. "
+        f"Falling back to the model's default thinking level."
+    )
+    GEMINI_THINKING_LEVEL = None
+
+# GEMINI_THINKING_BUDGET applies to Gemini 2.5.x models via the older
+# `thinkingBudget` field (an explicit token count). 0 disables thinking,
+# -1 enables dynamic thinking (model decides), or set a specific token count.
+# If unset, 2.5 models default to thinkingBudget=0 (thinking off) as before.
+_gemini_thinking_budget_raw = os.getenv('GEMINI_THINKING_BUDGET', '').strip()
+GEMINI_THINKING_BUDGET = int(_gemini_thinking_budget_raw) if _gemini_thinking_budget_raw else None
+
 # Auto-pause on HTTP 429 rate limit
 # When True (default): translation pauses after retries are exhausted; user resumes manually.
 # When False: translation auto-resumes from the last checkpoint after waiting `retry_after`

--- a/src/core/llm/providers/gemini.py
+++ b/src/core/llm/providers/gemini.py
@@ -19,6 +19,8 @@ from src.config import (
     MAX_TRANSLATION_ATTEMPTS,
     TEMPERATURE,
     GEMINI_SAFETY_THRESHOLD,
+    GEMINI_THINKING_LEVEL,
+    GEMINI_THINKING_BUDGET,
 )
 from ..base import LLMProvider, LLMResponse
 from ..exceptions import ContextOverflowError
@@ -77,13 +79,34 @@ class GeminiProvider(LLMProvider):
         self.api_endpoint = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent"
 
     def _is_thinking_model(self) -> bool:
-        """Check if the current model supports thinking mode (Gemini 2.5+)."""
-        return "2.5" in self.model
+        """Check if the current model supports thinking mode (Gemini 2.5+ and 3.x)."""
+        return "2.5" in self.model or "gemini-3" in self.model
 
     def _get_thinking_config(self) -> dict:
-        """Return thinkingConfig to disable thinking for supported models."""
-        if self._is_thinking_model():
-            return {"thinkingConfig": {"thinkingBudget": 0}}
+        """
+        Build the thinkingConfig block for this request, based on the model
+        generation and the GEMINI_THINKING_LEVEL / GEMINI_THINKING_BUDGET env
+        settings.
+
+        Gemini 3.x models use the newer `thinkingLevel` field (minimal/low/
+        medium/high). Gemini 2.5.x models use the older `thinkingBudget`
+        field (a token count; 0 disables thinking, -1 is dynamic).
+
+        Thinking is billed as output tokens, so for mechanical tasks like
+        translation, turning it down (or off, where the model allows it)
+        can meaningfully cut cost with little to no quality impact.
+        """
+        if "gemini-3" in self.model:
+            # default levels: medium for Flash, minimal for Flash-Lite, high for Pro
+            thinking_level = GEMINI_THINKING_LEVEL if GEMINI_THINKING_LEVEL is not None else 'minimal'
+            return {"thinkingConfig": {"thinkingLevel": thinking_level}}
+
+        if "2.5" in self.model:
+            # Preserve the previous hardcoded behavior (thinking off) when
+            # the user hasn't set an explicit budget, for backward compat.
+            budget = GEMINI_THINKING_BUDGET if GEMINI_THINKING_BUDGET is not None else 0
+            return {"thinkingConfig": {"thinkingBudget": budget}}
+
         return {}
 
     async def get_available_models(self) -> list[dict]:


### PR DESCRIPTION
Gemini's "thinking" (reasoning) tokens are billed at the output token rate, so for mechanical tasks like translation they mostly just inflate the bill without improving quality. Previously the thinking config was hardcoded: disabled for 2.5.x models, and left untouched (model default) for 3.x models, with no way to adjust either.

Add two new .env settings:
- GEMINI_THINKING_LEVEL: sets `thinkingLevel` (minimal/low/medium/high) for Gemini 3.x models.
- GEMINI_THINKING_BUDGET: sets `thinkingBudget` (token count) for Gemini 2.5.x models.

Both are optional and fall back to the previous default behavior when unset. An invalid GEMINI_THINKING_LEVEL value logs a warning and falls back to the model default instead of silently sending a bad request.

Also documents both variables in .env.example and docs/PROVIDERS.md.