### PR TITLE
Preserve block attributes and strip markdown heading in Plain Text Mode

### DIFF
--- a/src/api/blueprints/sample_routes.py
+++ b/src/api/blueprints/sample_routes.py
@@ -124,7 +124,7 @@ def _extract_epub_text(file_path: str) -> str:
                      if isinstance(el.tag, str) and _local_name(el) == "body"),
                     root,
                 )
-                paragraphs, _tags, _images = extract_plain_paragraphs(body)
+                paragraphs, _tags, _images, _attrib = extract_plain_paragraphs(body)
                 for text in paragraphs:
                     text = (text or "").strip()
                     if text:

--- a/src/core/common/plain_text_pipeline.py
+++ b/src/core/common/plain_text_pipeline.py
@@ -27,6 +27,7 @@ from src.prompts.prompts import PLAIN_TEXT_EXPECTED_PARAGRAPHS_OPTION
 PARAGRAPH_SEPARATOR = "\n\n"
 _RESPLIT_REGEX = re.compile(r"\n{2,}")
 _MARKUP_TAG_REGEX = re.compile(r"</?[A-Za-z][A-Za-z0-9]*(?:\s[^<>]*?)?/?>")
+_MARKDOWN_HEADING_MARKER_REGEX = re.compile(r"^\s*(?:#{1,6}\s*)+")
 
 
 def strip_hallucinated_markup(translated: str, source: str) -> str:
@@ -41,6 +42,23 @@ def strip_hallucinated_markup(translated: str, source: str) -> str:
     if "<" not in translated or "<" in source:
         return translated
     return _MARKUP_TAG_REGEX.sub("", translated)
+
+
+def strip_hallucinated_markdown_markers(translated: str) -> str:
+    """Remove leading markdown heading markers the model invented.
+
+    Dry Plain Text Mode sends the LLM a bare heading line like
+    "Chapter 6: Define Secrets and Clues" with no structure, and models
+    conditioned on markdown titles tend to echo "# " prefixes back. The
+    '#', '##', ... are content-adding noise, so drop them. A translation
+    that is a lone marker ("#") with no text is left as-is.
+    """
+    if not translated:
+        return translated
+    stripped = _MARKDOWN_HEADING_MARKER_REGEX.sub("", translated, count=1)
+    if not stripped:
+        return translated
+    return stripped
 
 
 def _split_translated_back_to_paragraphs(translated_text: str) -> List[str]:
@@ -519,6 +537,7 @@ async def translate_paragraphs_plain(
                     cleaned = clean_translated_text(value)
                     cleaned = strip_hallucinated_markup(
                         cleaned, chunks[i].get('main_content', ''))
+                    cleaned = strip_hallucinated_markdown_markers(cleaned)
                     translated_parts[i] = cleaned
                     stats.successful_first_try += 1
                     # A wrong paragraph count is reconciled silently at

--- a/src/core/epub/epub_translation_adapter.py
+++ b/src/core/epub/epub_translation_adapter.py
@@ -336,7 +336,7 @@ class EpubTranslationAdapter(TranslationAdapter[etree._Element, bool]):
                 log_callback("plain_text_no_body", f"⚠️ {file_href or 'document'}: no <body> found, skipping")
             return False, TranslationMetrics()
 
-        paragraphs_text, paragraphs_tag, images_by_paragraph = extract_plain_paragraphs(body)
+        paragraphs_text, paragraphs_tag, images_by_paragraph, paragraphs_attrib = extract_plain_paragraphs(body)
 
         if log_callback:
             log_callback(
@@ -395,6 +395,9 @@ class EpubTranslationAdapter(TranslationAdapter[etree._Element, bool]):
             # empty translation falls back to, so the paragraph survives instead
             # of being dropped. The bilingual flag only drives the interleaving.
             source_paragraphs=paragraphs_text,
+            # Carry each source block's attributes (class, id, xml:lang, ...)
+            # onto the rebuilt element instead of emitting a bare tag.
+            paragraphs_attrib=paragraphs_attrib,
         )
 
         return True, stats

--- a/src/core/epub/plain_extractor.py
+++ b/src/core/epub/plain_extractor.py
@@ -393,6 +393,11 @@ def replace_body_with_paragraphs(
                 _add_class(block, "plain-text-untranslated")
             elif bilingual:
                 _add_class(block, "plain-text-target")
+            # A model trained on markdown sometimes decorates a bare heading
+            # line with "# " prefixes in Plain Text Mode (e.g. "# Chapter 6").
+            # The heading tag already gives the structure, so drop the markers.
+            if raw_tag in ("h1", "h2", "h3", "h4", "h5", "h6") and text.startswith("#"):
+                text = text.lstrip("#").strip()
             block.text = text or source_text
 
         # Emit anchored images right after

--- a/src/core/epub/plain_extractor.py
+++ b/src/core/epub/plain_extractor.py
@@ -10,10 +10,13 @@ its base: it is folded into base（reading） first (see ruby_annotations).
 At rebuild time, the body is wiped and reconstructed as a flat sequence of
 block elements (<p>, <h1..h6>, <li>, <blockquote>, <pre>) plus, after each
 block that originally contained images, an extra <p class="plain-text-images"> wrapper
-with the original <img> elements unchanged. Void blocks (<hr>) carry no text
-and no images: they keep their own slot in the paragraph list and are
-re-emitted as a bare element at the same position, without ever reaching the
-LLM. The one case where the body is left alone is a page that yielded no
+with the original <img> elements unchanged. Each block element is rebuilt with
+its original tag *and its original attributes* (class, id, xml:lang, epub:type,
+title, ...) carried across, so semantic attributes survive translation even
+though the tag's inline children are flattened to text. Void blocks (<hr>)
+carry no text and no images: they keep their own slot in the paragraph list and
+are re-emitted as a bare element at the same position, without ever reaching
+the LLM. The one case where the body is left alone is a page that yielded no
 block at all (everything inside a DROP_TAGS subtree, e.g. an SVG-wrapped
 cover): its source markup is kept verbatim.
 """
@@ -108,6 +111,18 @@ def _clone_img(img: etree._Element) -> etree._Element:
     return new
 
 
+def _set_attributes(elem: etree._Element, attrib: Dict[str, str]) -> None:
+    """Copy recorded source attributes (including namespaced epub:type, xml:lang) onto a rebuilt element."""
+    for k, v in (attrib or {}).items():
+        elem.set(k, v)
+
+
+def _add_class(elem: etree._Element, cls: str) -> None:
+    """Append a plain-text marker class to an element, preserving any source class."""
+    existing = elem.get("class")
+    elem.set("class", f"{existing} {cls}".strip() if existing else cls)
+
+
 def _enclosing_table(elem: etree._Element) -> etree._Element:
     """Return the nearest <table> ancestor, or None."""
     parent = elem.getparent()
@@ -122,6 +137,7 @@ def _collect_table_blocks(
     table: etree._Element,
     paragraphs_text: List[str],
     paragraphs_tag: List[str],
+    paragraphs_attrib: List[Dict[str, str]],
     images_by_paragraph: Dict[int, List[etree._Element]],
 ) -> None:
     """
@@ -143,6 +159,7 @@ def _collect_table_blocks(
             idx = len(paragraphs_text)
             paragraphs_text.append(text)
             paragraphs_tag.append("p")
+            paragraphs_attrib.append(dict(elem.attrib))
             if images:
                 images_by_paragraph[idx] = images
 
@@ -151,6 +168,7 @@ def _collect_blocks(
     root: etree._Element,
     paragraphs_text: List[str],
     paragraphs_tag: List[str],
+    paragraphs_attrib: List[Dict[str, str]],
     images_by_paragraph: Dict[int, List[etree._Element]],
 ) -> None:
     """
@@ -168,18 +186,21 @@ def _collect_blocks(
         if name in VOID_BLOCK_TAGS:
             paragraphs_text.append("")
             paragraphs_tag.append(name)
+            paragraphs_attrib.append(dict(child.attrib))
             continue
 
         if name == "table":
-            _collect_table_blocks(child, paragraphs_text, paragraphs_tag, images_by_paragraph)
+            _collect_table_blocks(
+                child, paragraphs_text, paragraphs_tag, paragraphs_attrib, images_by_paragraph
+            )
             continue
 
         if name in LIST_WRAPPER_TAGS:
-            _collect_blocks(child, paragraphs_text, paragraphs_tag, images_by_paragraph)
+            _collect_blocks(child, paragraphs_text, paragraphs_tag, paragraphs_attrib, images_by_paragraph)
             continue
 
         if name in CONTAINER_TAGS:
-            _collect_blocks(child, paragraphs_text, paragraphs_tag, images_by_paragraph)
+            _collect_blocks(child, paragraphs_text, paragraphs_tag, paragraphs_attrib, images_by_paragraph)
             continue
 
         if name in BLOCK_TAGS:
@@ -193,6 +214,7 @@ def _collect_blocks(
             idx = len(paragraphs_text)
             paragraphs_text.append(text)
             paragraphs_tag.append(name)
+            paragraphs_attrib.append(dict(child.attrib))
             if images:
                 images_by_paragraph[idx] = images
             continue
@@ -207,6 +229,7 @@ def _collect_blocks(
             else:
                 paragraphs_text.append("")
                 paragraphs_tag.append("p")
+                paragraphs_attrib.append({})
                 images_by_paragraph[0] = [img_copy]
             continue
 
@@ -217,13 +240,14 @@ def _collect_blocks(
             idx = len(paragraphs_text)
             paragraphs_text.append(text)
             paragraphs_tag.append("p")
+            paragraphs_attrib.append(dict(child.attrib))
             if images:
                 images_by_paragraph[idx] = images
 
 
 def extract_plain_paragraphs(
     body_element: etree._Element,
-) -> Tuple[List[str], List[str], Dict[int, List[etree._Element]]]:
+) -> Tuple[List[str], List[str], Dict[int, List[etree._Element]], List[Dict[str, str]]]:
     """
     Extract the body as a flat list of (text, tag) pairs plus an image anchor map.
 
@@ -234,20 +258,24 @@ def extract_plain_paragraphs(
         paragraphs_text:        list of plain-text strings, one per block
         paragraphs_tag:         parallel list of tag names ("p", "h1", "li", ...)
         images_by_paragraph:    {paragraph_index: [<img> elements]}
+        paragraphs_attrib:      parallel list of attribute dicts, one per block
     """
     paragraphs_text: List[str] = []
     paragraphs_tag: List[str] = []
+    paragraphs_attrib: List[Dict[str, str]] = []
     images_by_paragraph: Dict[int, List[etree._Element]] = {}
 
     if body_element is None:
-        return paragraphs_text, paragraphs_tag, images_by_paragraph
+        return paragraphs_text, paragraphs_tag, images_by_paragraph, paragraphs_attrib
 
     # Fold <ruby> annotations first, otherwise flattening would glue the base
     # and its reading into a word that does not exist (issue #242).
     fold_ruby_annotations(body_element)
 
-    _collect_blocks(body_element, paragraphs_text, paragraphs_tag, images_by_paragraph)
-    return paragraphs_text, paragraphs_tag, images_by_paragraph
+    _collect_blocks(
+        body_element, paragraphs_text, paragraphs_tag, paragraphs_attrib, images_by_paragraph
+    )
+    return paragraphs_text, paragraphs_tag, images_by_paragraph, paragraphs_attrib
 
 
 def replace_body_with_paragraphs(
@@ -257,6 +285,7 @@ def replace_body_with_paragraphs(
     images_by_paragraph: Dict[int, List[etree._Element]],
     bilingual: bool = False,
     source_paragraphs: List[str] = None,
+    paragraphs_attrib: List[Dict[str, str]] = None,
 ) -> None:
     """
     Wipe body_element and refill it from the translated paragraphs.
@@ -273,6 +302,11 @@ def replace_body_with_paragraphs(
                    what an empty translation falls back to instead of the block
                    being dropped. Legacy callers that omit it still get an
                    empty block rather than a deletion.
+        paragraphs_attrib: attribute dict per paragraph, captured from the source
+                   block at extraction time. When provided, each rebuilt block
+                   keeps its source attributes (class, id, xml:lang, epub:type,
+                   ...); marker classes are appended to, never replacing, a
+                   source class.
     """
     count = len(translated_paragraphs)
 
@@ -301,16 +335,19 @@ def replace_body_with_paragraphs(
         raw_tag = paragraphs_tag[i] if i < len(paragraphs_tag) else "p"
         # <li> outside <ul>/<ol> is not valid XHTML — flatten to <p> in Plain Text Mode.
         tag = "p" if raw_tag == "li" else raw_tag
+        attrib = paragraphs_attrib[i] if paragraphs_attrib and i < len(paragraphs_attrib) else {}
 
         if raw_tag in VOID_BLOCK_TAGS:
-            etree.SubElement(body_element, raw_tag)
+            block = etree.SubElement(body_element, raw_tag)
+            _set_attributes(block, attrib)
             continue
 
         # Bilingual: emit source first when we have it
         source_emitted = False
         if bilingual and source_text:
             src_block = etree.SubElement(body_element, tag)
-            src_block.set("class", "plain-text-source")
+            _set_attributes(src_block, attrib)
+            _add_class(src_block, "plain-text-source")
             src_block.text = source_text
             source_emitted = True
 
@@ -348,13 +385,14 @@ def replace_body_with_paragraphs(
 
         if emit_target:
             block = etree.SubElement(body_element, tag)
+            _set_attributes(block, attrib)
             if untranslated:
-                # Replaces plain-text-target rather than adding to it: a block
-                # carries one class, and "this is still source text" is the more
-                # important of the two.
-                block.set("class", "plain-text-untranslated")
+                # One marker per block, untranslated over bilingual-target when
+                # both apply; either is appended to the source class, which the
+                # _set_attributes call above already restored.
+                _add_class(block, "plain-text-untranslated")
             elif bilingual:
-                block.set("class", "plain-text-target")
+                _add_class(block, "plain-text-target")
             block.text = text or source_text
 
         # Emit anchored images right after

--- a/src/core/epub/translator.py
+++ b/src/core/epub/translator.py
@@ -899,7 +899,7 @@ def _precount_chunks_plain_text(doc_root, max_tokens_per_chunk: int) -> int:
         if body is None:
             return 0
 
-        paragraphs, _, _ = extract_plain_paragraphs(body)
+        paragraphs, _, _, _ = extract_plain_paragraphs(body)
         if not paragraphs:
             return 0
 

--- a/src/prompts/prompts.py
+++ b/src/prompts/prompts.py
@@ -87,6 +87,8 @@ _PLAIN_TEXT_FORMAT_RULES = (
     "\n8. Separate every output paragraph with ONE BLANK LINE - never a single newline"
     "\n9. Do NOT merge two paragraphs into one, and do NOT split one paragraph into two"
     "\n10. An empty input paragraph stays empty - do not fill it"
+    "\n11. Do NOT add markdown heading markers (#, ##, ###, etc.) or any other "
+    "markdown formatting symbols to your output - output plain translated text only"
 )
 
 # prompt_options key carrying the paragraph count of the segment being retried.
@@ -109,10 +111,10 @@ def _plain_text_format_rules(prompt_options: Optional[Dict[str, Any]] = None) ->
     if not isinstance(expected, int) or isinstance(expected, bool) or expected < 1:
         return _PLAIN_TEXT_FORMAT_RULES
     return _PLAIN_TEXT_FORMAT_RULES + (
-        "\n11. RETRY: your previous answer for this exact text had the WRONG number of paragraphs"
-        f"\n12. This input contains EXACTLY {expected} paragraph(s); your output MUST contain "
+        "\n12. RETRY: your previous answer for this exact text had the WRONG number of paragraphs"
+        f"\n13. This input contains EXACTLY {expected} paragraph(s); your output MUST contain "
         f"EXACTLY {expected} paragraph(s), separated by ONE BLANK LINE"
-        "\n13. Count the paragraphs before answering. A disclaimer, an author's note, a chapter "
+        "\n14. Count the paragraphs before answering. A disclaimer, an author's note, a chapter "
         "heading or any short standalone line IS a paragraph and IS content: translate each one "
         "as its own paragraph - never drop it, never fold it into the next one, never summarize it"
     )

--- a/tests/unit/epub/test_heading_attribute_preservation.py
+++ b/tests/unit/epub/test_heading_attribute_preservation.py
@@ -4,25 +4,24 @@ Finding F3 of `plan/PLAN_CjkSourceRendering.md` measured
 `LOST ATTRS: {('h3','class'): 28}` over a real Chinese -> French EPUB: every
 translated `<h3 class="head">` came out as a bare `<h3>`.
 
-These tests localize the loss. Both translation paths of the EPUB pipeline are
-exercised on the same body HTML, with an LLM client stubbed at the transport
-level only (`generate` / `extract_translation`); every module under test is the
-real one, so the assertions describe production behaviour:
+These tests localize the loss (and its opposite, the preservation controls).
+Both translation paths of the EPUB pipeline are exercised on the same body
+HTML, with an LLM client stubbed at the transport level only (`generate` /
+`extract_translation`); every module under test is the real one, so the
+assertions describe production behaviour:
 
-  * Plain Text Mode (`prompt_options['plain_text_mode']`) LOSES the attribute.
-    `plain_extractor.extract_plain_paragraphs` records only a block's tag NAME,
-    and `replace_body_with_paragraphs` rebuilds each block with
-    `etree.SubElement(body, tag)` — no attribute is ever carried across. This
-    is the xfail below; see plan/PLAN_CjkSourceRendering.md section 5.1.
+  * Plain Text Mode (`prompt_options['plain_text_mode']`) PRESERVES the
+    attribute. `plain_extractor.extract_plain_paragraphs` records each block's
+    tag NAME *and* attributes, and `replace_body_with_paragraphs` carries the
+    attributes onto the rebuilt element (see plain_extractor.py). This is the
+    regression test below.
 
   * The placeholder path (the default) PRESERVES the attribute, both when the
     model echoes the placeholders and when it emits literal HTML tags instead
     and the token-alignment fallback has to repair the chunk. Those two are
-    passing controls, and they pin the loss to Plain Text Mode rather than to
-    `TagPreserver`, `PlaceholderRenumberer`, `TokenAlignmentFallback` or the
-    entity-escaping step of `_reconstruct_html`.
-
-No production code is fixed here: Phase 2 of the plan is diagnosis only.
+    passing controls, and they pin any future loss to Plain Text Mode rather
+    than to `TagPreserver`, `PlaceholderRenumberer`, `TokenAlignmentFallback`
+    or the entity-escaping step of `_reconstruct_html`.
 """
 import re
 from typing import List
@@ -211,19 +210,9 @@ async def test_placeholder_path_preserves_heading_class_when_model_emits_literal
     assert _heading_open_tags(doc_root) == ['<h3 class="head">']
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "F3 (plan/PLAN_CjkSourceRendering.md section 5.1): Plain Text Mode "
-        "rebuilds every block with etree.SubElement(body, tag) at "
-        "plain_extractor.py:281, so no source attribute is carried over and "
-        "class=\"head\" is dropped from every heading. Diagnosis-only phase: "
-        "the fix is a maintainer decision, so this stays xfail until it lands."
-    ),
-)
 @pytest.mark.asyncio
 async def test_plain_text_mode_preserves_heading_class():
-    """Reproduces F3: Plain Text Mode drops `class="head"` from the heading."""
+    """Regression: Plain Text Mode keeps `class="head"` on the translated heading."""
     doc_root = _parse_doc()
     client = EchoPlaceholdersClient()
     adapter = EpubTranslationAdapter()

--- a/tests/unit/epub/test_issue_207_content_loss.py
+++ b/tests/unit/epub/test_issue_207_content_loss.py
@@ -171,7 +171,7 @@ class TestPlainModeTables:
             "<tr><td>Paris</td><td>2.1 million</td></tr>"
             "</table>"
         )
-        paragraphs, _, _ = extract_plain_paragraphs(body)
+        paragraphs, _, _, _ = extract_plain_paragraphs(body)
         joined = " ".join(paragraphs)
 
         assert "Paris" in joined, "table cell text was deleted"
@@ -183,7 +183,7 @@ class TestPlainModeTables:
             "<p>Intro.</p>"
             "<table><tr><td>Cell text</td></tr></table>"
         )
-        paragraphs, tags, images = extract_plain_paragraphs(body)
+        paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
         replace_body_with_paragraphs(body, paragraphs, tags, images)
 
         rebuilt_text = " ".join("".join(body.itertext()).split())
@@ -197,7 +197,7 @@ class TestPlainModeFigures:
             '<figure><img src="images/map.png" alt="Map"/>'
             "<figcaption>A map of the region</figcaption></figure>"
         )
-        paragraphs, tags, images_by_paragraph = extract_plain_paragraphs(body)
+        paragraphs, tags, images_by_paragraph, _attrib = extract_plain_paragraphs(body)
 
         anchored = [img for imgs in images_by_paragraph.values() for img in imgs]
         assert any(
@@ -208,7 +208,7 @@ class TestPlainModeFigures:
         body = _parse_body(
             '<figure><img src="x.png"/><figcaption>The caption</figcaption></figure>'
         )
-        paragraphs, _, _ = extract_plain_paragraphs(body)
+        paragraphs, _, _, _ = extract_plain_paragraphs(body)
         assert "The caption" in " ".join(paragraphs)
 
     def test_picture_wrapped_image_is_anchored(self):
@@ -216,7 +216,7 @@ class TestPlainModeFigures:
             "<p>Some text.</p>"
             '<picture><source srcset="big.webp"/><img src="fallback.jpg"/></picture>'
         )
-        _, _, images_by_paragraph = extract_plain_paragraphs(body)
+        _, _, images_by_paragraph, _attrib = extract_plain_paragraphs(body)
 
         anchored = [img for imgs in images_by_paragraph.values() for img in imgs]
         assert any(img.get("src") == "fallback.jpg" for img in anchored)
@@ -225,7 +225,7 @@ class TestPlainModeFigures:
         body = _parse_body(
             '<p>Text around <figure><img src="inline.png"/></figure> an inline figure.</p>'
         )
-        _, _, images_by_paragraph = extract_plain_paragraphs(body)
+        _, _, images_by_paragraph, _attrib = extract_plain_paragraphs(body)
 
         anchored = [img for imgs in images_by_paragraph.values() for img in imgs]
         assert any(img.get("src") == "inline.png" for img in anchored)
@@ -235,7 +235,7 @@ class TestPlainModeFigures:
             "<p>Para.</p>"
             '<figure><img src="kept.png"/><figcaption>Cap</figcaption></figure>'
         )
-        paragraphs, tags, images = extract_plain_paragraphs(body)
+        paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
         replace_body_with_paragraphs(body, paragraphs, tags, images)
 
         srcs = [img.get("src") for img in _all_imgs(body)]
@@ -244,7 +244,7 @@ class TestPlainModeFigures:
     def test_standalone_image_still_anchored(self):
         # Pre-existing behavior that must not regress.
         body = _parse_body('<p>Hello.</p><img src="standalone.png"/>')
-        _, _, images_by_paragraph = extract_plain_paragraphs(body)
+        _, _, images_by_paragraph, _attrib = extract_plain_paragraphs(body)
 
         anchored = [img for imgs in images_by_paragraph.values() for img in imgs]
         assert any(img.get("src") == "standalone.png" for img in anchored)
@@ -254,7 +254,7 @@ class TestPlainModeFigures:
         body = _parse_body(
             "<p>Text.</p><svg xmlns='http://www.w3.org/2000/svg'><text>chart</text></svg>"
         )
-        paragraphs, _, images_by_paragraph = extract_plain_paragraphs(body)
+        paragraphs, _, images_by_paragraph, _attrib = extract_plain_paragraphs(body)
         assert "chart" not in " ".join(paragraphs)
         assert not images_by_paragraph
 
@@ -292,7 +292,7 @@ class TestWeakLlmSafety:
         monkeypatch.setattr(plain_pipeline, "clean_translated_text", lambda s: s)
 
         body = _parse_body(self.BODY_INNER)
-        paragraphs, _, _ = extract_plain_paragraphs(body)
+        paragraphs, _, _, _ = extract_plain_paragraphs(body)
         await plain_pipeline.translate_paragraphs_plain(
             paragraphs=paragraphs,
             source_language="English",
@@ -327,7 +327,7 @@ class TestWeakLlmSafety:
         monkeypatch.setattr(plain_pipeline, "clean_translated_text", lambda s: s)
 
         body = _parse_body(self.BODY_INNER)
-        paragraphs, tags, images = extract_plain_paragraphs(body)
+        paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
         translated, _, interrupted = await plain_pipeline.translate_paragraphs_plain(
             paragraphs=paragraphs,
             source_language="English",
@@ -429,7 +429,7 @@ class TestPlainModeCoverPage:
         body = _parse_body(SVG_COVER_BODY)
         before = etree.tostring(body, encoding="unicode")
 
-        paragraphs, tags, images = extract_plain_paragraphs(body)
+        paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
         assert paragraphs == [] and images == {}, (
             "precondition: the SVG subtree yields no translatable paragraph"
         )
@@ -445,7 +445,7 @@ class TestPlainModeCoverPage:
 
     def test_already_empty_body_stays_a_no_op(self):
         body = _parse_body("")
-        paragraphs, tags, images = extract_plain_paragraphs(body)
+        paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
         replace_body_with_paragraphs(body, paragraphs, tags, images)
 
         assert len(body) == 0
@@ -488,7 +488,7 @@ class TestPlainModeEmptyTranslation:
 
     def test_empty_translation_falls_back_to_the_source_text(self):
         body = _parse_body("<p>A paragraph the model returned nothing for.</p>")
-        paragraphs, tags, images = extract_plain_paragraphs(body)
+        paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
         replace_body_with_paragraphs(
             body, [""], tags, images, source_paragraphs=paragraphs
         )
@@ -502,7 +502,7 @@ class TestPlainModeEmptyTranslation:
         body = _parse_body("<p>First.</p><p></p><p>Second.</p>")
         input_p_count = _count_p(body)
 
-        paragraphs, tags, images = extract_plain_paragraphs(body)
+        paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
         replace_body_with_paragraphs(
             body, list(paragraphs), tags, images, source_paragraphs=paragraphs
         )
@@ -511,7 +511,7 @@ class TestPlainModeEmptyTranslation:
 
     def test_bilingual_empty_translation_emits_the_source_once(self):
         body = _parse_body("<p>Le texte source.</p>")
-        paragraphs, tags, images = extract_plain_paragraphs(body)
+        paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
         replace_body_with_paragraphs(
             body, [""], tags, images, bilingual=True, source_paragraphs=paragraphs
         )
@@ -526,7 +526,7 @@ class TestPlainModeEmptyTranslation:
         # Callers predating the source-text fallback pass no source_paragraphs.
         # An empty translation must still emit an (empty) block, not nothing.
         body = _parse_body("<p>Original.</p>")
-        _, tags, images = extract_plain_paragraphs(body)
+        _, tags, images, _attrib = extract_plain_paragraphs(body)
         replace_body_with_paragraphs(body, [""], tags, images)
 
         assert _count_p(body) == 1
@@ -537,7 +537,7 @@ class TestPlainModeEmptyTranslation:
         # stands in for the block, so a source <p><img/></p> comes out as one
         # <p>, not two.
         body = _parse_body('<p><img src="x.jpg"/></p>')
-        paragraphs, tags, images = extract_plain_paragraphs(body)
+        paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
         replace_body_with_paragraphs(
             body, list(paragraphs), tags, images, source_paragraphs=paragraphs
         )

--- a/tests/unit/epub/test_issue_207_content_loss.py
+++ b/tests/unit/epub/test_issue_207_content_loss.py
@@ -394,6 +394,30 @@ class TestWeakLlmSafety:
             "Le 1<sup>er</sup> chapitre<br/>", "The 1st chapter"
         ) == "Le 1er chapitre"
 
+    def test_markdown_marker_stripping_removes_heading_hashes(self):
+        from src.core.common.plain_text_pipeline import (
+            strip_hallucinated_markdown_markers,
+        )
+
+        # A heading line the model decorated with "# " in Plain Text Mode:
+        # the marker goes away, the translation stays.
+        assert strip_hallucinated_markdown_markers(
+            "# บทที่ 6: การกำหนดความลับและเบาะแส"
+        ) == "บทที่ 6: การกำหนดความลับและเบาะแส"
+        assert strip_hallucinated_markdown_markers(
+            "## Chapter 6"
+        ) == "Chapter 6"
+        # Leading whitespace before the marker must still be caught.
+        assert strip_hallucinated_markdown_markers(
+            "   ### Chapitre 6"
+        ) == "Chapitre 6"
+        # A lone "#" with no following text is not a heading marker - keep it.
+        assert strip_hallucinated_markdown_markers("#") == "#"
+        # Plain paragraphs with no marker are untouched.
+        assert strip_hallucinated_markdown_markers(
+            "Un paragraphe normal."
+        ) == "Un paragraphe normal."
+
 
 # === D. Plain Text Mode: the rebuild must never lose content ===
 

--- a/tests/unit/epub/test_plain_text_hr_separators.py
+++ b/tests/unit/epub/test_plain_text_hr_separators.py
@@ -57,7 +57,7 @@ def _local_tags(element: etree._Element) -> list:
 
 def test_hr_is_collected_as_void_block():
     body = _parse_body("<p>A</p><hr/><p>B</p>")
-    paragraphs, tags, images = extract_plain_paragraphs(body)
+    paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
 
     assert (paragraphs, tags, images) == (["A", "", "B"], ["p", "hr", "p"], {})
     assert len(paragraphs) == len(tags)
@@ -65,7 +65,7 @@ def test_hr_is_collected_as_void_block():
 
 def test_hr_nested_in_div_is_collected():
     body = _parse_body("<div><p>A</p><hr/><p>B</p></div>")
-    paragraphs, tags, images = extract_plain_paragraphs(body)
+    paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
 
     assert (paragraphs, tags, images) == (["A", "", "B"], ["p", "hr", "p"], {})
     assert len(paragraphs) == len(tags)
@@ -127,14 +127,16 @@ def test_hr_survives_bilingual_rebuild():
     )
 
 
-def test_hr_attributes_are_dropped():
+def test_hr_attributes_are_preserved():
     body = _parse_body('<p>A</p><hr class="scene"/><p>B</p>')
-    paragraphs, tags, images = extract_plain_paragraphs(body)
-    replace_body_with_paragraphs(body, list(paragraphs), tags, images)
+    paragraphs, tags, images, attrib = extract_plain_paragraphs(body)
+    assert attrib == [{}, {"class": "scene"}, {}]
+
+    replace_body_with_paragraphs(body, list(paragraphs), tags, images, paragraphs_attrib=attrib)
 
     hr_children = [child for child in body if child.tag.split("}")[-1] == "hr"]
     assert len(hr_children) == 1
-    assert hr_children[0].attrib == {}
+    assert hr_children[0].attrib == {"class": "scene"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/epub/test_ruby_annotations.py
+++ b/tests/unit/epub/test_ruby_annotations.py
@@ -177,7 +177,7 @@ class TestPlainTextPath:
 
     def test_reading_no_longer_glued_to_base(self):
         body = _body("<p>彼は<ruby>宇宙<rt>そら</rt></ruby>を見上げた。</p>")
-        paragraphs, _tags, _images = extract_plain_paragraphs(body)
+        paragraphs, _tags, _images, _attrib = extract_plain_paragraphs(body)
         assert paragraphs == ["彼は宇宙（そら）を見上げた。"]
         assert "宇宙そら" not in paragraphs[0]
 
@@ -199,7 +199,7 @@ class TestPlainTextPath:
         body = _body(
             '<p><ruby>宇宙<rt>そら</rt></ruby><img src="a.png"/></p>'
         )
-        paragraphs, tags, images = extract_plain_paragraphs(body)
+        paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
         assert paragraphs == ["宇宙（そら）"]
         assert tags == ["p"]
         assert len(images[0]) == 1

--- a/tests/unit/test_plain_text_alignment.py
+++ b/tests/unit/test_plain_text_alignment.py
@@ -146,7 +146,7 @@ async def test_epub_image_anchor_and_heading_stay_aligned(monkeypatch):
         "<p>Second body paragraph.</p>"
         "</body>"
     )
-    paragraphs, tags, images = extract_plain_paragraphs(body)
+    paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
     assert paragraphs[0] == ""  # synthetic anchor for the leading image
     assert 0 in images
 

--- a/tests/unit/test_plain_text_paragraph_mismatch.py
+++ b/tests/unit/test_plain_text_paragraph_mismatch.py
@@ -259,7 +259,7 @@ def test_untranslated_block_is_marked():
     body = etree.fromstring(
         "<body>" + "".join(f"<p>{p}</p>" for p in MERGED) + "</body>"
     )
-    paragraphs, tags, images = extract_plain_paragraphs(body)
+    paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
 
     replace_body_with_paragraphs(
         body, ["T::Alpha paragraph. Beta paragraph.", ""], tags, images,
@@ -276,7 +276,7 @@ def test_untranslated_block_is_marked():
 def test_translated_blocks_keep_their_classes():
     """Only the source-carrying block is marked; bilingual mode is unchanged."""
     body = etree.fromstring("<body><p>Source one.</p><p>Source two.</p></body>")
-    paragraphs, tags, images = extract_plain_paragraphs(body)
+    paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
     replace_body_with_paragraphs(
         body, ["Traduction une.", ""], tags, images,
         bilingual=True, source_paragraphs=paragraphs,
@@ -317,7 +317,7 @@ async def test_merged_segment_is_repaired_paragraph_by_paragraph(monkeypatch):
     body = etree.fromstring(
         "<body>" + "".join(f"<p>{p}</p>" for p in THREE) + "</body>"
     )
-    paragraphs, tags, images = extract_plain_paragraphs(body)
+    paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
 
     out, stats, logs = await _run(paragraphs)
 
@@ -354,7 +354,7 @@ async def test_repair_failure_falls_back_to_source_and_is_counted(monkeypatch):
     body = etree.fromstring(
         "<body>" + "".join(f"<p>{p}</p>" for p in THREE) + "</body>"
     )
-    paragraphs, tags, images = extract_plain_paragraphs(body)
+    paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
 
     out, stats, logs = await _run(paragraphs)
 


### PR DESCRIPTION
Awesome APP! by the way.

When I used this app to translate markdown files from English to Thai, it works flawlessly. But, when used for translate EPUB files it strip all attributes in EPUB's tag and didn't bring back all of it (even using wrong tags). 

Another bug is hashtag (#) magically appeared in h1 heading even there's none in original EPUB.

I hope fix said bugs and continue to improve this awesome app.

Cheers!