### PR TITLE
fix(epub): preserve block attributes and strip markdown markers in Plain Text Mode

### DIFF
--- a/src/api/blueprints/sample_routes.py
+++ b/src/api/blueprints/sample_routes.py
@@ -124,7 +124,7 @@ def _extract_epub_text(file_path: str) -> str:
                      if isinstance(el.tag, str) and _local_name(el) == "body"),
                     root,
                 )
-                paragraphs, _tags, _images = extract_plain_paragraphs(body)
+                paragraphs, _tags, _images, _attrib = extract_plain_paragraphs(body)
                 for text in paragraphs:
                     text = (text or "").strip()
                     if text:

--- a/src/core/common/plain_text_pipeline.py
+++ b/src/core/common/plain_text_pipeline.py
@@ -27,7 +27,12 @@ from src.prompts.prompts import PLAIN_TEXT_EXPECTED_PARAGRAPHS_OPTION
 PARAGRAPH_SEPARATOR = "\n\n"
 _RESPLIT_REGEX = re.compile(r"\n{2,}")
 _MARKUP_TAG_REGEX = re.compile(r"</?[A-Za-z][A-Za-z0-9]*(?:\s[^<>]*?)?/?>")
-_MARKDOWN_HEADING_MARKER_REGEX = re.compile(r"^\s*(?:#{1,6}\s*)+")
+# A markdown heading marker at the START OF A PARAGRAPH: the blob is split on
+# blank lines, so \A or a blank-line separator is what anchors the match, and
+# the separator is put back by the replacement. Requiring at least one space
+# followed by a non-space keeps "#1 bestseller", "#MeToo" and a lone "#" out
+# of it, and keeps the paragraph count of the segment unchanged.
+_MARKDOWN_HEADING_MARKER_REGEX = re.compile(r"(\A|\n{2,})[ \t]*#{1,6}[ \t]+(?=\S)")
 
 
 def strip_hallucinated_markup(translated: str, source: str) -> str:
@@ -44,21 +49,25 @@ def strip_hallucinated_markup(translated: str, source: str) -> str:
     return _MARKUP_TAG_REGEX.sub("", translated)
 
 
-def strip_hallucinated_markdown_markers(translated: str) -> str:
-    """Remove leading markdown heading markers the model invented.
+def strip_hallucinated_markdown_markers(translated: str, source: str) -> str:
+    """Remove markdown heading markers the model invented in Plain Text Mode.
 
-    Dry Plain Text Mode sends the LLM a bare heading line like
-    "Chapter 6: Define Secrets and Clues" with no structure, and models
-    conditioned on markdown titles tend to echo "# " prefixes back. The
-    '#', '##', ... are content-adding noise, so drop them. A translation
-    that is a lone marker ("#") with no text is left as-is.
+    Plain Text Mode sends the LLM a bare heading line like "Chapter 6: Define
+    Secrets and Clues" with no structure, and models conditioned on markdown
+    titles tend to echo a "# " prefix back. The heading tag already carries the
+    structure, so the marker is content-adding noise.
+
+    Every paragraph of the blob is checked, not just the first: a segment holds
+    many paragraphs and the decorated one is rarely the leading one. Like
+    strip_hallucinated_markup, a source that legitimately uses the marker (a
+    markdown sample inside a <pre> block) disarms the whole thing rather than
+    risk damaging real content.
     """
-    if not translated:
+    if not translated or "#" not in translated:
         return translated
-    stripped = _MARKDOWN_HEADING_MARKER_REGEX.sub("", translated, count=1)
-    if not stripped:
+    if _MARKDOWN_HEADING_MARKER_REGEX.search(source or ""):
         return translated
-    return stripped
+    return _MARKDOWN_HEADING_MARKER_REGEX.sub(r"\1", translated)
 
 
 def _split_translated_back_to_paragraphs(translated_text: str) -> List[str]:
@@ -139,6 +148,7 @@ async def _retry_segment_with_paragraph_count(
 
     cleaned = clean_translated_text(answer)
     cleaned = strip_hallucinated_markup(cleaned, main_content)
+    cleaned = strip_hallucinated_markdown_markers(cleaned, main_content)
     if not cleaned.strip():
         return None
     if _paragraph_count_mismatch(cleaned, expected_count) is not None:
@@ -187,6 +197,7 @@ async def _repair_segment_by_paragraph(
         if translated:
             cleaned = clean_translated_text(translated)
             cleaned = strip_hallucinated_markup(cleaned, text)
+            cleaned = strip_hallucinated_markdown_markers(cleaned, text)
             # One paragraph in, one paragraph out, always: a model that split
             # this single paragraph would otherwise re-introduce the very
             # misalignment the repair exists to remove. Never recurse.
@@ -537,7 +548,8 @@ async def translate_paragraphs_plain(
                     cleaned = clean_translated_text(value)
                     cleaned = strip_hallucinated_markup(
                         cleaned, chunks[i].get('main_content', ''))
-                    cleaned = strip_hallucinated_markdown_markers(cleaned)
+                    cleaned = strip_hallucinated_markdown_markers(
+                        cleaned, chunks[i].get('main_content', ''))
                     translated_parts[i] = cleaned
                     stats.successful_first_try += 1
                     # A wrong paragraph count is reconciled silently at

--- a/src/core/common/plain_text_pipeline.py
+++ b/src/core/common/plain_text_pipeline.py
@@ -27,6 +27,7 @@ from src.prompts.prompts import PLAIN_TEXT_EXPECTED_PARAGRAPHS_OPTION
 PARAGRAPH_SEPARATOR = "\n\n"
 _RESPLIT_REGEX = re.compile(r"\n{2,}")
 _MARKUP_TAG_REGEX = re.compile(r"</?[A-Za-z][A-Za-z0-9]*(?:\s[^<>]*?)?/?>")
+_MARKDOWN_HEADING_MARKER_REGEX = re.compile(r"^\s*(?:#{1,6}\s*)+")
 
 
 def strip_hallucinated_markup(translated: str, source: str) -> str:
@@ -41,6 +42,23 @@ def strip_hallucinated_markup(translated: str, source: str) -> str:
     if "<" not in translated or "<" in source:
         return translated
     return _MARKUP_TAG_REGEX.sub("", translated)
+
+
+def strip_hallucinated_markdown_markers(translated: str) -> str:
+    """Remove leading markdown heading markers the model invented.
+
+    Dry Plain Text Mode sends the LLM a bare heading line like
+    "Chapter 6: Define Secrets and Clues" with no structure, and models
+    conditioned on markdown titles tend to echo "# " prefixes back. The
+    '#', '##', ... are content-adding noise, so drop them. A translation
+    that is a lone marker ("#") with no text is left as-is.
+    """
+    if not translated:
+        return translated
+    stripped = _MARKDOWN_HEADING_MARKER_REGEX.sub("", translated, count=1)
+    if not stripped:
+        return translated
+    return stripped
 
 
 def _split_translated_back_to_paragraphs(translated_text: str) -> List[str]:
@@ -519,6 +537,7 @@ async def translate_paragraphs_plain(
                     cleaned = clean_translated_text(value)
                     cleaned = strip_hallucinated_markup(
                         cleaned, chunks[i].get('main_content', ''))
+                    cleaned = strip_hallucinated_markdown_markers(cleaned)
                     translated_parts[i] = cleaned
                     stats.successful_first_try += 1
                     # A wrong paragraph count is reconciled silently at

--- a/src/core/epub/epub_translation_adapter.py
+++ b/src/core/epub/epub_translation_adapter.py
@@ -336,7 +336,7 @@ class EpubTranslationAdapter(TranslationAdapter[etree._Element, bool]):
                 log_callback("plain_text_no_body", f"⚠️ {file_href or 'document'}: no <body> found, skipping")
             return False, TranslationMetrics()
 
-        paragraphs_text, paragraphs_tag, images_by_paragraph = extract_plain_paragraphs(body)
+        paragraphs_text, paragraphs_tag, images_by_paragraph, paragraphs_attrib = extract_plain_paragraphs(body)
 
         if log_callback:
             log_callback(
@@ -395,6 +395,9 @@ class EpubTranslationAdapter(TranslationAdapter[etree._Element, bool]):
             # empty translation falls back to, so the paragraph survives instead
             # of being dropped. The bilingual flag only drives the interleaving.
             source_paragraphs=paragraphs_text,
+            # Carry each source block's attributes (class, id, xml:lang, ...)
+            # onto the rebuilt element instead of emitting a bare tag.
+            paragraphs_attrib=paragraphs_attrib,
         )
 
         return True, stats

--- a/src/core/epub/plain_extractor.py
+++ b/src/core/epub/plain_extractor.py
@@ -393,6 +393,11 @@ def replace_body_with_paragraphs(
                 _add_class(block, "plain-text-untranslated")
             elif bilingual:
                 _add_class(block, "plain-text-target")
+            # A model trained on markdown sometimes decorates a bare heading
+            # line with "# " prefixes in Plain Text Mode (e.g. "# Chapter 6").
+            # The heading tag already gives the structure, so drop the markers.
+            if raw_tag in ("h1", "h2", "h3", "h4", "h5", "h6") and text.startswith("#"):
+                text = text.lstrip("#").strip()
             block.text = text or source_text
 
         # Emit anchored images right after

--- a/src/core/epub/plain_extractor.py
+++ b/src/core/epub/plain_extractor.py
@@ -10,10 +10,13 @@ its base: it is folded into base（reading） first (see ruby_annotations).
 At rebuild time, the body is wiped and reconstructed as a flat sequence of
 block elements (<p>, <h1..h6>, <li>, <blockquote>, <pre>) plus, after each
 block that originally contained images, an extra <p class="plain-text-images"> wrapper
-with the original <img> elements unchanged. Void blocks (<hr>) carry no text
-and no images: they keep their own slot in the paragraph list and are
-re-emitted as a bare element at the same position, without ever reaching the
-LLM. The one case where the body is left alone is a page that yielded no
+with the original <img> elements unchanged. Each block element is rebuilt with
+its original tag *and its original attributes* (class, id, xml:lang, epub:type,
+title, ...) carried across, so semantic attributes survive translation even
+though the tag's inline children are flattened to text. Void blocks (<hr>)
+carry no text and no images: they keep their own slot in the paragraph list and
+are re-emitted as a bare element at the same position, without ever reaching
+the LLM. The one case where the body is left alone is a page that yielded no
 block at all (everything inside a DROP_TAGS subtree, e.g. an SVG-wrapped
 cover): its source markup is kept verbatim.
 """
@@ -108,6 +111,18 @@ def _clone_img(img: etree._Element) -> etree._Element:
     return new
 
 
+def _set_attributes(elem: etree._Element, attrib: Dict[str, str]) -> None:
+    """Copy recorded source attributes (including namespaced epub:type, xml:lang) onto a rebuilt element."""
+    for k, v in (attrib or {}).items():
+        elem.set(k, v)
+
+
+def _add_class(elem: etree._Element, cls: str) -> None:
+    """Append a plain-text marker class to an element, preserving any source class."""
+    existing = elem.get("class")
+    elem.set("class", f"{existing} {cls}".strip() if existing else cls)
+
+
 def _enclosing_table(elem: etree._Element) -> etree._Element:
     """Return the nearest <table> ancestor, or None."""
     parent = elem.getparent()
@@ -122,6 +137,7 @@ def _collect_table_blocks(
     table: etree._Element,
     paragraphs_text: List[str],
     paragraphs_tag: List[str],
+    paragraphs_attrib: List[Dict[str, str]],
     images_by_paragraph: Dict[int, List[etree._Element]],
 ) -> None:
     """
@@ -143,6 +159,7 @@ def _collect_table_blocks(
             idx = len(paragraphs_text)
             paragraphs_text.append(text)
             paragraphs_tag.append("p")
+            paragraphs_attrib.append(dict(elem.attrib))
             if images:
                 images_by_paragraph[idx] = images
 
@@ -151,6 +168,7 @@ def _collect_blocks(
     root: etree._Element,
     paragraphs_text: List[str],
     paragraphs_tag: List[str],
+    paragraphs_attrib: List[Dict[str, str]],
     images_by_paragraph: Dict[int, List[etree._Element]],
 ) -> None:
     """
@@ -168,18 +186,21 @@ def _collect_blocks(
         if name in VOID_BLOCK_TAGS:
             paragraphs_text.append("")
             paragraphs_tag.append(name)
+            paragraphs_attrib.append(dict(child.attrib))
             continue
 
         if name == "table":
-            _collect_table_blocks(child, paragraphs_text, paragraphs_tag, images_by_paragraph)
+            _collect_table_blocks(
+                child, paragraphs_text, paragraphs_tag, paragraphs_attrib, images_by_paragraph
+            )
             continue
 
         if name in LIST_WRAPPER_TAGS:
-            _collect_blocks(child, paragraphs_text, paragraphs_tag, images_by_paragraph)
+            _collect_blocks(child, paragraphs_text, paragraphs_tag, paragraphs_attrib, images_by_paragraph)
             continue
 
         if name in CONTAINER_TAGS:
-            _collect_blocks(child, paragraphs_text, paragraphs_tag, images_by_paragraph)
+            _collect_blocks(child, paragraphs_text, paragraphs_tag, paragraphs_attrib, images_by_paragraph)
             continue
 
         if name in BLOCK_TAGS:
@@ -193,6 +214,7 @@ def _collect_blocks(
             idx = len(paragraphs_text)
             paragraphs_text.append(text)
             paragraphs_tag.append(name)
+            paragraphs_attrib.append(dict(child.attrib))
             if images:
                 images_by_paragraph[idx] = images
             continue
@@ -207,6 +229,7 @@ def _collect_blocks(
             else:
                 paragraphs_text.append("")
                 paragraphs_tag.append("p")
+                paragraphs_attrib.append({})
                 images_by_paragraph[0] = [img_copy]
             continue
 
@@ -217,13 +240,14 @@ def _collect_blocks(
             idx = len(paragraphs_text)
             paragraphs_text.append(text)
             paragraphs_tag.append("p")
+            paragraphs_attrib.append(dict(child.attrib))
             if images:
                 images_by_paragraph[idx] = images
 
 
 def extract_plain_paragraphs(
     body_element: etree._Element,
-) -> Tuple[List[str], List[str], Dict[int, List[etree._Element]]]:
+) -> Tuple[List[str], List[str], Dict[int, List[etree._Element]], List[Dict[str, str]]]:
     """
     Extract the body as a flat list of (text, tag) pairs plus an image anchor map.
 
@@ -234,20 +258,24 @@ def extract_plain_paragraphs(
         paragraphs_text:        list of plain-text strings, one per block
         paragraphs_tag:         parallel list of tag names ("p", "h1", "li", ...)
         images_by_paragraph:    {paragraph_index: [<img> elements]}
+        paragraphs_attrib:      parallel list of attribute dicts, one per block
     """
     paragraphs_text: List[str] = []
     paragraphs_tag: List[str] = []
+    paragraphs_attrib: List[Dict[str, str]] = []
     images_by_paragraph: Dict[int, List[etree._Element]] = {}
 
     if body_element is None:
-        return paragraphs_text, paragraphs_tag, images_by_paragraph
+        return paragraphs_text, paragraphs_tag, images_by_paragraph, paragraphs_attrib
 
     # Fold <ruby> annotations first, otherwise flattening would glue the base
     # and its reading into a word that does not exist (issue #242).
     fold_ruby_annotations(body_element)
 
-    _collect_blocks(body_element, paragraphs_text, paragraphs_tag, images_by_paragraph)
-    return paragraphs_text, paragraphs_tag, images_by_paragraph
+    _collect_blocks(
+        body_element, paragraphs_text, paragraphs_tag, paragraphs_attrib, images_by_paragraph
+    )
+    return paragraphs_text, paragraphs_tag, images_by_paragraph, paragraphs_attrib
 
 
 def replace_body_with_paragraphs(
@@ -257,6 +285,7 @@ def replace_body_with_paragraphs(
     images_by_paragraph: Dict[int, List[etree._Element]],
     bilingual: bool = False,
     source_paragraphs: List[str] = None,
+    paragraphs_attrib: List[Dict[str, str]] = None,
 ) -> None:
     """
     Wipe body_element and refill it from the translated paragraphs.
@@ -273,6 +302,11 @@ def replace_body_with_paragraphs(
                    what an empty translation falls back to instead of the block
                    being dropped. Legacy callers that omit it still get an
                    empty block rather than a deletion.
+        paragraphs_attrib: attribute dict per paragraph, captured from the source
+                   block at extraction time. When provided, each rebuilt block
+                   keeps its source attributes (class, id, xml:lang, epub:type,
+                   ...); marker classes are appended to, never replacing, a
+                   source class.
     """
     count = len(translated_paragraphs)
 
@@ -301,16 +335,19 @@ def replace_body_with_paragraphs(
         raw_tag = paragraphs_tag[i] if i < len(paragraphs_tag) else "p"
         # <li> outside <ul>/<ol> is not valid XHTML — flatten to <p> in Plain Text Mode.
         tag = "p" if raw_tag == "li" else raw_tag
+        attrib = paragraphs_attrib[i] if paragraphs_attrib and i < len(paragraphs_attrib) else {}
 
         if raw_tag in VOID_BLOCK_TAGS:
-            etree.SubElement(body_element, raw_tag)
+            block = etree.SubElement(body_element, raw_tag)
+            _set_attributes(block, attrib)
             continue
 
         # Bilingual: emit source first when we have it
         source_emitted = False
         if bilingual and source_text:
             src_block = etree.SubElement(body_element, tag)
-            src_block.set("class", "plain-text-source")
+            _set_attributes(src_block, attrib)
+            _add_class(src_block, "plain-text-source")
             src_block.text = source_text
             source_emitted = True
 
@@ -348,13 +385,14 @@ def replace_body_with_paragraphs(
 
         if emit_target:
             block = etree.SubElement(body_element, tag)
+            _set_attributes(block, attrib)
             if untranslated:
-                # Replaces plain-text-target rather than adding to it: a block
-                # carries one class, and "this is still source text" is the more
-                # important of the two.
-                block.set("class", "plain-text-untranslated")
+                # One marker per block, untranslated over bilingual-target when
+                # both apply; either is appended to the source class, which the
+                # _set_attributes call above already restored.
+                _add_class(block, "plain-text-untranslated")
             elif bilingual:
-                block.set("class", "plain-text-target")
+                _add_class(block, "plain-text-target")
             block.text = text or source_text
 
         # Emit anchored images right after

--- a/src/core/epub/plain_extractor.py
+++ b/src/core/epub/plain_extractor.py
@@ -11,9 +11,10 @@ At rebuild time, the body is wiped and reconstructed as a flat sequence of
 block elements (<p>, <h1..h6>, <li>, <blockquote>, <pre>) plus, after each
 block that originally contained images, an extra <p class="plain-text-images"> wrapper
 with the original <img> elements unchanged. Each block element is rebuilt with
-its original tag *and its original attributes* (class, id, xml:lang, epub:type,
-title, ...) carried across, so semantic attributes survive translation even
-though the tag's inline children are flattened to text. Void blocks (<hr>)
+its original tag *and the source attributes that still apply to a flattened
+block* (class, id, style, dir, title, epub:type), so semantic attributes
+survive translation even though the tag's inline children are flattened to
+text — see CARRIED_ATTRIBUTES for what is copied and why. Void blocks (<hr>)
 carry no text and no images: they keep their own slot in the paragraph list and
 are re-emitted as a bare element at the same position, without ever reaching
 the LLM. The one case where the body is left alone is a page that yielded no
@@ -46,6 +47,17 @@ SPACED_TAGS = ("td", "th", "tr", "caption")
 TABLE_CELL_TAGS = ("td", "th", "caption")
 # List wrappers we descend into (the inner <li> items become individual blocks)
 LIST_WRAPPER_TAGS = ("ul", "ol")
+EPUB_TYPE_ATTR = "{http://www.idpf.org/2007/ops}type"
+# Source attributes copied onto a rebuilt block. The list is a whitelist rather
+# than "everything the source block had" for two reasons:
+#   * Plain Text Mode flattens <li>, <td>, <th> and unknown blocks into <p>, so
+#     a tag-specific attribute (colspan, rowspan, scope, headers, value) would
+#     land on an element that cannot legally carry it and epubcheck rejects it.
+#   * `lang` / `xml:lang` describe the SOURCE language. Copied onto translated
+#     text they would override the target language that lang_support writes on
+#     <html>, and a reading system would hand a French paragraph to an English
+#     speech engine. Dropping them lets the block inherit the correct root lang.
+CARRIED_ATTRIBUTES = ("class", "id", "style", "dir", "title", EPUB_TYPE_ATTR)
 
 
 def _local_name(elem: etree._Element) -> str:
@@ -111,10 +123,21 @@ def _clone_img(img: etree._Element) -> etree._Element:
     return new
 
 
-def _set_attributes(elem: etree._Element, attrib: Dict[str, str]) -> None:
-    """Copy recorded source attributes (including namespaced epub:type, xml:lang) onto a rebuilt element."""
-    for k, v in (attrib or {}).items():
-        elem.set(k, v)
+def _set_attributes(
+    elem: etree._Element, attrib: Dict[str, str], with_id: bool = True
+) -> None:
+    """Copy the carried source attributes (see CARRIED_ATTRIBUTES) onto a rebuilt element.
+
+    with_id=False leaves `id` behind: bilingual mode emits two elements for one
+    source block, and duplicating the id there would produce invalid XHTML and
+    an ambiguous target for every TOC anchor pointing at it.
+    """
+    for key in CARRIED_ATTRIBUTES:
+        if key == "id" and not with_id:
+            continue
+        value = (attrib or {}).get(key)
+        if value is not None:
+            elem.set(key, value)
 
 
 def _add_class(elem: etree._Element, cls: str) -> None:
@@ -304,9 +327,10 @@ def replace_body_with_paragraphs(
                    empty block rather than a deletion.
         paragraphs_attrib: attribute dict per paragraph, captured from the source
                    block at extraction time. When provided, each rebuilt block
-                   keeps its source attributes (class, id, xml:lang, epub:type,
-                   ...); marker classes are appended to, never replacing, a
-                   source class.
+                   keeps the subset of them that still applies once the block is
+                   flattened (CARRIED_ATTRIBUTES); marker classes are appended
+                   to, never replacing, a source class, and `id` is emitted once
+                   per source block even in bilingual mode.
     """
     count = len(translated_paragraphs)
 
@@ -385,7 +409,10 @@ def replace_body_with_paragraphs(
 
         if emit_target:
             block = etree.SubElement(body_element, tag)
-            _set_attributes(block, attrib)
+            # The bilingual source twin, when there is one, already claimed the
+            # source id: it comes first in reading order, so an anchor aimed at
+            # this block still lands at the top of the right section.
+            _set_attributes(block, attrib, with_id=not source_emitted)
             if untranslated:
                 # One marker per block, untranslated over bilingual-target when
                 # both apply; either is appended to the source class, which the
@@ -393,11 +420,6 @@ def replace_body_with_paragraphs(
                 _add_class(block, "plain-text-untranslated")
             elif bilingual:
                 _add_class(block, "plain-text-target")
-            # A model trained on markdown sometimes decorates a bare heading
-            # line with "# " prefixes in Plain Text Mode (e.g. "# Chapter 6").
-            # The heading tag already gives the structure, so drop the markers.
-            if raw_tag in ("h1", "h2", "h3", "h4", "h5", "h6") and text.startswith("#"):
-                text = text.lstrip("#").strip()
             block.text = text or source_text
 
         # Emit anchored images right after

--- a/src/core/epub/translator.py
+++ b/src/core/epub/translator.py
@@ -899,7 +899,7 @@ def _precount_chunks_plain_text(doc_root, max_tokens_per_chunk: int) -> int:
         if body is None:
             return 0
 
-        paragraphs, _, _ = extract_plain_paragraphs(body)
+        paragraphs, _, _, _ = extract_plain_paragraphs(body)
         if not paragraphs:
             return 0
 

--- a/src/prompts/prompts.py
+++ b/src/prompts/prompts.py
@@ -87,6 +87,8 @@ _PLAIN_TEXT_FORMAT_RULES = (
     "\n8. Separate every output paragraph with ONE BLANK LINE - never a single newline"
     "\n9. Do NOT merge two paragraphs into one, and do NOT split one paragraph into two"
     "\n10. An empty input paragraph stays empty - do not fill it"
+    "\n11. Do NOT add markdown heading markers (#, ##, ###, etc.) or any other "
+    "markdown formatting symbols to your output - output plain translated text only"
 )
 
 # prompt_options key carrying the paragraph count of the segment being retried.
@@ -109,10 +111,10 @@ def _plain_text_format_rules(prompt_options: Optional[Dict[str, Any]] = None) ->
     if not isinstance(expected, int) or isinstance(expected, bool) or expected < 1:
         return _PLAIN_TEXT_FORMAT_RULES
     return _PLAIN_TEXT_FORMAT_RULES + (
-        "\n11. RETRY: your previous answer for this exact text had the WRONG number of paragraphs"
-        f"\n12. This input contains EXACTLY {expected} paragraph(s); your output MUST contain "
+        "\n12. RETRY: your previous answer for this exact text had the WRONG number of paragraphs"
+        f"\n13. This input contains EXACTLY {expected} paragraph(s); your output MUST contain "
         f"EXACTLY {expected} paragraph(s), separated by ONE BLANK LINE"
-        "\n13. Count the paragraphs before answering. A disclaimer, an author's note, a chapter "
+        "\n14. Count the paragraphs before answering. A disclaimer, an author's note, a chapter "
         "heading or any short standalone line IS a paragraph and IS content: translate each one "
         "as its own paragraph - never drop it, never fold it into the next one, never summarize it"
     )

--- a/tests/unit/epub/test_heading_attribute_preservation.py
+++ b/tests/unit/epub/test_heading_attribute_preservation.py
@@ -13,8 +13,10 @@ assertions describe production behaviour:
   * Plain Text Mode (`prompt_options['plain_text_mode']`) PRESERVES the
     attribute. `plain_extractor.extract_plain_paragraphs` records each block's
     tag NAME *and* attributes, and `replace_body_with_paragraphs` carries the
-    attributes onto the rebuilt element (see plain_extractor.py). This is the
-    regression test below.
+    whitelisted ones (`plain_extractor.CARRIED_ATTRIBUTES`, `class` included)
+    onto the rebuilt element. This is the regression test below; which
+    attributes are carried and which are deliberately dropped is pinned by
+    test_plain_text_attribute_policy.py.
 
   * The placeholder path (the default) PRESERVES the attribute, both when the
     model echoes the placeholders and when it emits literal HTML tags instead

--- a/tests/unit/epub/test_heading_attribute_preservation.py
+++ b/tests/unit/epub/test_heading_attribute_preservation.py
@@ -4,25 +4,24 @@ Finding F3 of `plan/PLAN_CjkSourceRendering.md` measured
 `LOST ATTRS: {('h3','class'): 28}` over a real Chinese -> French EPUB: every
 translated `<h3 class="head">` came out as a bare `<h3>`.
 
-These tests localize the loss. Both translation paths of the EPUB pipeline are
-exercised on the same body HTML, with an LLM client stubbed at the transport
-level only (`generate` / `extract_translation`); every module under test is the
-real one, so the assertions describe production behaviour:
+These tests localize the loss (and its opposite, the preservation controls).
+Both translation paths of the EPUB pipeline are exercised on the same body
+HTML, with an LLM client stubbed at the transport level only (`generate` /
+`extract_translation`); every module under test is the real one, so the
+assertions describe production behaviour:
 
-  * Plain Text Mode (`prompt_options['plain_text_mode']`) LOSES the attribute.
-    `plain_extractor.extract_plain_paragraphs` records only a block's tag NAME,
-    and `replace_body_with_paragraphs` rebuilds each block with
-    `etree.SubElement(body, tag)` — no attribute is ever carried across. This
-    is the xfail below; see plan/PLAN_CjkSourceRendering.md section 5.1.
+  * Plain Text Mode (`prompt_options['plain_text_mode']`) PRESERVES the
+    attribute. `plain_extractor.extract_plain_paragraphs` records each block's
+    tag NAME *and* attributes, and `replace_body_with_paragraphs` carries the
+    attributes onto the rebuilt element (see plain_extractor.py). This is the
+    regression test below.
 
   * The placeholder path (the default) PRESERVES the attribute, both when the
     model echoes the placeholders and when it emits literal HTML tags instead
     and the token-alignment fallback has to repair the chunk. Those two are
-    passing controls, and they pin the loss to Plain Text Mode rather than to
-    `TagPreserver`, `PlaceholderRenumberer`, `TokenAlignmentFallback` or the
-    entity-escaping step of `_reconstruct_html`.
-
-No production code is fixed here: Phase 2 of the plan is diagnosis only.
+    passing controls, and they pin any future loss to Plain Text Mode rather
+    than to `TagPreserver`, `PlaceholderRenumberer`, `TokenAlignmentFallback`
+    or the entity-escaping step of `_reconstruct_html`.
 """
 import re
 from typing import List
@@ -211,19 +210,9 @@ async def test_placeholder_path_preserves_heading_class_when_model_emits_literal
     assert _heading_open_tags(doc_root) == ['<h3 class="head">']
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "F3 (plan/PLAN_CjkSourceRendering.md section 5.1): Plain Text Mode "
-        "rebuilds every block with etree.SubElement(body, tag) at "
-        "plain_extractor.py:281, so no source attribute is carried over and "
-        "class=\"head\" is dropped from every heading. Diagnosis-only phase: "
-        "the fix is a maintainer decision, so this stays xfail until it lands."
-    ),
-)
 @pytest.mark.asyncio
 async def test_plain_text_mode_preserves_heading_class():
-    """Reproduces F3: Plain Text Mode drops `class="head"` from the heading."""
+    """Regression: Plain Text Mode keeps `class="head"` on the translated heading."""
     doc_root = _parse_doc()
     client = EchoPlaceholdersClient()
     adapter = EpubTranslationAdapter()

--- a/tests/unit/epub/test_issue_207_content_loss.py
+++ b/tests/unit/epub/test_issue_207_content_loss.py
@@ -171,7 +171,7 @@ class TestPlainModeTables:
             "<tr><td>Paris</td><td>2.1 million</td></tr>"
             "</table>"
         )
-        paragraphs, _, _ = extract_plain_paragraphs(body)
+        paragraphs, _, _, _ = extract_plain_paragraphs(body)
         joined = " ".join(paragraphs)
 
         assert "Paris" in joined, "table cell text was deleted"
@@ -183,7 +183,7 @@ class TestPlainModeTables:
             "<p>Intro.</p>"
             "<table><tr><td>Cell text</td></tr></table>"
         )
-        paragraphs, tags, images = extract_plain_paragraphs(body)
+        paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
         replace_body_with_paragraphs(body, paragraphs, tags, images)
 
         rebuilt_text = " ".join("".join(body.itertext()).split())
@@ -197,7 +197,7 @@ class TestPlainModeFigures:
             '<figure><img src="images/map.png" alt="Map"/>'
             "<figcaption>A map of the region</figcaption></figure>"
         )
-        paragraphs, tags, images_by_paragraph = extract_plain_paragraphs(body)
+        paragraphs, tags, images_by_paragraph, _attrib = extract_plain_paragraphs(body)
 
         anchored = [img for imgs in images_by_paragraph.values() for img in imgs]
         assert any(
@@ -208,7 +208,7 @@ class TestPlainModeFigures:
         body = _parse_body(
             '<figure><img src="x.png"/><figcaption>The caption</figcaption></figure>'
         )
-        paragraphs, _, _ = extract_plain_paragraphs(body)
+        paragraphs, _, _, _ = extract_plain_paragraphs(body)
         assert "The caption" in " ".join(paragraphs)
 
     def test_picture_wrapped_image_is_anchored(self):
@@ -216,7 +216,7 @@ class TestPlainModeFigures:
             "<p>Some text.</p>"
             '<picture><source srcset="big.webp"/><img src="fallback.jpg"/></picture>'
         )
-        _, _, images_by_paragraph = extract_plain_paragraphs(body)
+        _, _, images_by_paragraph, _attrib = extract_plain_paragraphs(body)
 
         anchored = [img for imgs in images_by_paragraph.values() for img in imgs]
         assert any(img.get("src") == "fallback.jpg" for img in anchored)
@@ -225,7 +225,7 @@ class TestPlainModeFigures:
         body = _parse_body(
             '<p>Text around <figure><img src="inline.png"/></figure> an inline figure.</p>'
         )
-        _, _, images_by_paragraph = extract_plain_paragraphs(body)
+        _, _, images_by_paragraph, _attrib = extract_plain_paragraphs(body)
 
         anchored = [img for imgs in images_by_paragraph.values() for img in imgs]
         assert any(img.get("src") == "inline.png" for img in anchored)
@@ -235,7 +235,7 @@ class TestPlainModeFigures:
             "<p>Para.</p>"
             '<figure><img src="kept.png"/><figcaption>Cap</figcaption></figure>'
         )
-        paragraphs, tags, images = extract_plain_paragraphs(body)
+        paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
         replace_body_with_paragraphs(body, paragraphs, tags, images)
 
         srcs = [img.get("src") for img in _all_imgs(body)]
@@ -244,7 +244,7 @@ class TestPlainModeFigures:
     def test_standalone_image_still_anchored(self):
         # Pre-existing behavior that must not regress.
         body = _parse_body('<p>Hello.</p><img src="standalone.png"/>')
-        _, _, images_by_paragraph = extract_plain_paragraphs(body)
+        _, _, images_by_paragraph, _attrib = extract_plain_paragraphs(body)
 
         anchored = [img for imgs in images_by_paragraph.values() for img in imgs]
         assert any(img.get("src") == "standalone.png" for img in anchored)
@@ -254,7 +254,7 @@ class TestPlainModeFigures:
         body = _parse_body(
             "<p>Text.</p><svg xmlns='http://www.w3.org/2000/svg'><text>chart</text></svg>"
         )
-        paragraphs, _, images_by_paragraph = extract_plain_paragraphs(body)
+        paragraphs, _, images_by_paragraph, _attrib = extract_plain_paragraphs(body)
         assert "chart" not in " ".join(paragraphs)
         assert not images_by_paragraph
 
@@ -292,7 +292,7 @@ class TestWeakLlmSafety:
         monkeypatch.setattr(plain_pipeline, "clean_translated_text", lambda s: s)
 
         body = _parse_body(self.BODY_INNER)
-        paragraphs, _, _ = extract_plain_paragraphs(body)
+        paragraphs, _, _, _ = extract_plain_paragraphs(body)
         await plain_pipeline.translate_paragraphs_plain(
             paragraphs=paragraphs,
             source_language="English",
@@ -327,7 +327,7 @@ class TestWeakLlmSafety:
         monkeypatch.setattr(plain_pipeline, "clean_translated_text", lambda s: s)
 
         body = _parse_body(self.BODY_INNER)
-        paragraphs, tags, images = extract_plain_paragraphs(body)
+        paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
         translated, _, interrupted = await plain_pipeline.translate_paragraphs_plain(
             paragraphs=paragraphs,
             source_language="English",
@@ -429,7 +429,7 @@ class TestPlainModeCoverPage:
         body = _parse_body(SVG_COVER_BODY)
         before = etree.tostring(body, encoding="unicode")
 
-        paragraphs, tags, images = extract_plain_paragraphs(body)
+        paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
         assert paragraphs == [] and images == {}, (
             "precondition: the SVG subtree yields no translatable paragraph"
         )
@@ -445,7 +445,7 @@ class TestPlainModeCoverPage:
 
     def test_already_empty_body_stays_a_no_op(self):
         body = _parse_body("")
-        paragraphs, tags, images = extract_plain_paragraphs(body)
+        paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
         replace_body_with_paragraphs(body, paragraphs, tags, images)
 
         assert len(body) == 0
@@ -488,7 +488,7 @@ class TestPlainModeEmptyTranslation:
 
     def test_empty_translation_falls_back_to_the_source_text(self):
         body = _parse_body("<p>A paragraph the model returned nothing for.</p>")
-        paragraphs, tags, images = extract_plain_paragraphs(body)
+        paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
         replace_body_with_paragraphs(
             body, [""], tags, images, source_paragraphs=paragraphs
         )
@@ -502,7 +502,7 @@ class TestPlainModeEmptyTranslation:
         body = _parse_body("<p>First.</p><p></p><p>Second.</p>")
         input_p_count = _count_p(body)
 
-        paragraphs, tags, images = extract_plain_paragraphs(body)
+        paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
         replace_body_with_paragraphs(
             body, list(paragraphs), tags, images, source_paragraphs=paragraphs
         )
@@ -511,7 +511,7 @@ class TestPlainModeEmptyTranslation:
 
     def test_bilingual_empty_translation_emits_the_source_once(self):
         body = _parse_body("<p>Le texte source.</p>")
-        paragraphs, tags, images = extract_plain_paragraphs(body)
+        paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
         replace_body_with_paragraphs(
             body, [""], tags, images, bilingual=True, source_paragraphs=paragraphs
         )
@@ -526,7 +526,7 @@ class TestPlainModeEmptyTranslation:
         # Callers predating the source-text fallback pass no source_paragraphs.
         # An empty translation must still emit an (empty) block, not nothing.
         body = _parse_body("<p>Original.</p>")
-        _, tags, images = extract_plain_paragraphs(body)
+        _, tags, images, _attrib = extract_plain_paragraphs(body)
         replace_body_with_paragraphs(body, [""], tags, images)
 
         assert _count_p(body) == 1
@@ -537,7 +537,7 @@ class TestPlainModeEmptyTranslation:
         # stands in for the block, so a source <p><img/></p> comes out as one
         # <p>, not two.
         body = _parse_body('<p><img src="x.jpg"/></p>')
-        paragraphs, tags, images = extract_plain_paragraphs(body)
+        paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
         replace_body_with_paragraphs(
             body, list(paragraphs), tags, images, source_paragraphs=paragraphs
         )

--- a/tests/unit/epub/test_issue_207_content_loss.py
+++ b/tests/unit/epub/test_issue_207_content_loss.py
@@ -15,6 +15,7 @@ D. Plain Text Mode must not empty a body whose whole content sits inside a
    its §5.1: `replace_body_with_paragraphs` rebuilding the body from scratch.
 """
 import os
+import re
 import tempfile
 
 import pytest
@@ -396,27 +397,132 @@ class TestWeakLlmSafety:
 
     def test_markdown_marker_stripping_removes_heading_hashes(self):
         from src.core.common.plain_text_pipeline import (
-            strip_hallucinated_markdown_markers,
+            strip_hallucinated_markdown_markers as strip_markers,
         )
 
         # A heading line the model decorated with "# " in Plain Text Mode:
         # the marker goes away, the translation stays.
-        assert strip_hallucinated_markdown_markers(
-            "# บทที่ 6: การกำหนดความลับและเบาะแส"
-        ) == "บทที่ 6: การกำหนดความลับและเบาะแส"
-        assert strip_hallucinated_markdown_markers(
-            "## Chapter 6"
-        ) == "Chapter 6"
+        assert strip_markers(
+            "# บทที่ 6", "Chapter 6"
+        ) == "บทที่ 6"
+        assert strip_markers("## Chapter 6", "Chapter 6") == "Chapter 6"
         # Leading whitespace before the marker must still be caught.
-        assert strip_hallucinated_markdown_markers(
-            "   ### Chapitre 6"
-        ) == "Chapitre 6"
-        # A lone "#" with no following text is not a heading marker - keep it.
-        assert strip_hallucinated_markdown_markers("#") == "#"
+        assert strip_markers("   ### Chapitre 6", "Chapter 6") == "Chapitre 6"
         # Plain paragraphs with no marker are untouched.
-        assert strip_hallucinated_markdown_markers(
-            "Un paragraphe normal."
+        assert strip_markers(
+            "Un paragraphe normal.", "A normal paragraph."
         ) == "Un paragraphe normal."
+
+    def test_markdown_marker_stripping_spares_hashes_that_are_content(self):
+        from src.core.common.plain_text_pipeline import (
+            strip_hallucinated_markdown_markers as strip_markers,
+        )
+
+        # A marker is "#" x1-6 FOLLOWED BY A SPACE. Without the space the hash
+        # is part of the word and dropping it would eat real content.
+        assert strip_markers("#1 des ventes", "#1 bestseller") == "#1 des ventes"
+        assert strip_markers("#MeToo, la suite", "#MeToo, after") == "#MeToo, la suite"
+        # A lone "#" is not a heading marker - keep it.
+        assert strip_markers("#", "#") == "#"
+        # A source that uses the marker itself (a markdown sample in a <pre>)
+        # disarms the strip entirely, exactly like strip_hallucinated_markup.
+        assert strip_markers("# Titre", "# Heading") == "# Titre"
+
+    def test_markdown_marker_stripping_keeps_the_paragraph_count(self):
+        from src.core.common.plain_text_pipeline import (
+            _split_translated_back_to_paragraphs,
+            strip_hallucinated_markdown_markers as strip_markers,
+        )
+
+        sep = "\n\n"
+
+        # Every paragraph of a segment is checked, not just the first one.
+        translated = sep.join(["# Titre un", "Texte.", "## Titre deux"])
+        source = sep.join(["Heading one", "Text.", "Heading two"])
+        assert strip_markers(translated, source) == sep.join(
+            ["Titre un", "Texte.", "Titre deux"]
+        )
+
+        # A paragraph made of a lone "#" must not be swallowed together with
+        # the blank line that follows it: the segment still has 3 paragraphs,
+        # otherwise the count contract with the segment would break.
+        blob = sep.join(["#", "Deuxieme.", "Troisieme."])
+        out = strip_markers(blob, sep.join(["A", "B", "C"]))
+        assert len(_split_translated_back_to_paragraphs(out)) == len(
+            _split_translated_back_to_paragraphs(blob)
+        ) == 3
+
+    @pytest.mark.asyncio
+    async def test_markers_are_stripped_wherever_they_land_in_a_segment(
+        self, monkeypatch
+    ):
+        """A marker on any paragraph of a segment, not just the leading one."""
+        import src.core.common.plain_text_pipeline as plain_pipeline
+
+        async def decorating_llm(*, main_content, **kwargs):
+            paragraphs = re.split(r"\n{2,}", main_content)
+            # The model decorates the LAST paragraph: a strip anchored on the
+            # start of the blob would miss it.
+            return "\n\n".join(
+                f"# T::{p}" if i == len(paragraphs) - 1 else f"T::{p}"
+                for i, p in enumerate(paragraphs)
+            )
+
+        monkeypatch.setattr(
+            plain_pipeline, "generate_translation_request", decorating_llm
+        )
+        monkeypatch.setattr(plain_pipeline, "clean_translated_text", lambda s: s)
+
+        translated, stats, interrupted = await plain_pipeline.translate_paragraphs_plain(
+            paragraphs=["Chapter One", "Intro paragraph.", "Closing paragraph."],
+            source_language="English",
+            target_language="French",
+            model_name="m",
+            llm_client=object(),
+            max_tokens_per_chunk=1000,
+        )
+
+        assert not interrupted
+        # The "T::" prefix is what tells a real translation apart from a chunk
+        # that failed and kept its source text.
+        assert stats.failed_chunks == 0
+        assert translated == [
+            "T::Chapter One", "T::Intro paragraph.", "T::Closing paragraph."
+        ]
+
+    @pytest.mark.asyncio
+    async def test_markers_are_stripped_on_the_repair_path_too(self, monkeypatch):
+        """The per-paragraph repair goes through the same cleaning as a first pass."""
+        import src.core.common.plain_text_pipeline as plain_pipeline
+
+        async def merging_then_decorating_llm(*, main_content, **kwargs):
+            paragraphs = [
+                p.strip() for p in re.split(r"\n{2,}", main_content) if p.strip()
+            ]
+            if len(paragraphs) > 1:
+                # Merges whatever it is asked, count hint included: the segment
+                # retry cannot recover, so the per-paragraph repair runs.
+                return " ".join(paragraphs)
+            return f"## T::{paragraphs[0]}"
+
+        monkeypatch.setattr(
+            plain_pipeline, "generate_translation_request", merging_then_decorating_llm
+        )
+        monkeypatch.setattr(plain_pipeline, "clean_translated_text", lambda s: s)
+
+        translated, stats, interrupted = await plain_pipeline.translate_paragraphs_plain(
+            paragraphs=["Chapter One", "Intro paragraph."],
+            source_language="English",
+            target_language="French",
+            model_name="m",
+            llm_client=object(),
+            max_tokens_per_chunk=1000,
+        )
+
+        assert not interrupted
+        assert stats.paragraph_count_mismatches == 1, "precondition: the repair ran"
+        assert stats.failed_chunks == 0
+        assert translated == ["T::Chapter One", "T::Intro paragraph."]
 
 
 # === D. Plain Text Mode: the rebuild must never lose content ===

--- a/tests/unit/epub/test_issue_207_content_loss.py
+++ b/tests/unit/epub/test_issue_207_content_loss.py
@@ -394,6 +394,30 @@ class TestWeakLlmSafety:
             "Le 1<sup>er</sup> chapitre<br/>", "The 1st chapter"
         ) == "Le 1er chapitre"
 
+    def test_markdown_marker_stripping_removes_heading_hashes(self):
+        from src.core.common.plain_text_pipeline import (
+            strip_hallucinated_markdown_markers,
+        )
+
+        # A heading line the model decorated with "# " in Plain Text Mode:
+        # the marker goes away, the translation stays.
+        assert strip_hallucinated_markdown_markers(
+            "# บทที่ 6: การกำหนดความลับและเบาะแส"
+        ) == "บทที่ 6: การกำหนดความลับและเบาะแส"
+        assert strip_hallucinated_markdown_markers(
+            "## Chapter 6"
+        ) == "Chapter 6"
+        # Leading whitespace before the marker must still be caught.
+        assert strip_hallucinated_markdown_markers(
+            "   ### Chapitre 6"
+        ) == "Chapitre 6"
+        # A lone "#" with no following text is not a heading marker - keep it.
+        assert strip_hallucinated_markdown_markers("#") == "#"
+        # Plain paragraphs with no marker are untouched.
+        assert strip_hallucinated_markdown_markers(
+            "Un paragraphe normal."
+        ) == "Un paragraphe normal."
+
 
 # === D. Plain Text Mode: the rebuild must never lose content ===
 

--- a/tests/unit/epub/test_plain_text_attribute_policy.py
+++ b/tests/unit/epub/test_plain_text_attribute_policy.py
@@ -1,0 +1,112 @@
+"""
+Which source attributes Plain Text Mode carries onto a rebuilt block.
+
+Plain Text Mode wipes the body and re-emits one element per collected block, so
+every attribute the output has was put there deliberately. Copying the source
+block's whole attribute dict is not safe:
+
+  * `<li>`, `<td>`, `<th>` and unknown blocks are flattened to `<p>`, so a
+    tag-specific attribute (colspan, scope, value, ...) would end up on an
+    element that cannot legally carry it and epubcheck rejects the file.
+  * `lang` / `xml:lang` name the SOURCE language. On translated text they
+    override the target language `lang_support` writes on `<html>`, which is
+    how a French paragraph ends up read aloud by an English speech engine.
+  * Bilingual mode emits two elements for one source block: a duplicated `id`
+    is invalid XHTML and makes every TOC anchor pointing at it ambiguous.
+
+`plain_extractor.CARRIED_ATTRIBUTES` is the whitelist; these tests pin it.
+"""
+from lxml import etree
+
+from src.core.epub.plain_extractor import (
+    EPUB_TYPE_ATTR,
+    extract_plain_paragraphs,
+    replace_body_with_paragraphs,
+)
+
+XML_LANG_ATTR = "{http://www.w3.org/XML/1998/namespace}lang"
+NS = 'xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops"'
+
+
+def _rebuild(body_inner: str, translations, **kwargs):
+    """Extract then rebuild a body, returning its block children."""
+    root = etree.fromstring(f"<html {NS}><body>{body_inner}</body></html>".encode())
+    body = root[0]
+    paragraphs, tags, images, attrib = extract_plain_paragraphs(body)
+    replace_body_with_paragraphs(
+        body, translations, tags, images,
+        source_paragraphs=paragraphs, paragraphs_attrib=attrib, **kwargs
+    )
+    return body
+
+
+def _local(elem) -> str:
+    return elem.tag.split("}")[-1]
+
+
+def test_semantic_attributes_survive_the_rebuild():
+    body = _rebuild(
+        '<h1 id="ch1" class="head" style="text-indent:0" title="Part one" '
+        'dir="ltr" epub:type="title">Chapter One</h1>',
+        ["Chapitre Un"],
+    )
+
+    heading = body[0]
+    assert _local(heading) == "h1"
+    assert heading.get("id") == "ch1"
+    assert heading.get("class") == "head"
+    assert heading.get("style") == "text-indent:0"
+    assert heading.get("title") == "Part one"
+    assert heading.get("dir") == "ltr"
+    assert heading.get(EPUB_TYPE_ATTR) == "title"
+
+
+def test_source_language_attributes_are_not_carried_over():
+    """The block must inherit the target lang set on <html>, not keep the source's."""
+    body = _rebuild(
+        '<p xml:lang="en" lang="en" class="body">Hello there.</p>', ["Bonjour."]
+    )
+
+    paragraph = body[0]
+    assert paragraph.get(XML_LANG_ATTR) is None
+    assert paragraph.get("lang") is None
+    # The rest of the attributes are untouched by the exclusion.
+    assert paragraph.get("class") == "body"
+
+
+def test_table_cell_attributes_do_not_follow_the_cell_into_a_paragraph():
+    body = _rebuild(
+        '<table><tr><td colspan="2" rowspan="3" scope="col" headers="h1" '
+        'class="cell">Cell</td></tr></table>',
+        ["Cellule"],
+    )
+
+    paragraph = body[0]
+    assert _local(paragraph) == "p"
+    assert paragraph.get("class") == "cell"
+    for attr in ("colspan", "rowspan", "scope", "headers"):
+        assert paragraph.get(attr) is None, f"{attr} is not valid on <p>"
+
+
+def test_list_item_attributes_do_not_follow_the_item_into_a_paragraph():
+    body = _rebuild('<ol><li value="3" class="item">Item</li></ol>', ["Article"])
+
+    paragraph = body[0]
+    assert _local(paragraph) == "p"
+    assert paragraph.get("class") == "item"
+    assert paragraph.get("value") is None, "value is not valid on <p>"
+
+
+def test_bilingual_emits_the_source_id_exactly_once():
+    body = _rebuild(
+        '<h2 id="ch1" class="head">Chapter 1</h2>', ["Chapitre 1"], bilingual=True
+    )
+
+    source_block, target_block = body[0], body[1]
+    assert [b.get("id") for b in body] == ["ch1", None], (
+        "a duplicated id is invalid XHTML and makes the TOC anchor ambiguous"
+    )
+    # The id goes to the block that comes first in reading order, so an anchor
+    # still lands at the top of the right section.
+    assert source_block.get("class") == "head plain-text-source"
+    assert target_block.get("class") == "head plain-text-target"

--- a/tests/unit/epub/test_plain_text_hr_separators.py
+++ b/tests/unit/epub/test_plain_text_hr_separators.py
@@ -57,7 +57,7 @@ def _local_tags(element: etree._Element) -> list:
 
 def test_hr_is_collected_as_void_block():
     body = _parse_body("<p>A</p><hr/><p>B</p>")
-    paragraphs, tags, images = extract_plain_paragraphs(body)
+    paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
 
     assert (paragraphs, tags, images) == (["A", "", "B"], ["p", "hr", "p"], {})
     assert len(paragraphs) == len(tags)
@@ -65,7 +65,7 @@ def test_hr_is_collected_as_void_block():
 
 def test_hr_nested_in_div_is_collected():
     body = _parse_body("<div><p>A</p><hr/><p>B</p></div>")
-    paragraphs, tags, images = extract_plain_paragraphs(body)
+    paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
 
     assert (paragraphs, tags, images) == (["A", "", "B"], ["p", "hr", "p"], {})
     assert len(paragraphs) == len(tags)
@@ -127,14 +127,16 @@ def test_hr_survives_bilingual_rebuild():
     )
 
 
-def test_hr_attributes_are_dropped():
+def test_hr_attributes_are_preserved():
     body = _parse_body('<p>A</p><hr class="scene"/><p>B</p>')
-    paragraphs, tags, images = extract_plain_paragraphs(body)
-    replace_body_with_paragraphs(body, list(paragraphs), tags, images)
+    paragraphs, tags, images, attrib = extract_plain_paragraphs(body)
+    assert attrib == [{}, {"class": "scene"}, {}]
+
+    replace_body_with_paragraphs(body, list(paragraphs), tags, images, paragraphs_attrib=attrib)
 
     hr_children = [child for child in body if child.tag.split("}")[-1] == "hr"]
     assert len(hr_children) == 1
-    assert hr_children[0].attrib == {}
+    assert hr_children[0].attrib == {"class": "scene"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/epub/test_ruby_annotations.py
+++ b/tests/unit/epub/test_ruby_annotations.py
@@ -177,7 +177,7 @@ class TestPlainTextPath:
 
     def test_reading_no_longer_glued_to_base(self):
         body = _body("<p>彼は<ruby>宇宙<rt>そら</rt></ruby>を見上げた。</p>")
-        paragraphs, _tags, _images = extract_plain_paragraphs(body)
+        paragraphs, _tags, _images, _attrib = extract_plain_paragraphs(body)
         assert paragraphs == ["彼は宇宙（そら）を見上げた。"]
         assert "宇宙そら" not in paragraphs[0]
 
@@ -199,7 +199,7 @@ class TestPlainTextPath:
         body = _body(
             '<p><ruby>宇宙<rt>そら</rt></ruby><img src="a.png"/></p>'
         )
-        paragraphs, tags, images = extract_plain_paragraphs(body)
+        paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
         assert paragraphs == ["宇宙（そら）"]
         assert tags == ["p"]
         assert len(images[0]) == 1

--- a/tests/unit/test_plain_text_alignment.py
+++ b/tests/unit/test_plain_text_alignment.py
@@ -146,7 +146,7 @@ async def test_epub_image_anchor_and_heading_stay_aligned(monkeypatch):
         "<p>Second body paragraph.</p>"
         "</body>"
     )
-    paragraphs, tags, images = extract_plain_paragraphs(body)
+    paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
     assert paragraphs[0] == ""  # synthetic anchor for the leading image
     assert 0 in images
 

--- a/tests/unit/test_plain_text_paragraph_mismatch.py
+++ b/tests/unit/test_plain_text_paragraph_mismatch.py
@@ -259,7 +259,7 @@ def test_untranslated_block_is_marked():
     body = etree.fromstring(
         "<body>" + "".join(f"<p>{p}</p>" for p in MERGED) + "</body>"
     )
-    paragraphs, tags, images = extract_plain_paragraphs(body)
+    paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
 
     replace_body_with_paragraphs(
         body, ["T::Alpha paragraph. Beta paragraph.", ""], tags, images,
@@ -276,7 +276,7 @@ def test_untranslated_block_is_marked():
 def test_translated_blocks_keep_their_classes():
     """Only the source-carrying block is marked; bilingual mode is unchanged."""
     body = etree.fromstring("<body><p>Source one.</p><p>Source two.</p></body>")
-    paragraphs, tags, images = extract_plain_paragraphs(body)
+    paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
     replace_body_with_paragraphs(
         body, ["Traduction une.", ""], tags, images,
         bilingual=True, source_paragraphs=paragraphs,
@@ -317,7 +317,7 @@ async def test_merged_segment_is_repaired_paragraph_by_paragraph(monkeypatch):
     body = etree.fromstring(
         "<body>" + "".join(f"<p>{p}</p>" for p in THREE) + "</body>"
     )
-    paragraphs, tags, images = extract_plain_paragraphs(body)
+    paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
 
     out, stats, logs = await _run(paragraphs)
 
@@ -354,7 +354,7 @@ async def test_repair_failure_falls_back_to_source_and_is_counted(monkeypatch):
     body = etree.fromstring(
         "<body>" + "".join(f"<p>{p}</p>" for p in THREE) + "</body>"
     )
-    paragraphs, tags, images = extract_plain_paragraphs(body)
+    paragraphs, tags, images, _attrib = extract_plain_paragraphs(body)
 
     out, stats, logs = await _run(paragraphs)
 


### PR DESCRIPTION
Follow-up to #269 by @3xbun, whose two commits are included here unchanged.

Plain Text Mode rebuilt every block as a bare `etree.SubElement(body, tag)`, so a `<h3 class="head">` came back as `<h3>`, and models conditioned on markdown decorated bare heading lines with `# ` prefixes. #269 fixes both; this branch narrows the edges of those two fixes.

## Preserve block attributes (@3xbun)

`extract_plain_paragraphs` now records each block's attributes alongside its tag name, and `replace_body_with_paragraphs` carries them onto the rebuilt element.

## Restrict what is carried over

Copying the source block's whole attribute dict has three side effects on ordinary EPUBs:

- `<li>`, `<td>`, `<th>` and unknown blocks are flattened to `<p>`, so `colspan`, `rowspan`, `scope`, `headers` and `value` landed on an element that cannot legally carry them and epubcheck rejects the file.
- `lang` / `xml:lang` name the source language. On translated text they override the target language `lang_support` writes on `<html>`, so a French paragraph would be handed to an English speech engine.
- Bilingual mode emits two elements per source block and gave both the same `id`: invalid XHTML and an ambiguous target for every TOC anchor.

`CARRIED_ATTRIBUTES` is now the whitelist (`class`, `id`, `style`, `dir`, `title`, `epub:type`), and `id` goes to the first element emitted for the slot.

## Strip hallucinated markdown markers (@3xbun, then tightened)

The prompt gains a rule against markdown formatting, and the pipeline strips markers the model invented. The strip itself had three holes, fixed here:

- `^\s*(?:#{1,6}\s*)+` required no space after the hashes, so `#1 bestseller` became `1 bestseller` and `#MeToo` became `MeToo`.
- `\s*` crosses blank lines, so a paragraph made of a lone `#` was swallowed with its separator and the segment came back one paragraph short, breaking the count contract.
- Anchored on `^` with `count=1`, it cleaned only the first paragraph of a segment, and ran on the first-pass branch only: a segment repaired by `_retry_segment_with_paragraph_count` or `_repair_segment_by_paragraph` kept its markers.

A marker is now `#`×1-6 followed by a space and a non-space, anchored on the start of the blob or on a blank-line separator the replacement puts back. A source that uses the marker itself (a markdown sample inside `<pre>`) disarms the strip, mirroring `strip_hallucinated_markup`.

## Tests

`tests/unit/epub/test_plain_text_attribute_policy.py` pins the attribute policy. The marker tests cover the false positives, the paragraph-count invariant, and two end-to-end cases through `translate_paragraphs_plain`. `test_issue_207_content_loss.py` was using `re` without importing it, which made a fake LLM raising `NameError` look like a successful translation; fixed, and the fakes now prefix `T::` so a fallback to source text cannot pass for a translation.

`pytest tests/unit`: 1761 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
