### PR TITLE
docs(resume): fix a docstring line contradicted by #260

### DIFF
--- a/src/api/blueprints/translation_routes.py
+++ b/src/api/blueprints/translation_routes.py
@@ -205,9 +205,11 @@ def _apply_resume_overrides(config, overrides):
     """Merge optional model/provider override fields into a resume config in place.
 
     Lets the resume request switch model/provider for the remaining chunks
-    (issue #183). An empty/absent body leaves `config` untouched. API keys flow
-    through `_resolve_api_key` exactly like the start endpoint, and a multi-key
-    string is passed through unchanged so the key-rotation pool still works.
+    (issue #183). An empty/absent body leaves model, provider and endpoint
+    untouched; `auto_pause_on_rate_limit` is refreshed either way, see below.
+    API keys flow through `_resolve_api_key` exactly like the start endpoint,
+    and a multi-key string is passed through unchanged so the key-rotation
+    pool still works.
 
     Credentials are validated even with an empty body: checkpoints no longer
     persist API keys (issue #213), so every resume must find its key in .env


### PR DESCRIPTION
Follow-up to #260, flagged in [this comment](https://github.com/hydropix/TranslateBooksWithLLMs/pull/260#issuecomment-5395592722).

The opening paragraph of `_apply_resume_overrides` still said an empty or absent body leaves `config` untouched. #260 made that false: `auto_pause_on_rate_limit` is now refreshed from the live setting on every resume, empty body included, which the paragraph two lines below already explains. The two statements contradicted each other.

Reworded to name the fields that really are a snapshot (model, provider, endpoint) and to point at the paragraph that covers the exception.

Docstring only, no behaviour change. `tests/unit/test_resume_overrides.py` and `tests/unit/test_checkpoint_secrets.py` pass (25 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)