### PR TITLE
fix(pricing): prefer the most specific model in the default-pricing fallback

### DIFF
--- a/src/core/pricing/pricing_data.py
+++ b/src/core/pricing/pricing_data.py
@@ -68,7 +68,8 @@ def get_default_pricing(provider: str, model: str) -> dict | None:
     Return {input, output} prices per 1M tokens for the given provider/model.
 
     Returns None if no default pricing is known.
-    Lookup is case-insensitive and tolerates minor variants in model names.
+    Lookup is case-insensitive and tolerates minor variants in model names
+    (dated snapshots, preview suffixes); the most specific known name wins.
     """
     provider_data = DEFAULT_PRICING.get(provider.lower())
     if not provider_data:
@@ -82,9 +83,16 @@ def get_default_pricing(provider: str, model: str) -> dict | None:
         if known_model.lower() == model_lower:
             return _strip_note(pricing)
 
-    for known_model, pricing in provider_data.items():
-        if known_model.lower() in model_lower or model_lower in known_model.lower():
-            return _strip_note(pricing)
+    # Last resort: substring match. Prefer the most specific key, otherwise
+    # dict insertion order decides and "gpt-4.1-nano-2025-04-14" is priced as
+    # "gpt-4.1" (20x too high) simply because it is listed first.
+    contained = [k for k in provider_data if k.lower() in model_lower]
+    if contained:
+        return _strip_note(provider_data[max(contained, key=len)])
+
+    containing = [k for k in provider_data if model_lower in k.lower()]
+    if containing:
+        return _strip_note(provider_data[min(containing, key=len)])
 
     return None
 

--- a/tests/unit/test_pricing_lookup.py
+++ b/tests/unit/test_pricing_lookup.py
@@ -1,0 +1,74 @@
+"""
+Unit tests for get_default_pricing() model matching.
+
+Regression tests for item 1 of issue #231: the last-resort substring lookup
+returned the first insertion-order entry whose name overlapped the queried
+model, so a dated snapshot such as "gpt-4.1-nano-2025-04-14" was priced as
+"gpt-4.1" simply because the broader key is listed first.
+
+https://github.com/hydropix/TranslateBooksWithLLMs/issues/231
+"""
+import pytest
+import sys
+from pathlib import Path
+
+# Add project root to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from src.core.pricing.pricing_data import DEFAULT_PRICING, get_default_pricing
+
+
+class TestGetDefaultPricingSpecificity:
+    """The most specific known model name must win the substring fallback."""
+
+    @pytest.mark.parametrize("provider,model,expected", [
+        # Dated OpenAI snapshots: the "-mini"/"-nano" variants used to resolve
+        # to their much more expensive parent.
+        ("openai", "gpt-4o-mini-2024-07-18", {"input": 0.15, "output": 0.60}),
+        ("openai", "gpt-4.1-mini-2025-04-14", {"input": 0.40, "output": 1.60}),
+        ("openai", "gpt-4.1-nano-2025-04-14", {"input": 0.10, "output": 0.40}),
+        ("openai", "o1-mini-2024-09-12", {"input": 3.00, "output": 12.00}),
+        # Gemini preview ids reach the model dropdown, so this is a real input.
+        ("gemini", "gemini-2.5-flash-lite-preview-06-17",
+         {"input": 0.10, "output": 0.40}),
+    ])
+    def test_dated_variant_uses_its_own_price(self, provider, model, expected):
+        """A dated/preview id must match the longest known name it contains."""
+        assert get_default_pricing(provider, model) == expected
+
+    @pytest.mark.parametrize("provider,model,expected", [
+        ("openai", "gpt-4o-2024-11-20", {"input": 2.50, "output": 10.00}),
+        ("openai", "gpt-4-turbo-2024-04-09", {"input": 10.00, "output": 30.00}),
+        ("openai", "gpt-4o-mini", {"input": 0.15, "output": 0.60}),
+        ("openai", "GPT-4O-MINI", {"input": 0.15, "output": 0.60}),
+        ("mistral", "mistral-large-2411", {"input": 2.00, "output": 6.00}),
+        ("gemini", "gemini-2.5-pro", {"input": 1.25, "output": 10.00}),
+    ])
+    def test_existing_matches_are_unchanged(self, provider, model, expected):
+        """Exact, case-insensitive and parent-model lookups keep their price."""
+        assert get_default_pricing(provider, model) == expected
+
+    @pytest.mark.parametrize("provider,model", [
+        ("openai", "totally-unknown-model"),
+        ("unknown-provider", "gpt-4o"),
+    ])
+    def test_unknown_stays_unknown(self, provider, model):
+        """No pricing is invented for unknown providers or models."""
+        assert get_default_pricing(provider, model) is None
+
+    def test_every_table_key_resolves_to_its_own_entry(self):
+        """No key in DEFAULT_PRICING may be shadowed by another one."""
+        mismatches = [
+            (provider, model)
+            for provider, models in DEFAULT_PRICING.items()
+            for model, entry in models.items()
+            if get_default_pricing(provider, model) != {
+                "input": entry["input"],
+                "output": entry["output"],
+            }
+        ]
+        assert mismatches == [], f"Shadowed pricing entries: {mismatches}"
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
Addresses **item 1 of #231** ("Pricing lookup matches the wrong (shorter) model first"), implementing the remedy specified there: *"Fix: prefer the longest matching key."* Scoped to that item only — the other seven items in #231 are untouched, so this does not close the issue.

## Problem

`get_default_pricing()` ends with a last-resort substring loop that returns the **first** entry whose name overlaps the queried model, so dict insertion order decides the price (`src/core/pricing/pricing_data.py:85-87`):

```python
for known_model, pricing in provider_data.items():
    if known_model.lower() in model_lower or model_lower in known_model.lower():
        return _strip_note(pricing)
```

In `DEFAULT_PRICING` the broader model is always listed before its cheaper sibling (`gpt-4o` before `gpt-4o-mini`, `gpt-4.1` before `gpt-4.1-mini`/`gpt-4.1-nano`, `o1` before `o1-mini`, `gemini-2.5-flash` before `gemini-2.5-flash-lite`), so any dated snapshot or preview id resolves to the expensive parent. Run against `main` (9fe62f2):

```
$ python -c "from src.core.pricing.pricing_data import get_default_pricing as g; ..."
openai  gpt-4o-mini-2024-07-18               -> {'input': 2.5,  'output': 10.0}   # should be 0.15 / 0.60
openai  gpt-4.1-mini-2025-04-14              -> {'input': 2.0,  'output': 8.0}    # should be 0.40 / 1.60
openai  gpt-4.1-nano-2025-04-14              -> {'input': 2.0,  'output': 8.0}    # should be 0.10 / 0.40
openai  o1-mini-2024-09-12                   -> {'input': 15.0, 'output': 60.0}   # should be 3.00 / 12.00
gemini  gemini-2.5-flash-lite-preview-06-17  -> {'input': 0.3,  'output': 2.5}    # should be 0.10 / 0.40
```

These ids are not hypothetical: `gemini.py` fetches the live model list and only filters `experimental` / `latest` / `vision` / `-exp-`, so `gemini-2.5-flash-lite-preview-06-17` reaches the model dropdown as-is.

Two backend paths report the resulting figure:

- `src/api/blueprints/sample_routes.py:282` `_compute_cost_usd()` calls `get_default_pricing(provider, model)` with the raw column model string, with no user-override escape hatch, and emits the result as `cost` in the cell payload.
- `POST /api/cost/estimate` with no `pricing` override (`cost_routes.py:145`), returned with `pricing_source: "default_table"` — i.e. presented as a known table value rather than as unknown.

Worth noting: the frontend twin `resolvePricing()` (`src/web/static/js/providers/cost-estimator.js:137`) does exact + case-insensitive matching **only** and then returns `{pricing: null, source: 'unknown'}`. So for the same input the two implementations disagree — the JS side honestly says "unknown" while Python silently returns the parent model's price and labels it `default_table`.

## Change

`src/core/pricing/pricing_data.py` — the three-line loop becomes a most-specific match, keeping the same two-direction tolerance:

- when a known name is **contained in** the queried id (the dated-snapshot case), the **longest** such key wins;
- in the reverse direction (the queried id is a truncation of a known name), the **shortest** such key wins.

The provider lookup, the exact match, the case-insensitive match and the trailing `return None` are untouched, and no entry of `DEFAULT_PRICING` is edited.

`tests/unit/test_pricing_lookup.py` (new) covers the five corrected ids, six lookups that must stay unchanged, the two unknown cases, and a sweep asserting that every key in `DEFAULT_PRICING` still resolves to its own entry (no key shadowed by another).

## Verification

`pricing_data.py` has no imports, so the behaviour is checkable with a bare interpreter. After the patch:

```
openai  gpt-4o-mini-2024-07-18               -> {'input': 0.15, 'output': 0.6}
openai  gpt-4.1-mini-2025-04-14              -> {'input': 0.4,  'output': 1.6}
openai  gpt-4.1-nano-2025-04-14              -> {'input': 0.1,  'output': 0.4}
openai  o1-mini-2024-09-12                   -> {'input': 3.0,  'output': 12.0}
gemini  gemini-2.5-flash-lite-preview-06-17  -> {'input': 0.1,  'output': 0.4}
openai  gpt-4o-2024-11-20                    -> {'input': 2.5,  'output': 10.0}   # unchanged
openai  gpt-4-turbo-2024-04-09               -> {'input': 10.0, 'output': 30.0}   # unchanged
mistral mistral-large-2411                   -> {'input': 2.0,  'output': 6.0}    # unchanged
openai  gpt-4o-mini                          -> {'input': 0.15, 'output': 0.6}    # unchanged
gemini  gemini-2.5-pro                       -> {'input': 1.25, 'output': 10.0}   # unchanged
openai  totally-unknown-model                -> None                              # unchanged
unknownprov gpt-4o                           -> None                              # unchanged
```

New test file, with the source patch reverted (proves it is a real regression test):

```
$ python -m pytest tests/unit/test_pricing_lookup.py
5 failed, 9 passed in 0.46s
```

With the patch applied:

```
$ python -m pytest tests/unit/test_pricing_lookup.py
14 passed in 0.28s
```

Full default suite (`pytest.ini` already excludes `integration` and `e2e`), Python 3.12.10, `requirements.txt` installed in a clean venv:

```
$ python -m pytest
6 failed, 2236 passed, 3 skipped, 10 deselected, 1 xfailed in 72.98s
```

The 6 failures are all in `tests/characterization/test_progress_baseline.py` (progress-trace golden files) and are **pre-existing**: I re-ran that file on unmodified `main` and got the same `6 failed, 4 passed`. Nothing there touches pricing.

## Limitations

Substring matching remains a heuristic — it is still possible for an unrelated id to contain a known model name. This PR only removes the insertion-order dependency; a stricter scheme (prefix/regex matching, or refusing to guess and returning `None`) would be a larger behavioural change, so I kept it out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
